### PR TITLE
Rename rum.session.id to session.id

### DIFF
--- a/instrumentation/src/main/java/io/opentelemetry/android/NoopOpenTelemetryRum.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/NoopOpenTelemetryRum.java
@@ -18,7 +18,7 @@ enum NoopOpenTelemetryRum implements OpenTelemetryRum {
 
     @Override
     public String getRumSessionId() {
-        // RUM sessionId has the same format as traceId
+        // RUM session.id has the same format as traceId
         return TraceId.getInvalid();
     }
 }

--- a/instrumentation/src/main/java/io/opentelemetry/android/RumConstants.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/RumConstants.java
@@ -15,7 +15,7 @@ public class RumConstants {
 
     public static final String OTEL_RUM_LOG_TAG = "OpenTelemetryRum";
 
-    public static final AttributeKey<String> SESSION_ID_KEY = stringKey("rum.session.id");
+    public static final AttributeKey<String> SESSION_ID_KEY = stringKey("session.id");
 
     public static final AttributeKey<String> LAST_SCREEN_NAME_KEY =
             AttributeKey.stringKey("last.screen.name");


### PR DESCRIPTION
Now that https://github.com/open-telemetry/semantic-conventions/pull/215 has landed, let's follow the convention.