### PR TITLE
Added os.description resource attribute

### DIFF
--- a/instrumentation/src/main/java/io/opentelemetry/android/AndroidResource.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/AndroidResource.java
@@ -78,6 +78,8 @@ final class AndroidResource {
                 .append(Build.VERSION.RELEASE)
                 .append(" (Build ")
                 .append(Build.ID)
+                .append(" API level ")
+                .append(Build.VERSION.SDK_INT)
                 .append(")")
                 .toString();
     }

--- a/instrumentation/src/main/java/io/opentelemetry/android/AndroidResource.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/AndroidResource.java
@@ -72,8 +72,9 @@ final class AndroidResource {
     }
 
     private static String getOSDescription() {
-        StringBuilder OSDescriptionBuilder = new StringBuilder();
-        return OSDescriptionBuilder.append("Android Version ")
+        StringBuilder osDescriptionBuilder = new StringBuilder();
+        return osDescriptionBuilder
+                .append("Android Version ")
                 .append(Build.VERSION.RELEASE)
                 .append(" (Build ")
                 .append(Build.ID)

--- a/instrumentation/src/main/java/io/opentelemetry/android/AndroidResource.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/AndroidResource.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.android.RumConstants.RUM_SDK_VERSION;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.DEVICE_MANUFACTURER;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.DEVICE_MODEL_IDENTIFIER;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.DEVICE_MODEL_NAME;
+import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_DESCRIPTION;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_NAME;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_TYPE;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_VERSION;
@@ -35,6 +36,7 @@ final class AndroidResource {
                 .put(OS_NAME, "Android")
                 .put(OS_TYPE, "linux")
                 .put(OS_VERSION, Build.VERSION.RELEASE)
+                .put(OS_DESCRIPTION, getOSDescription())
                 .build();
     }
 
@@ -67,5 +69,15 @@ final class AndroidResource {
         } catch (Exception e) {
             return defaultValue;
         }
+    }
+
+    private static String getOSDescription() {
+        StringBuilder OSDescriptionBuilder = new StringBuilder();
+        return OSDescriptionBuilder.append("Android Version ")
+                .append(Build.VERSION.RELEASE)
+                .append(" (Build ")
+                .append(Build.ID)
+                .append(")")
+                .toString();
     }
 }

--- a/instrumentation/src/test/java/io/opentelemetry/android/AndroidResourceTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/AndroidResourceTest.java
@@ -6,8 +6,10 @@
 package io.opentelemetry.android;
 
 import static io.opentelemetry.android.RumConstants.RUM_SDK_VERSION;
+import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.DEVICE_MANUFACTURER;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.DEVICE_MODEL_IDENTIFIER;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.DEVICE_MODEL_NAME;
+import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_DESCRIPTION;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_NAME;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_TYPE;
 import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_VERSION;
@@ -30,6 +32,14 @@ class AndroidResourceTest {
 
     String appName = "robotron";
     String rumSdkVersion = "1.2.3";
+    String osDescription =
+            new StringBuilder()
+                    .append("Android Version ")
+                    .append(Build.VERSION.RELEASE)
+                    .append(" (Build ")
+                    .append(Build.ID)
+                    .append(")")
+                    .toString();
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     Application app;
@@ -38,6 +48,7 @@ class AndroidResourceTest {
     void testFullResource() {
         ApplicationInfo appInfo = new ApplicationInfo();
         appInfo.labelRes = 12345;
+
         when(app.getApplicationContext().getApplicationInfo()).thenReturn(appInfo);
         when(app.getApplicationContext().getString(appInfo.labelRes)).thenReturn(appName);
         when(app.getApplicationContext().getResources().getString(R.string.rum_version))
@@ -51,9 +62,11 @@ class AndroidResourceTest {
                                         .put(RUM_SDK_VERSION, rumSdkVersion)
                                         .put(DEVICE_MODEL_NAME, Build.MODEL)
                                         .put(DEVICE_MODEL_IDENTIFIER, Build.MODEL)
+                                        .put(DEVICE_MANUFACTURER, Build.MANUFACTURER)
                                         .put(OS_NAME, "Android")
                                         .put(OS_TYPE, "linux")
                                         .put(OS_VERSION, Build.VERSION.RELEASE)
+                                        .put(OS_DESCRIPTION, osDescription)
                                         .build());
 
         Resource result = AndroidResource.createDefault(app);
@@ -74,9 +87,11 @@ class AndroidResourceTest {
                                         .put(RUM_SDK_VERSION, "unknown")
                                         .put(DEVICE_MODEL_NAME, Build.MODEL)
                                         .put(DEVICE_MODEL_IDENTIFIER, Build.MODEL)
+                                        .put(DEVICE_MANUFACTURER, Build.MANUFACTURER)
                                         .put(OS_NAME, "Android")
                                         .put(OS_TYPE, "linux")
                                         .put(OS_VERSION, Build.VERSION.RELEASE)
+                                        .put(OS_DESCRIPTION, osDescription)
                                         .build());
 
         Resource result = AndroidResource.createDefault(app);

--- a/instrumentation/src/test/java/io/opentelemetry/android/AndroidResourceTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/AndroidResourceTest.java
@@ -38,6 +38,8 @@ class AndroidResourceTest {
                     .append(Build.VERSION.RELEASE)
                     .append(" (Build ")
                     .append(Build.ID)
+                    .append(" API level ")
+                    .append(Build.VERSION.SDK_INT)
                     .append(")")
                     .toString();
 


### PR DESCRIPTION
As per our discussion in previous 2 client sig meetings, adding os.description attribute which would contain build number and API level as well. Below screenshot shows what os.description string looks like from debug log.

<img width="500" alt="Screenshot 2023-08-29 at 1 11 15 PM" src="https://github.com/open-telemetry/opentelemetry-android/assets/138259843/46ce64ba-7d7f-4da5-adb0-77597ace4b8b">

Will soon create the other PR - proposing a change in semantic conventions to add os.build and os.api.level attribute. Thanks!