### PR TITLE
Remove otel core bom

### DIFF
--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -73,7 +73,6 @@ dependencies {
     implementation("io.zipkin.reporter2:zipkin-sender-okhttp3")
     implementation("io.opentelemetry:opentelemetry-exporter-logging")
     implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")
-    implementation(platform("io.opentelemetry:opentelemetry-bom-alpha"))
     implementation("io.opentelemetry:opentelemetry-semconv")
 
     testImplementation("org.mockito:mockito-core:5.5.0")


### PR DESCRIPTION
This was unfortunately causing an unparseable pom to be published: https://oss.sonatype.org/content/repositories/snapshots/io/opentelemetry/android/instrumentation/0.1.0-alpha-SNAPSHOT/instrumentation-0.1.0-alpha-20230829.211843-1.pom

Note that the version is missing from the bom in the `<dependencyManagement>` section.  We only need the topmost bom, which is instrumentation.