### PR TITLE
Exclude mangled package from gradle.properties

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -22,7 +22,6 @@
       // somehow renovate gets confused by the android property in gradle.properties,
       // so let's just exclude it and hopefully clean up the dashboard
       "matchPackageNames": ["string:rum.version"],
-      "matchUpdateTypes": ["major", "minor"],
       "enabled": false
     }
   ]

--- a/renovate.json5
+++ b/renovate.json5
@@ -17,6 +17,13 @@
       "matchPackageNames": ["androidx.browser:browser"],
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false
+    },
+    {
+      // somehow renovate gets confused by the android property in gradle.properties,
+      // so let's just exclude it and hopefully clean up the dashboard
+      "matchPackageNames": ["string:rum.version"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Over in #23 there is a lookup warning for a nonsensical maven package, which is really just a property sourced from gradle.properties and put into an android resource value. Let's try excluding it.