### PR TITLE
Update to latest otel version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@ android.useAndroidX=true
 # generate the BuildConfig class that contains the app version
 android.defaults.buildfeatures.buildconfig=true
 android.minSdk=21
-otel.sdk.version=1.28.0
+otel.sdk.version=1.29.0
 
 version=0.1.0
 group=io.opentelemetry.android


### PR DESCRIPTION
Might it be that renovate doesn't grok the `gradle.properties` approach here?