### PR TITLE
Add dependencyManagement

### DIFF
--- a/auto-instrumentation/okhttp/okhttp-3.0/agent/build.gradle.kts
+++ b/auto-instrumentation/okhttp/okhttp-3.0/agent/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
 }
 
 dependencies {
+    implementation(platform(project(":dependencyManagement")))
     implementation(project(":auto-instrumentation:okhttp:okhttp-3.0:library"))
     implementation("net.bytebuddy:byte-buddy:${property("bytebuddy.version")}")
 }

--- a/auto-instrumentation/okhttp/okhttp-3.0/agent/build.gradle.kts
+++ b/auto-instrumentation/okhttp/okhttp-3.0/agent/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 }
 
 dependencies {
-    implementation(platform(project(":dependencyManagement")))
     implementation(project(":auto-instrumentation:okhttp:okhttp-3.0:library"))
     implementation("net.bytebuddy:byte-buddy:${property("bytebuddy.version")}")
 }

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/build.gradle.kts
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 }
 
 dependencies {
-    implementation(platform(project(":dependencyManagement")))
     // Pin at 3.0.0 for api compatibility
     api("com.squareup.okhttp3:okhttp:3.0.0")
     api("io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0")

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/build.gradle.kts
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/build.gradle.kts
@@ -5,7 +5,8 @@ plugins {
 
 dependencies {
     implementation(platform(project(":dependencyManagement")))
-    api("com.squareup.okhttp3:okhttp")
+    // Pin at 3.0.0 for api compatibility
+    api("com.squareup.okhttp3:okhttp:3.0.0")
     api("io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0")
     implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv")
 }

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/build.gradle.kts
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/build.gradle.kts
@@ -3,9 +3,9 @@ plugins {
     id("otel.publish-conventions")
 }
 
-val otelVersion = project.property("otel.sdk.version")
 dependencies {
-    api("com.squareup.okhttp3:okhttp:3.0.0")
-    api("io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0:$otelVersion-alpha")
-    implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv:$otelVersion-alpha")
+    implementation(platform(project(":dependencyManagement")))
+    api("com.squareup.okhttp3:okhttp")
+    api("io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0")
+    implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv")
 }

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttp3Singletons.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttp3Singletons.java
@@ -11,7 +11,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientResend;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientResendCount;
 import io.opentelemetry.instrumentation.api.instrumenter.net.PeerServiceAttributesExtractor;
 import io.opentelemetry.instrumentation.library.okhttp.v3_0.OkHttpInstrumentationConfig;
 import io.opentelemetry.instrumentation.okhttp.v3_0.internal.ConnectionErrorSpanInterceptor;
@@ -38,6 +38,8 @@ public final class OkHttp3Singletons {
                                             OkHttpInstrumentationConfig
                                                     .getCapturedResponseHeaders())
                                     .setKnownMethods(OkHttpInstrumentationConfig.getKnownMethods()),
+                    builder ->
+                            builder.setKnownMethods(OkHttpInstrumentationConfig.getKnownMethods()),
                     singletonList(
                             PeerServiceAttributesExtractor.create(
                                     OkHttpAttributesGetter.INSTANCE,
@@ -46,7 +48,8 @@ public final class OkHttp3Singletons {
 
     public static final Interceptor CONTEXT_INTERCEPTOR =
             chain -> {
-                try (Scope ignored = HttpClientResend.initialize(Context.current()).makeCurrent()) {
+                try (Scope ignored =
+                        HttpClientResendCount.initialize(Context.current()).makeCurrent()) {
                     return chain.proceed(chain.request());
                 }
             };

--- a/auto-instrumentation/okhttp/okhttp-3.0/testing/build.gradle.kts
+++ b/auto-instrumentation/okhttp/okhttp-3.0/testing/build.gradle.kts
@@ -4,8 +4,6 @@ plugins {
 }
 
 dependencies {
-    implementation(platform(project(":dependencyManagement")))
-
     byteBuddy(project(":auto-instrumentation:okhttp:okhttp-3.0:agent"))
     implementation(project(":auto-instrumentation:okhttp:okhttp-3.0:library"))
     implementation("com.squareup.okhttp3:okhttp")

--- a/auto-instrumentation/okhttp/okhttp-3.0/testing/build.gradle.kts
+++ b/auto-instrumentation/okhttp/okhttp-3.0/testing/build.gradle.kts
@@ -4,8 +4,10 @@ plugins {
 }
 
 dependencies {
+    implementation(platform(project(":dependencyManagement")))
+
     byteBuddy(project(":auto-instrumentation:okhttp:okhttp-3.0:agent"))
     implementation(project(":auto-instrumentation:okhttp:okhttp-3.0:library"))
-    implementation("com.squareup.okhttp3:okhttp:4.11.0")
-    androidTestImplementation("com.squareup.okhttp3:mockwebserver:4.11.0")
+    implementation("com.squareup.okhttp3:okhttp")
+    androidTestImplementation("com.squareup.okhttp3:mockwebserver:${rootProject.extra["okhttpVersion"]}")
 }

--- a/buildSrc/src/main/kotlin/otel.android-app-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.android-app-conventions.gradle.kts
@@ -22,8 +22,9 @@ android {
     }
 }
 
-val otelVersion = rootProject.property("otel.sdk.version")
 dependencies {
-    androidTestImplementation("androidx.test:runner:1.5.2")
-    androidTestImplementation("io.opentelemetry:opentelemetry-sdk-testing:$otelVersion")
+    implementation(platform(project(":dependencyManagement")))
+
+    androidTestImplementation("androidx.test:runner:${rootProject.extra["androidTestRunnerVersion"]}")
+    androidTestImplementation("io.opentelemetry:opentelemetry-sdk-testing:${rootProject.extra["otelSdkVersion"]}")
 }

--- a/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
@@ -25,4 +25,8 @@ android {
         sourceCompatibility(javaVersion)
         targetCompatibility(javaVersion)
     }
+
+    dependencies {
+        implementation(platform(project(":dependencyManagement")))
+    }
 }

--- a/buildSrc/src/main/kotlin/otel.java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-library-conventions.gradle.kts
@@ -1,3 +1,4 @@
+import gradle.kotlin.dsl.accessors._98848321c7233c2f7fb697478033dcb2.implementation
 import ru.vyarus.gradle.plugin.animalsniffer.AnimalSniffer
 
 plugins {
@@ -13,6 +14,7 @@ java {
 }
 
 dependencies {
+    implementation(platform(project(":dependencyManagement")))
     signature("com.toasttab.android:gummy-bears-api-${project.property("android.minSdk")}:0.5.1:coreLib@signature")
     implementation("com.google.code.findbugs:jsr305:3.0.2")
 }

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -1,0 +1,59 @@
+plugins {
+    `java-platform`
+}
+
+val otelSdkVersion = "1.30.1"
+rootProject.extra["otelSdkVersion"] = otelSdkVersion
+val otelSdkAlphaVersion = otelSdkVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
+val otelInstrumentationVersion = "1.30.0"
+val otelInstrumentationAlphaVersion =
+    otelInstrumentationVersion.replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
+
+val androidTestRunnerVersion = "1.5.2"
+rootProject.extra["androidTestRunnerVersion"] = androidTestRunnerVersion
+val androidxCoreVersion = "1.12.0"
+val androidxNavFragmentVersion = "2.7.3"
+val androidxTestCoreVersion = "1.5.0"
+val appCompatVersion = "1.6.1"
+val asmVersion = "9.5"
+val assertjVersion = "3.24.2"
+val awaitilityVersion = "4.2.0"
+val byteBuddyVersion = "1.14.8"
+val errorProneVersion = "2.21.1"
+val jmhVersion = "1.37"
+val junitVersion = "5.10.0"
+val mockitoVersion = "5.5.0"
+val mockwebserverVersion = "4.11.0"
+
+val okhttpVersion = "4.11.0"
+rootProject.extra["okhttpVersion"] = okhttpVersion
+val roboelectricVersion = "4.10.3"
+val slf4jVersion = "2.0.9"
+
+javaPlatform {
+    allowDependencies()
+}
+
+dependencies {
+
+    // BOMs
+    api(enforcedPlatform("org.junit:junit-bom:$junitVersion"))
+    api(enforcedPlatform("io.opentelemetry:opentelemetry-bom-alpha:$otelSdkAlphaVersion"))
+    api(enforcedPlatform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelInstrumentationAlphaVersion"))
+    api(enforcedPlatform("com.squareup.okhttp3:okhttp-bom:$okhttpVersion"))
+
+    constraints {
+        api("androidx.appcompat:appcompat:$appCompatVersion")
+        api("androidx.core:core:$androidxCoreVersion")
+        api("androidx.navigation:navigation-fragment:$androidxNavFragmentVersion")
+
+        api("androidx.test:runner:$androidTestRunnerVersion")
+        api("androidx.test:core:$androidxTestCoreVersion")
+        api("org.awaitility:awaitility:$awaitilityVersion")
+        api("org.assertj:assertj-core:$assertjVersion")
+        api("org.mockito:mockito-core:$mockitoVersion")
+        api("org.mockito:mockito-junit-jupiter:$mockitoVersion")
+        api("org.robolectric:robolectric:$roboelectricVersion")
+        api("com.squareup.okhttp3:mockwebserver:$mockwebserverVersion")
+    }
+}

--- a/dependencyManagement/build.gradle.kts
+++ b/dependencyManagement/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     api(enforcedPlatform("org.junit:junit-bom:$junitVersion"))
     api(enforcedPlatform("io.opentelemetry:opentelemetry-bom-alpha:$otelSdkAlphaVersion"))
     api(enforcedPlatform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:$otelInstrumentationAlphaVersion"))
-    api(enforcedPlatform("com.squareup.okhttp3:okhttp-bom:$okhttpVersion"))
+    api(platform("com.squareup.okhttp3:okhttp-bom:$okhttpVersion"))
 
     constraints {
         api("androidx.appcompat:appcompat:$appCompatVersion")

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,6 @@ android.useAndroidX=true
 android.defaults.buildfeatures.buildconfig=true
 android.minSdk=21
 android.compileSdk=34
-otel.sdk.version=1.29.0
 bytebuddy.version=1.14.8
 
 version=0.2.0

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -58,7 +58,6 @@ android {
 }
 
 dependencies {
-    implementation(platform(project(":dependencyManagement")))
 
     implementation("androidx.appcompat:appcompat")
     implementation("androidx.core:core")

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -58,11 +58,12 @@ android {
 }
 
 dependencies {
-    implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("androidx.core:core:1.12.0")
-    implementation("androidx.navigation:navigation-fragment:2.7.3")
+    implementation(platform(project(":dependencyManagement")))
 
-    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${property("otel.sdk.version")}-alpha"))
+    implementation("androidx.appcompat:appcompat")
+    implementation("androidx.core:core")
+    implementation("androidx.navigation:navigation-fragment")
+
     api("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-sdk")
     implementation("io.opentelemetry:opentelemetry-exporter-zipkin")
@@ -71,17 +72,16 @@ dependencies {
     implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")
     implementation("io.opentelemetry:opentelemetry-semconv")
 
-    testImplementation("org.mockito:mockito-core:5.5.0")
-    testImplementation("org.mockito:mockito-junit-jupiter:5.5.0")
-    testImplementation(platform("org.junit:junit-bom:5.10.0"))
+    testImplementation("org.mockito:mockito-core")
+    testImplementation("org.mockito:mockito-junit-jupiter")
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-engine")
     testImplementation("org.junit.vintage:junit-vintage-engine")
     testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
-    testImplementation("org.robolectric:robolectric:4.10.3")
-    testImplementation("androidx.test:core:1.5.0")
-    testImplementation("org.assertj:assertj-core:3.24.2")
-    testImplementation("org.awaitility:awaitility:4.2.0")
+    testImplementation("org.robolectric:robolectric")
+    testImplementation("androidx.test:core")
+    testImplementation("org.assertj:assertj-core")
+    testImplementation("org.awaitility:awaitility")
 
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,7 @@
 rootProject.name = "opentelemetry-android"
 
 include(":instrumentation")
+include(":dependencyManagement")
 include(":auto-instrumentation:okhttp:okhttp-3.0:agent")
 include(":auto-instrumentation:okhttp:okhttp-3.0:library")
 include(":auto-instrumentation:okhttp:okhttp-3.0:testing")


### PR DESCRIPTION
This adds a dependencyManagement module to help consolidate dependencies across the project into one consistent place. This is consistent with the other java-based otel projects.

There were a few cases where I could not figure out how to propagate the constraint into `androidTestImplementation`, so those reference the version via root project variable.

This resolves #86