### PR TITLE
Fix workflow filename used by codeql

### DIFF
--- a/.github/workflows/codeql-daily.yml
+++ b/.github/workflows/codeql-daily.yml
@@ -40,6 +40,6 @@ jobs:
     needs:
       - analyze
     if: always()
-    uses: ./.github/workflows/reusable-open-issue-on-failure.yml
+    uses: ./.github/workflows/reusable-workflow-notification.yml
     with:
       success: ${{ needs.analyze.result == 'success' }}


### PR DESCRIPTION
I tested the codeql workflow and it failed because of copypasta using the wrong workflow name. 🤦🏻 