### PR TITLE
Add workflow to run build when main is merged.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,31 +22,10 @@ jobs:
       - name: run gradle
         run: ./gradlew check
 
-  issue:
-    name: Open issue on failure
-    needs: [ build ]
-    runs-on: ubuntu-20.04
-    permissions:
-      issues: write
+  workflow-notification:
+    needs:
+      - analyze
     if: always()
-    steps:
-      # run this action to get workflow conclusion
-      # You can get conclusion by env (env.WORKFLOW_CONCLUSION)
-      - uses: technote-space/workflow-conclusion-action@v3.0.3
-      - uses: actions/checkout@v3
-      - name: Create issue
-        if: env.WORKFLOW_CONCLUSION == 'failure' # notify only if failure
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          cat > body.txt << EOF
-          [Android build #$GITHUB_RUN_NUMBER](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) failed.
-          Please take a look and fix it ASAP.
-          EOF
-
-          gh issue create \
-            --title "Android build #$GITHUB_RUN_NUMBER failed" \
-            --label bug \
-            --label automated \
-            --assignee "@open-telemetry/android-maintainers" \
-            --body-file body.txt
+    uses: ./.github/workflows/reusable-workflow-notification.yml
+    with:
+      success: ${{ needs.build.result == 'success' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,52 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+      - release/*
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: "build"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK for running Gradle
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17.0.6
+        # TODO: Build and publish a snapshot instead!
+      - name: run gradle
+        run: ./gradlew check
+
+  issue:
+    name: Open issue on failure
+    needs: [ build ]
+    runs-on: ubuntu-20.04
+    permissions:
+      issues: write
+    if: always()
+    steps:
+      # run this action to get workflow conclusion
+      # You can get conclusion by env (env.WORKFLOW_CONCLUSION)
+      - uses: technote-space/workflow-conclusion-action@v3.0.3
+      - uses: actions/checkout@v3
+      - name: Create issue
+        if: env.WORKFLOW_CONCLUSION == 'failure' # notify only if failure
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cat > body.txt << EOF
+          [Android build #$GITHUB_RUN_NUMBER](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID) failed.
+          Please take a look and fix it ASAP.
+          EOF
+
+          gh issue create \
+            --title "Android build #$GITHUB_RUN_NUMBER failed" \
+            --label bug \
+            --label automated \
+            --assignee "@open-telemetry/android-maintainers" \
+            --body-file body.txt

--- a/.github/workflows/reusable-workflow-notification.yml
+++ b/.github/workflows/reusable-workflow-notification.yml
@@ -1,0 +1,37 @@
+# this is useful because notifications for scheduled workflows are only sent to the user who
+# initially created the given workflow
+name: Reusable - Workflow notification
+
+on:
+  workflow_call:
+    inputs:
+      success:
+        type: boolean
+        required: true
+
+jobs:
+  workflow-notification:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Open issue or add comment if issue already open
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          number=$(gh issue list --search "Workflow failed: $GITHUB_WORKFLOW" --limit 1 --json number -q .[].number)
+
+          echo $number
+          echo ${{ inputs.success }}
+
+          if [[ $number ]]; then
+            if [[ "${{ inputs.success }}" == "true" ]]; then
+              gh issue close $number
+            else
+              gh issue comment $number \
+                               --body "See [$GITHUB_WORKFLOW #$GITHUB_RUN_NUMBER](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
+            fi
+          elif [[ "${{ inputs.success }}" == "false" ]]; then
+            gh issue create --title "Workflow failed: $GITHUB_WORKFLOW (#$GITHUB_RUN_NUMBER)" \
+                            --body "See [$GITHUB_WORKFLOW #$GITHUB_RUN_NUMBER](https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
+          fi


### PR DESCRIPTION
This should also automatically create an issue if/when the build step fails. 

This is also a likely candidate place to publish a snapshot build, so I added a TODO. Relates to #9.