### PR TITLE
Renovate otel version fix

### DIFF
--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -58,14 +58,13 @@ android {
     }
 }
 
-val otelVersion = project.property("otel.sdk.version")
 
 dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("androidx.core:core:1.10.1")
     implementation("androidx.navigation:navigation-fragment:2.6.0")
 
-    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelVersion-alpha"))
+    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${property("otel.sdk.version")}-alpha"))
     api("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-sdk")
     implementation("io.opentelemetry:opentelemetry-exporter-zipkin")

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -58,7 +58,6 @@ android {
     }
 }
 
-
 dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("androidx.core:core:1.10.1")


### PR DESCRIPTION
This is an attempt to make Renovate recognize and update the OTel SDK version based on what was found here: https://github.com/open-telemetry/opentelemetry-android/pull/75