### PR TITLE
Don't require up to date

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -4,6 +4,14 @@ This document describes any changes that have been made to the
 settings for this repository beyond the [OpenTelemetry default repository
 settings](https://github.com/open-telemetry/community/blob/main/docs/how-to-configure-new-repository.md#repository-settings).
 
+## Branch protections
+
+### `main`
+
+- Require branches to be up to date before merging: UNCHECKED
+  (PR jobs take too long, and leaving this unchecked has not been a significant problem)
+
+
 ## Secrets and variables > Actions
 
 * `GPG_PASSWORD` - stored in OpenTelemetry-Java 1Password


### PR DESCRIPTION
This matches the behavior in the instrumentation repo and is a notable reduction in click-before-merge burden. Change has already been made.