### PR TITLE
Adding android targetsdk

### DIFF
--- a/buildSrc/src/main/kotlin/otel.android-app-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.android-app-conventions.gradle.kts
@@ -12,6 +12,7 @@ android {
 
     defaultConfig {
         minSdk = (property("android.minSdk") as String).toInt()
+        targetSdk = (property("android.targetSdk") as String).toInt()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,7 @@ android.useAndroidX=true
 # generate the BuildConfig class that contains the app version
 android.defaults.buildfeatures.buildconfig=true
 android.minSdk=21
+android.targetSdk=23
 android.compileSdk=34
 otel.sdk.version=1.29.0
 bytebuddy.version=1.14.8


### PR DESCRIPTION
This will avoid issues when running android tests on devices with OS version 14+, [ref](https://developer.android.com/about/versions/14/behavior-changes-all#minimum-target-api-level).