### PR TITLE
Allow user to customize propagators

### DIFF
--- a/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -172,9 +172,11 @@ public final class OpenTelemetryRumBuilder {
     public OpenTelemetryRumBuilder addPropagatorCustomizer(
             Function<? super TextMapPropagator, ? extends TextMapPropagator> propagatorCustomizer) {
         requireNonNull(propagatorCustomizer, "propagatorCustomizer");
+        Function<? super TextMapPropagator, ? extends TextMapPropagator> existing =
+                this.propagatorCustomizer;
         this.propagatorCustomizer =
                 propagator -> {
-                    TextMapPropagator result = this.propagatorCustomizer.apply(propagator);
+                    TextMapPropagator result = existing.apply(propagator);
                     return propagatorCustomizer.apply(result);
                 };
         return this;

--- a/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -49,13 +49,15 @@ public final class OpenTelemetryRumBuilder {
     private final List<Consumer<InstrumentedApplication>> instrumentationInstallers =
             new ArrayList<>();
 
-    private Function<? super TextMapPropagator, ? extends TextMapPropagator> propagatorCustomizer = (a) -> a;
+    private Function<? super TextMapPropagator, ? extends TextMapPropagator> propagatorCustomizer =
+            (a) -> a;
 
     private Resource resource;
 
     private static TextMapPropagator buildDefaultPropagator() {
         Map<Class<? extends TextMapPropagator>, TextMapPropagator> result = new HashMap<>();
-        return TextMapPropagator.composite(W3CTraceContextPropagator.getInstance(), W3CBaggagePropagator.getInstance());
+        return TextMapPropagator.composite(
+                W3CTraceContextPropagator.getInstance(), W3CBaggagePropagator.getInstance());
     }
 
     OpenTelemetryRumBuilder(Application application) {
@@ -160,20 +162,21 @@ public final class OpenTelemetryRumBuilder {
     }
 
     /**
-     * Adds a {@link Function} to invoke with the default {@link TextMapPropagator}
-     * to allow customization. The return value of the {@link BiFunction} will replace
-     * the passed-in argument. To add new propagators, use {@code TextMapPropagator.composite()}
-     * with the existing propagator passed to your function.
+     * Adds a {@link Function} to invoke with the default {@link TextMapPropagator} to allow
+     * customization. The return value of the {@link BiFunction} will replace the passed-in
+     * argument. To add new propagators, use {@code TextMapPropagator.composite()} with the existing
+     * propagator passed to your function.
      *
      * <p>Multiple calls will execute the customizers in order.
      */
     public OpenTelemetryRumBuilder addPropagatorCustomizer(
             Function<? super TextMapPropagator, ? extends TextMapPropagator> propagatorCustomizer) {
         requireNonNull(propagatorCustomizer, "propagatorCustomizer");
-        this.propagatorCustomizer = propagator -> {
-            TextMapPropagator result = this.propagatorCustomizer.apply(propagator);
-            return propagatorCustomizer.apply(result);
-        };
+        this.propagatorCustomizer =
+                propagator -> {
+                    TextMapPropagator result = this.propagatorCustomizer.apply(propagator);
+                    return propagatorCustomizer.apply(result);
+                };
         return this;
     }
 

--- a/instrumentation/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -8,7 +8,6 @@ package io.opentelemetry.android;
 import static io.opentelemetry.android.RumConstants.SESSION_ID_KEY;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
-import static java.util.Collections.singletonList;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -108,11 +107,12 @@ class OpenTelemetryRumBuilderTest {
         TextMapGetter<? super Object> getter = mock(TextMapGetter.class);
         TextMapPropagator customPropagator = mock(TextMapPropagator.class);
 
-        when(customPropagator.fields()).thenReturn(singletonList("beep"));
         when(customPropagator.extract(context, carrier, getter)).thenReturn(expected);
 
         OpenTelemetryRum rum =
-                OpenTelemetryRum.builder(application).addPropagator(customPropagator).build();
+                OpenTelemetryRum.builder(application)
+                        .addPropagatorCustomizer(x -> customPropagator)
+                        .build();
         Context result =
                 rum.getOpenTelemetry()
                         .getPropagators()
@@ -126,7 +126,9 @@ class OpenTelemetryRumBuilderTest {
         TextMapPropagator customPropagator = mock(TextMapPropagator.class);
 
         OpenTelemetryRum rum =
-                OpenTelemetryRum.builder(application).setPropagator(customPropagator).build();
+                OpenTelemetryRum.builder(application)
+                        .addPropagatorCustomizer(x -> customPropagator)
+                        .build();
         TextMapPropagator result = rum.getOpenTelemetry().getPropagators().getTextMapPropagator();
         assertThat(result).isSameAs(customPropagator);
     }


### PR DESCRIPTION
Relates to #56.

This adds two new methods to the `OpenTelemetryRumBuilder`: 

* `setPropagator(TextMapPropagator)` - replaces all configured propagators with the given one
* `addPropagator(TextMapPropagator)` - adds the propagator to the collection of configured propagators to use in the sdk

This also defaults the propagators to the same ones as the upstream sdk -- `W3CTraceContextPropagator` and `W3CBaggagePropagator`.