### PR TITLE
Adding @jack-berg and @trask as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,4 @@
 # This file controls who is tagged for review for any given pull request.
 
  # For anything not explicitly taken by someone else:
-* @open-telemetry/android-maintainers
-* @trask
-* @jack-berg
+* @open-telemetry/android-approvers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,5 @@
 
  # For anything not explicitly taken by someone else:
 * @open-telemetry/android-maintainers
+* @trask
+* @jack-berg


### PR DESCRIPTION
We talked about this in the last SIG and @jack-berg and @trask agreed to be `CODEOWNERS` for a period to help get the project going and reduce time-to-merge across timezones.