### PR TITLE
Pin okhttp dependency via compileOnly

### DIFF
--- a/auto-instrumentation/okhttp/okhttp-3.0/library/build.gradle.kts
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/build.gradle.kts
@@ -5,7 +5,8 @@ plugins {
 
 dependencies {
     // Pin at 3.0.0 for api compatibility
-    api("com.squareup.okhttp3:okhttp:3.0.0")
+    //noinspection GradleDependency
+    compileOnly("com.squareup.okhttp3:okhttp:3.0.0")
     api("io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0")
     implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv")
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -19,6 +19,12 @@
       "enabled": false
     },
     {
+      // pin okhttp at 3.0.0 for api compatibility
+      "matchPackageNames": ["com.squareup.okhttp3:okhttp"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
       // somehow renovate gets confused by the android property in gradle.properties,
       // so let's just exclude it and hopefully clean up the dashboard
       "matchPackageNames": ["string:rum.version"],


### PR DESCRIPTION
This was mentioned as part of #91. It also addresses the renovatebot desire to update past 3.0.0.