### PR TITLE
Centralizing dependencies

### DIFF
--- a/auto-instrumentation/okhttp/okhttp-3.0/agent/build.gradle.kts
+++ b/auto-instrumentation/okhttp/okhttp-3.0/agent/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 dependencies {
-    implementation("com.squareup.okhttp3:okhttp:4.11.0")
     implementation(project(":auto-instrumentation:okhttp:okhttp-3.0:library"))
-    implementation("net.bytebuddy:byte-buddy:${property("bytebuddy.version")}")
+    implementation(libs.okhttp)
+    implementation(libs.byteBuddy)
 }

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/build.gradle.kts
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/build.gradle.kts
@@ -3,11 +3,8 @@ plugins {
     id("otel.publish-conventions")
 }
 
-val otelVersion = project.property("otel.sdk.version")
 dependencies {
-    // pin okhttp api at 3.0.0 for now
-    //noinspection GradleDependency
-    compileOnly("com.squareup.okhttp3:okhttp:3.0.0")
-    api("io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0:$otelVersion-alpha")
-    implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv:$otelVersion-alpha")
+    compileOnly(libs.okhttp)
+    api(libs.opentelemetry.instrumentation.okhttp)
+    implementation(libs.opentelemetry.instrumentation.apiSemconv)
 }

