### PR TITLE
Add codeql to run nightly

### DIFF
--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -39,5 +39,7 @@ jobs:
     # open an issue on failure because it can be easy to miss CI failure notifications
     needs:
       - analyze
-    if: failure() && github.run_attempt == 1
+    if: always()
     uses: ./.github/workflows/reusable-open-issue-on-failure.yml
+    with:
+      success: ${{ needs.analyze.result == 'success' }}

--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -1,0 +1,43 @@
+name: CodeQL (daily)
+
+on:
+  schedule:
+    # Daily at 03:55 (UTC)
+    - cron: '55 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: java
+          # using "latest" helps to keep up with the latest Kotlin support
+          # see https://github.com/github/codeql-action/issues/1555#issuecomment-1452228433
+          tools: latest
+
+      - uses: gradle/gradle-build-action@v2
+        with:
+          # skipping build cache is needed so that all modules will be analyzed
+          arguments: assemble --no-build-cache
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v2
+
+  open-issue-on-failure:
+    # open an issue on failure because it can be easy to miss CI failure notifications
+    needs:
+      - analyze
+    if: failure() && github.run_attempt == 1
+    uses: ./.github/workflows/reusable-open-issue-on-failure.yml


### PR DESCRIPTION
Getting ahead of the security audit by adding nightly codeql like the other otel repos. Copied verbatim from the `opentelemetry-java` repo.