### PR TITLE
Improve output artifact names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+Welcome to OpenTelemetry Android repository!
+
+Before you start - see OpenTelemetry general
+[contributing](https://github.com/open-telemetry/community/blob/main/CONTRIBUTING.md)
+requirements and recommendations.
+
+Make sure to review the projects [license](LICENSE) and sign the
+[CNCF CLA](https://identity.linuxfoundation.org/projects/cncf). A signed CLA will be enforced by an
+automatic check once you submit a PR, but you can also sign it after opening your PR.
+
+## Requirements
+
+Java 17 or higher is required to build the projects in this repository.
+The built artifacts can be Android API Level 21 and higher.
+API levels 21 to 25 require desugaring of the core library.
+
+## Building opentelemetry-android
+
+1. Clone the repository
+```
+git clone https://github.com/open-telemetry/opentelemetry-android.git
+cd opentelemetry-android
+```
+
+2. To build the android artifact, run the gradle wrapper with `assemble`:
+```
+./gradlew assemble
+```
+
+The output artifacts will be in `instrumentation/build/outputs/`.
+
+3. To run the tests and code checks:
+```
+./gradlew check
+```
+
+## Code Conventions
+
+We use [spotless](https://github.com/diffplug/spotless) to enforce a consistent code style
+throughout the project. This includes reformatting (linting) of both source code and markdown.
+
+Before submitting a PR, you should ensure that your code is linted by
+running `./gradlew spotlessApply` and committing your changes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,9 @@ git clone https://github.com/open-telemetry/opentelemetry-android.git
 cd opentelemetry-android
 ```
 
-2. To build the android artifact, run the gradle wrapper with `assemble`:
+2. To build the android artifact, run the gradle wrapper with `createReleaseBuild`:
 ```
-./gradlew assemble
+./gradlew createReleaseBuild
 ```
 
 The output artifacts will be in `instrumentation/build/outputs/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,9 @@ git clone https://github.com/open-telemetry/opentelemetry-android.git
 cd opentelemetry-android
 ```
 
-2. To build the android artifact, run the gradle wrapper with `createReleaseBuild`:
+2. To build the android artifact, run the gradle wrapper with `assemble`:
 ```
-./gradlew createReleaseBuild
+./gradlew assemble
 ```
 
 The output artifacts will be in `instrumentation/build/outputs/`.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,16 @@
 The repository contains the OpenTelemetry Android SDK for generating mobile
 client telemetry for real user monitoring (RUM). It is built on top
 of the [OpenTelemetry Java SDK](https://github.com/open-telemetry/opentelemetry-java).
+
+# Getting Started
+
+This project is still in its infancy.
+
+For an overview of how to contribute, see the contributing guide in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+We are also available in the [#otel-android](https://cloud-native.slack.com/archives/C05J0T9K27Q)
+channel in the [CNCF slack](https://slack.cncf.io/). Please join us there for further discussions.
+
+# Requirements
+
+TBD

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ buildscript {
     }
     dependencies {
         // keep this version in sync with /buildSrc/build.gradle.kts
-        classpath("com.android.tools.build:gradle:8.0.2")
+        classpath("com.android.tools.build:gradle:8.1.0")
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 
 dependencies {
     // keep this version in sync with /build.gradle.kts
-    implementation("com.android.tools.build:gradle:8.0.2")
+    implementation("com.android.tools.build:gradle:8.1.0")
 
     implementation("com.diffplug.spotless:spotless-plugin-gradle:6.20.0")
     implementation("net.ltgt.gradle:gradle-errorprone-plugin:3.1.0")

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -28,18 +28,16 @@ android {
         }
     }
 
-    libraryVariants.all {
-        outputs
-            .map { it as com.android.build.gradle.internal.api.BaseVariantOutputImpl }
-            .all { variant ->
-                variant.outputs.all {
-                    if (variant.outputFileName.endsWith(".aar")) {
-                        variant.outputFileName = "opentelemetry-android-${variant.name}.aar"
-                    }
-                    false
+    androidComponents {
+        onVariants {
+            if (it.buildType == "release") { // The one we choose to release
+                project.tasks.register("createReleaseBuild", Copy::class) {
+                    from(it.artifacts.get(com.android.build.api.artifact.SingleArtifact.AAR))
+                    into(project.layout.buildDirectory.dir("outputs/aar"))
+                    rename(".+", "opentelemetry-android.aar")
                 }
-                false
             }
+        }
     }
 
     compileOptions {

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -40,6 +40,12 @@ android {
         }
     }
 
+    project.afterEvaluate {
+        tasks.named("assembleRelease") {
+            finalizedBy("createReleaseBuild")
+        }
+    }
+
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
 

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
-    id("com.android.library")
     id("otel.android-library-conventions")
     id("otel.errorprone-conventions")
 }
@@ -11,7 +10,7 @@ android {
     namespace = "io.opentelemetry.android"
 
     compileSdk = 33
-    buildToolsVersion = "30.0.3"
+    buildToolsVersion = "33.0.1"
 
     defaultConfig {
         minSdk = 21
@@ -27,6 +26,20 @@ android {
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
+    }
+
+    libraryVariants.all {
+        outputs
+            .map { it as com.android.build.gradle.internal.api.BaseVariantOutputImpl }
+            .all { variant ->
+                variant.outputs.all {
+                    if (variant.outputFileName.endsWith(".aar")) {
+                        variant.outputFileName = "opentelemetry-android-${variant.name}.aar"
+                    }
+                    false
+                }
+                false
+            }
     }
 
     compileOptions {


### PR DESCRIPTION
Resolves #4. 

I chose the filename prefix to be `opentelemetry-android` which ends up generating `opentelemetry-android-debug.aar` and `opentelemetry-android-release.aar`. I'm not sure why there are both debug and release variants, and if we'll want to publish both? For now, at least it's an improvement on `instrumentation-debug.aar` 🙃 

I also added a `CONTRIBUTING.md` and made a few `README.md` additions.