--- a/auto-instrumentation/okhttp/okhttp-3.0/testing/build.gradle.kts
+++ b/auto-instrumentation/okhttp/okhttp-3.0/testing/build.gradle.kts
@@ -6,6 +6,6 @@ plugins {
 dependencies {
     byteBuddy(project(":auto-instrumentation:okhttp:okhttp-3.0:agent"))
     implementation(project(":auto-instrumentation:okhttp:okhttp-3.0:library"))
-    implementation("com.squareup.okhttp3:okhttp:4.11.0")
-    androidTestImplementation("com.squareup.okhttp3:mockwebserver:4.11.0")
+    implementation(libs.okhttp)
+    androidTestImplementation(libs.okhttp.mockwebserver)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,15 +5,14 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        // keep this version in sync with /buildSrc/build.gradle.kts
-        classpath("com.android.tools.build:gradle:8.1.2")
-        classpath("net.bytebuddy:byte-buddy-gradle-plugin:${property("bytebuddy.version")}")
+        classpath(libs.androd.plugin)
+        classpath(libs.byteBuddy.plugin)
     }
 }
 
 plugins {
     id("otel.spotless-conventions")
-    id("io.github.gradle-nexus.publish-plugin") version "1.3.0"
+    alias(libs.plugins.publishPlugin)
 }
 
 extra["java_version"] = JavaVersion.VERSION_1_8

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -20,10 +20,9 @@ repositories {
 
 dependencies {
     // keep this version in sync with /build.gradle.kts
-    implementation("com.android.tools.build:gradle:8.1.2")
-
-    implementation("com.diffplug.spotless:spotless-plugin-gradle:6.22.0")
-    implementation("net.ltgt.gradle:gradle-errorprone-plugin:3.1.0")
-    implementation("net.ltgt.gradle:gradle-nullaway-plugin:1.6.0")
-    implementation("ru.vyarus:gradle-animalsniffer-plugin:1.7.1")
+    implementation(libs.androd.plugin)
+    implementation(libs.spotless.plugin)
+    implementation(libs.errorprone.plugin)
+    implementation(libs.nullaway.plugin)
+    implementation(libs.animalsniffer.plugin)
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -19,7 +19,6 @@ repositories {
 }
 
 dependencies {
-    // keep this version in sync with /build.gradle.kts
     implementation(libs.androd.plugin)
     implementation(libs.spotless.plugin)
     implementation(libs.errorprone.plugin)

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,8 +1,6 @@
 plugins {
     `kotlin-dsl`
-
-    // When updating, update below in dependencies too
-    id("com.diffplug.spotless") version "6.22.0"
+    alias(libs.plugins.spotless)
 }
 
 spotless {

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/otel.android-app-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.android-app-conventions.gradle.kts
@@ -23,8 +23,8 @@ android {
     }
 }
 
-val otelVersion = rootProject.property("otel.sdk.version")
+val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 dependencies {
-    androidTestImplementation("androidx.test:runner:1.5.2")
-    androidTestImplementation("io.opentelemetry:opentelemetry-sdk-testing:$otelVersion")
+    androidTestImplementation(libs.findLibrary("androidx-test-runner").get())
+    androidTestImplementation(libs.findLibrary("opentelemetry-sdk-testing").get())
 }

--- a/buildSrc/src/main/kotlin/otel.errorprone-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.errorprone-conventions.gradle.kts
@@ -20,10 +20,11 @@ if (isAndroidProject) {
     }
 }
 
+val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 dependencies {
-    errorprone("com.uber.nullaway:nullaway:0.10.14")
-    errorprone("com.google.errorprone:error_prone_core:2.22.0")
-    errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
+    errorprone(libs.findLibrary("nullaway").get())
+    errorprone(libs.findLibrary("errorprone-core").get())
+    errorproneJavac(libs.findLibrary("errorprone-javac").get())
 }
 
 nullaway {

--- a/buildSrc/src/main/kotlin/otel.java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-library-conventions.gradle.kts
@@ -12,9 +12,10 @@ java {
     targetCompatibility = javaVersion
 }
 
+val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 dependencies {
     signature("com.toasttab.android:gummy-bears-api-${project.property("android.minSdk")}:0.5.1:coreLib@signature")
-    implementation("com.google.code.findbugs:jsr305:3.0.2")
+    implementation(libs.findLibrary("findbugs-jsr305").get())
 }
 
 animalsniffer {

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,8 +21,6 @@ android.defaults.buildfeatures.buildconfig=true
 android.minSdk=21
 android.targetSdk=23
 android.compileSdk=34
-otel.sdk.version=1.29.0
-bytebuddy.version=1.14.8
 
 version=0.2.0
 group=io.opentelemetry.android

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ opentelemetry-platform = { module = "io.opentelemetry.instrumentation:openteleme
 androidx-appcompat = "androidx.appcompat:appcompat:1.6.1"
 androidx-navigation-fragment = "androidx.navigation:navigation-fragment:2.7.4"
 androidx-core = "androidx.core:core:1.12.0"
+findbugs-jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 
 #Testing
 opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing", version.ref = "opentelemetry" }
@@ -27,7 +28,6 @@ desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.0.3"
 nullaway = "com.uber.nullaway:nullaway:0.10.14"
 errorprone-core = "com.google.errorprone:error_prone_core:2.22.0"
 errorprone-javac = "com.google.errorprone:javac:9+181-r4173-1"
-findbugs-jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 spotless-plugin = "com.diffplug.spotless:spotless-plugin-gradle:6.22.0"
 errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:3.1.0"
 nullaway-plugin = "net.ltgt.gradle:gradle-nullaway-plugin:1.6.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ mockito = "5.5.0"
 junit = "5.10.0"
 byteBuddy = "1.14.8"
 okhttp = "4.11.0"
+spotless = "6.22.0"
 
 [libraries]
 opentelemetry-platform = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetry" }
@@ -35,7 +36,7 @@ desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.0.3"
 nullaway = "com.uber.nullaway:nullaway:0.10.14"
 errorprone-core = "com.google.errorprone:error_prone_core:2.22.0"
 errorprone-javac = "com.google.errorprone:javac:9+181-r4173-1"
-spotless-plugin = "com.diffplug.spotless:spotless-plugin-gradle:6.22.0"
+spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:3.1.0"
 nullaway-plugin = "net.ltgt.gradle:gradle-nullaway-plugin:1.6.0"
 animalsniffer-plugin = "ru.vyarus:gradle-animalsniffer-plugin:1.7.1"
@@ -48,3 +49,4 @@ junit = ["junit-jupiter-api", "junit-jupiter-engine", "junit-vintage-engine"]
 
 [plugins]
 publishPlugin = { id = "io.github.gradle-nexus.publish-plugin", version = "1.3.0" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
-opentelemetry = "1.29.0-alpha"
+opentelemetry = "1.29.0"
+opentelemetry-alpha = "1.29.0-alpha"
 mockito = "5.5.0"
 junit = "5.10.0"
 byteBuddy = "1.14.8"
@@ -7,15 +8,15 @@ okhttp = "4.11.0"
 spotless = "6.22.0"
 
 [libraries]
-opentelemetry-platform = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetry" }
+opentelemetry-platform = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetry-alpha" }
 androidx-appcompat = "androidx.appcompat:appcompat:1.6.1"
 androidx-navigation-fragment = "androidx.navigation:navigation-fragment:2.7.4"
 androidx-core = "androidx.core:core:1.12.0"
 findbugs-jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 byteBuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "byteBuddy" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
-opentelemetry-instrumentation-apiSemconv = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv", version.ref = "opentelemetry" }
-opentelemetry-instrumentation-okhttp = { module = "io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0", version.ref = "opentelemetry" }
+opentelemetry-instrumentation-apiSemconv = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv", version.ref = "opentelemetry-alpha" }
+opentelemetry-instrumentation-okhttp = { module = "io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0", version.ref = "opentelemetry-alpha" }
 
 #Test tools
 opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing", version.ref = "opentelemetry" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,43 @@
+[versions]
+gradle = "8.1.2"
+opentelemetry = "1.30.1-alpha"
+mockito = "5.5.0"
+junit = "5.10.0"
+
+[libraries]
+gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
+opentelemetry-platform = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetry" }
+androidx-appcompat = "androidx.appcompat:appcompat:1.6.1"
+androidx-navigation-fragment = "androidx.navigation:navigation-fragment:2.7.4"
+androidx-core = "androidx.core:core:1.12.0"
+desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.0.3"
+nullaway = "com.uber.nullaway:nullaway:0.10.14"
+errorprone-core = "com.google.errorprone:error_prone_core:2.22.0"
+errorprone-javac = "com.google.errorprone:javac:9+181-r4173-1"
+findbugs-jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
+
+#Testing
+opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing", version.ref = "opentelemetry" }
+androidx-test-core = "androidx.test:core:1.5.0"
+androidx-test-runner = "androidx.test:runner:1.5.2"
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
+junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
+junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
+junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit" }
+robolectric = "org.robolectric:robolectric:4.10.3"
+assertj-core = "org.assertj:assertj-core:3.24.2"
+awaitility = "org.awaitility:awaitility:4.2.0"
+
+#Compilation
+spotless-plugin = "com.diffplug.spotless:spotless-plugin-gradle:6.22.0"
+errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:3.1.0"
+nullaway-plugin = "net.ltgt.gradle:gradle-nullaway-plugin:1.6.0"
+animalsniffer-plugin = "ru.vyarus:gradle-animalsniffer-plugin:1.7.1"
+androd-plugin = "com.android.tools.build:gradle:8.1.2"
+
+[bundles]
+mockito = ["mockito-core", "mockito-junit-jupiter"]
+junit = ["junit-jupiter-api", "junit-jupiter-engine", "junit-vintage-engine"]
+
+[plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 opentelemetry = "1.29.0"
 opentelemetry-alpha = "1.29.0-alpha"
-mockito = "5.5.0"
+mockito = "5.6.0"
 junit = "5.10.0"
-byteBuddy = "1.14.8"
+byteBuddy = "1.14.9"
 okhttp = "4.11.0"
 spotless = "6.22.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,20 +1,13 @@
 [versions]
-gradle = "8.1.2"
 opentelemetry = "1.30.1-alpha"
 mockito = "5.5.0"
 junit = "5.10.0"
 
 [libraries]
-gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 opentelemetry-platform = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetry" }
 androidx-appcompat = "androidx.appcompat:appcompat:1.6.1"
 androidx-navigation-fragment = "androidx.navigation:navigation-fragment:2.7.4"
 androidx-core = "androidx.core:core:1.12.0"
-desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.0.3"
-nullaway = "com.uber.nullaway:nullaway:0.10.14"
-errorprone-core = "com.google.errorprone:error_prone_core:2.22.0"
-errorprone-javac = "com.google.errorprone:javac:9+181-r4173-1"
-findbugs-jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 
 #Testing
 opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing", version.ref = "opentelemetry" }
@@ -30,6 +23,11 @@ assertj-core = "org.assertj:assertj-core:3.24.2"
 awaitility = "org.awaitility:awaitility:4.2.0"
 
 #Compilation
+desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.0.3"
+nullaway = "com.uber.nullaway:nullaway:0.10.14"
+errorprone-core = "com.google.errorprone:error_prone_core:2.22.0"
+errorprone-javac = "com.google.errorprone:javac:9+181-r4173-1"
+findbugs-jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 spotless-plugin = "com.diffplug.spotless:spotless-plugin-gradle:6.22.0"
 errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:3.1.0"
 nullaway-plugin = "net.ltgt.gradle:gradle-nullaway-plugin:1.6.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,9 @@
 [versions]
-opentelemetry = "1.30.1-alpha"
+opentelemetry = "1.29.0-alpha"
 mockito = "5.5.0"
 junit = "5.10.0"
+byteBuddy = "1.14.8"
+okhttp = "4.11.0"
 
 [libraries]
 opentelemetry-platform = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetry" }
@@ -9,8 +11,12 @@ androidx-appcompat = "androidx.appcompat:appcompat:1.6.1"
 androidx-navigation-fragment = "androidx.navigation:navigation-fragment:2.7.4"
 androidx-core = "androidx.core:core:1.12.0"
 findbugs-jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
+byteBuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "byteBuddy" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
+opentelemetry-instrumentation-apiSemconv = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv", version.ref = "opentelemetry" }
+opentelemetry-instrumentation-okhttp = { module = "io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0", version.ref = "opentelemetry" }
 
-#Testing
+#Test tools
 opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing", version.ref = "opentelemetry" }
 androidx-test-core = "androidx.test:core:1.5.0"
 androidx-test-runner = "androidx.test:runner:1.5.2"
@@ -22,8 +28,9 @@ junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", vers
 robolectric = "org.robolectric:robolectric:4.10.3"
 assertj-core = "org.assertj:assertj-core:3.24.2"
 awaitility = "org.awaitility:awaitility:4.2.0"
+okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 
-#Compilation
+#Compilation tools
 desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.0.3"
 nullaway = "com.uber.nullaway:nullaway:0.10.14"
 errorprone-core = "com.google.errorprone:error_prone_core:2.22.0"
@@ -33,9 +40,11 @@ errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:3.1.0"
 nullaway-plugin = "net.ltgt.gradle:gradle-nullaway-plugin:1.6.0"
 animalsniffer-plugin = "ru.vyarus:gradle-animalsniffer-plugin:1.7.1"
 androd-plugin = "com.android.tools.build:gradle:8.1.2"
+byteBuddy-plugin = { module = "net.bytebuddy:byte-buddy-gradle-plugin", version.ref = "byteBuddy" }
 
 [bundles]
 mockito = ["mockito-core", "mockito-junit-jupiter"]
 junit = ["junit-jupiter-api", "junit-jupiter-engine", "junit-vintage-engine"]
 
 [plugins]
+publishPlugin = { id = "io.github.gradle-nexus.publish-plugin", version = "1.3.0" }

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -58,11 +58,11 @@ android {
 }
 
 dependencies {
-    implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("androidx.core:core:1.12.0")
-    implementation("androidx.navigation:navigation-fragment:2.7.4")
+    implementation(libs.androidx.appcompat)
+    implementation(libs.androidx.core)
+    implementation(libs.androidx.navigation.fragment)
 
-    api(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:${property("otel.sdk.version")}-alpha"))
+    api(platform(libs.opentelemetry.platform))
     api("io.opentelemetry:opentelemetry-api")
     implementation("io.opentelemetry:opentelemetry-sdk")
     implementation("io.opentelemetry:opentelemetry-exporter-zipkin")
@@ -71,19 +71,15 @@ dependencies {
     implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")
     implementation("io.opentelemetry:opentelemetry-semconv")
 
-    testImplementation("org.mockito:mockito-core:5.5.0")
-    testImplementation("org.mockito:mockito-junit-jupiter:5.5.0")
-    testImplementation(platform("org.junit:junit-bom:5.10.0"))
-    testImplementation("org.junit.jupiter:junit-jupiter-api")
-    testImplementation("org.junit.jupiter:junit-jupiter-engine")
-    testImplementation("org.junit.vintage:junit-vintage-engine")
+    testImplementation(libs.bundles.mockito)
+    testImplementation(libs.bundles.junit)
     testImplementation("io.opentelemetry:opentelemetry-sdk-testing")
-    testImplementation("org.robolectric:robolectric:4.10.3")
-    testImplementation("androidx.test:core:1.5.0")
-    testImplementation("org.assertj:assertj-core:3.24.2")
-    testImplementation("org.awaitility:awaitility:4.2.0")
+    testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.test.core)
+    testImplementation(libs.assertj.core)
+    testImplementation(libs.awaitility)
 
-    coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
+    coreLibraryDesugaring(libs.desugarJdkLibs)
 }
 
 tasks.withType<Test> {

--- a/renovate.json5
+++ b/renovate.json5
@@ -19,12 +19,6 @@
       "enabled": false
     },
     {
-      // pin okhttp at 3.0.0 for api compatibility
-      "matchPackageNames": ["com.squareup.okhttp3:okhttp"],
-      "matchUpdateTypes": ["major", "minor"],
-      "enabled": false
-    },
-    {
       // somehow renovate gets confused by the android property in gradle.properties,
       // so let's just exclude it and hopefully clean up the dashboard
       "matchPackageNames": ["string:rum.version"],


### PR DESCRIPTION
Based on [this comment](https://github.com/open-telemetry/opentelemetry-android/pull/101#issuecomment-1744354656).

For posterity -- we were unable to use the `dependencyManagemetn` style `platform()` support (like in other projects) due to [this bug in AGP](https://issuetracker.google.com/issues/248059128).