### PR TITLE
Okhttp callback support

### DIFF
--- a/auto-instrumentation/okhttp/okhttp-3.0/README.md
+++ b/auto-instrumentation/okhttp/okhttp-3.0/README.md
@@ -1,5 +1,7 @@
 # Android Instrumentation for OkHttp version 3.0 and higher
 
+# 🚧Work in progress 🚧
+
 Provides OpenTelemetry instrumentation for [okhttp3](https://square.github.io/okhttp/).
 
 ## Quickstart
@@ -15,7 +17,7 @@ release](https://search.maven.org/search?q=g:net.bytebuddy%20AND%20a:byte-buddy)
 #### Byte buddy compilation plugin
 
 This plugin leverages
-Android's [ASM API](https://developer.android.com/reference/tools/gradle-api/8.0/com/android/build/api/instrumentation/AsmClassVisitorFactory)
+Android's [Transform API](https://developer.android.com/reference/tools/gradle-api/current/com/android/build/api/variant/ScopedArtifactsOperation#toTransform(com.android.build.api.artifact.ScopedArtifact,kotlin.Function1,kotlin.Function1,kotlin.Function1))
 to instrument bytecode at compile time. You can find more info on
 its [repo page](https://github.com/raphw/byte-buddy/tree/master/byte-buddy-gradle-plugin/android-plugin.
 
@@ -30,8 +32,10 @@ plugins {
 ```kotlin
 implementation("io.opentelemetry.android:okhttp-3.0-library:OPENTELEMETRY_VERSION")
 byteBuddy("io.opentelemetry.android:okhttp-3.0-agent:OPENTELEMETRY_VERSION")
+```
 
-After adding the plugin and the dependencies to your project, your OkHttp requests will be traced automatically.
+After adding the plugin and the dependencies to your project, your OkHttp requests will be traced
+automatically.
 
 ### Configuration
 

--- a/auto-instrumentation/okhttp/okhttp-3.0/agent/src/main/java/io/opentelemetry/instrumentation/agent/okhttp/v3_0/OkHttpClientAdvice.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/agent/src/main/java/io/opentelemetry/instrumentation/agent/okhttp/v3_0/OkHttpClientAdvice.java
@@ -6,7 +6,9 @@
 package io.opentelemetry.instrumentation.agent.okhttp.v3_0;
 
 import io.opentelemetry.instrumentation.library.okhttp.v3_0.internal.OkHttp3Singletons;
+
 import net.bytebuddy.asm.Advice;
+
 import okhttp3.OkHttpClient;
 
 public class OkHttpClientAdvice {
@@ -16,9 +18,7 @@ public class OkHttpClientAdvice {
         if (!builder.interceptors().contains(OkHttp3Singletons.CONTEXT_INTERCEPTOR)) {
             builder.interceptors().add(0, OkHttp3Singletons.CONTEXT_INTERCEPTOR);
             builder.interceptors().add(1, OkHttp3Singletons.CONNECTION_ERROR_INTERCEPTOR);
-        }
-        if (!builder.networkInterceptors().contains(OkHttp3Singletons.TRACING_INTERCEPTOR)) {
-            builder.addNetworkInterceptor(OkHttp3Singletons.TRACING_INTERCEPTOR);
+            builder.interceptors().add(2, OkHttp3Singletons.TRACING_INTERCEPTOR);
         }
     }
 }

--- a/auto-instrumentation/okhttp/okhttp-3.0/agent/src/main/java/io/opentelemetry/instrumentation/agent/okhttp/v3_0/OkHttpClientAdvice.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/agent/src/main/java/io/opentelemetry/instrumentation/agent/okhttp/v3_0/OkHttpClientAdvice.java
@@ -15,10 +15,13 @@ public class OkHttpClientAdvice {
 
     @Advice.OnMethodEnter
     public static void enter(@Advice.Argument(0) OkHttpClient.Builder builder) {
-        if (!builder.interceptors().contains(OkHttp3Singletons.CONTEXT_INTERCEPTOR)) {
-            builder.interceptors().add(0, OkHttp3Singletons.CONTEXT_INTERCEPTOR);
-            builder.interceptors().add(1, OkHttp3Singletons.CONNECTION_ERROR_INTERCEPTOR);
-            builder.interceptors().add(2, OkHttp3Singletons.TRACING_INTERCEPTOR);
+        if (!builder.interceptors().contains(OkHttp3Singletons.CALLBACK_CONTEXT_INTERCEPTOR)) {
+            builder.interceptors().add(0, OkHttp3Singletons.CALLBACK_CONTEXT_INTERCEPTOR);
+            builder.interceptors().add(1, OkHttp3Singletons.RESEND_COUNT_CONTEXT_INTERCEPTOR);
+            builder.interceptors().add(2, OkHttp3Singletons.CONNECTION_ERROR_INTERCEPTOR);
+        }
+        if (!builder.networkInterceptors().contains(OkHttp3Singletons.TRACING_INTERCEPTOR)) {
+            builder.addNetworkInterceptor(OkHttp3Singletons.TRACING_INTERCEPTOR);
         }
     }
 }

--- a/auto-instrumentation/okhttp/okhttp-3.0/agent/src/main/java/io/opentelemetry/instrumentation/agent/okhttp/v3_0/OkHttpClientAdvice.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/agent/src/main/java/io/opentelemetry/instrumentation/agent/okhttp/v3_0/OkHttpClientAdvice.java
@@ -6,9 +6,7 @@
 package io.opentelemetry.instrumentation.agent.okhttp.v3_0;
 
 import io.opentelemetry.instrumentation.library.okhttp.v3_0.internal.OkHttp3Singletons;
-
 import net.bytebuddy.asm.Advice;
-
 import okhttp3.OkHttpClient;
 
 public class OkHttpClientAdvice {

--- a/auto-instrumentation/okhttp/okhttp-3.0/agent/src/main/java/io/opentelemetry/instrumentation/agent/okhttp/v3_0/callback/OkHttpCallbackAdvice.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/agent/src/main/java/io/opentelemetry/instrumentation/agent/okhttp/v3_0/callback/OkHttpCallbackAdvice.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.agent.okhttp.v3_0.callback;
+
+import net.bytebuddy.asm.Advice;
+
+import io.opentelemetry.instrumentation.library.okhttp.v3_0.internal.OkHttpCallbackAdviceHelper;
+import okhttp3.Call;
+
+public class OkHttpCallbackAdvice {
+
+    @Advice.OnMethodEnter
+    public static void enter(@Advice.This Call call) {
+        OkHttpCallbackAdviceHelper.onEnterDispatcherEnqueue(call);
+    }
+}

--- a/auto-instrumentation/okhttp/okhttp-3.0/agent/src/main/java/io/opentelemetry/instrumentation/agent/okhttp/v3_0/callback/OkHttpCallbackAdvice.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/agent/src/main/java/io/opentelemetry/instrumentation/agent/okhttp/v3_0/callback/OkHttpCallbackAdvice.java
@@ -5,18 +5,19 @@
 
 package io.opentelemetry.instrumentation.agent.okhttp.v3_0.callback;
 
-import net.bytebuddy.asm.Advice;
-
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.library.okhttp.v3_0.internal.OkHttpCallbackAdviceHelper;
 import io.opentelemetry.instrumentation.library.okhttp.v3_0.internal.TracingCallback;
+import net.bytebuddy.asm.Advice;
 import okhttp3.Call;
 import okhttp3.Callback;
 
 public class OkHttpCallbackAdvice {
 
     @Advice.OnMethodEnter
-    public static void enter(@Advice.This Call call, @Advice.Argument(value = 0, readOnly = false) Callback callback) {
+    public static void enter(
+            @Advice.This Call call,
+            @Advice.Argument(value = 0, readOnly = false) Callback callback) {
         if (OkHttpCallbackAdviceHelper.propagateContext(call)) {
             callback = new TracingCallback(callback, Context.current());
         }

--- a/auto-instrumentation/okhttp/okhttp-3.0/agent/src/main/java/io/opentelemetry/instrumentation/agent/okhttp/v3_0/callback/OkHttpCallbackAdvice.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/agent/src/main/java/io/opentelemetry/instrumentation/agent/okhttp/v3_0/callback/OkHttpCallbackAdvice.java
@@ -7,13 +7,18 @@ package io.opentelemetry.instrumentation.agent.okhttp.v3_0.callback;
 
 import net.bytebuddy.asm.Advice;
 
+import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.library.okhttp.v3_0.internal.OkHttpCallbackAdviceHelper;
+import io.opentelemetry.instrumentation.library.okhttp.v3_0.internal.TracingCallback;
 import okhttp3.Call;
+import okhttp3.Callback;
 
 public class OkHttpCallbackAdvice {
 
     @Advice.OnMethodEnter
-    public static void enter(@Advice.This Call call) {
-        OkHttpCallbackAdviceHelper.onEnterDispatcherEnqueue(call);
+    public static void enter(@Advice.This Call call, @Advice.Argument(value = 0, readOnly = false) Callback callback) {
+        if (OkHttpCallbackAdviceHelper.propagateContext(call)) {
+            callback = new TracingCallback(callback, Context.current());
+        }
     }
 }

--- a/auto-instrumentation/okhttp/okhttp-3.0/agent/src/main/java/io/opentelemetry/instrumentation/agent/okhttp/v3_0/callback/OkHttpCallbackPlugin.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/agent/src/main/java/io/opentelemetry/instrumentation/agent/okhttp/v3_0/callback/OkHttpCallbackPlugin.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.agent.okhttp.v3_0.callback;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.build.Plugin;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.ClassFileLocator;
+import net.bytebuddy.dynamic.DynamicType;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+import okhttp3.Callback;
+
+public class OkHttpCallbackPlugin implements Plugin {
+    private static final Pattern REAL_CALL_PATTERN = Pattern.compile("^okhttp3\\..*RealCall$");
+
+    @Override
+    public DynamicType.Builder<?> apply(
+            DynamicType.Builder<?> builder,
+            TypeDescription typeDescription,
+            ClassFileLocator classFileLocator) {
+        return builder.visit(Advice.to(OkHttpCallbackAdvice.class)
+                .on(named("enqueue")
+                        .and(takesArgument(0, Callback.class))));
+
+    }
+
+    @Override
+    public void close() throws IOException {
+        // No operation.
+    }
+
+    @Override
+    public boolean matches(TypeDescription target) {
+        return REAL_CALL_PATTERN.matcher(target.getTypeName()).matches();
+    }
+}

--- a/auto-instrumentation/okhttp/okhttp-3.0/agent/src/main/java/io/opentelemetry/instrumentation/agent/okhttp/v3_0/callback/OkHttpCallbackPlugin.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/agent/src/main/java/io/opentelemetry/instrumentation/agent/okhttp/v3_0/callback/OkHttpCallbackPlugin.java
@@ -8,15 +8,13 @@ package io.opentelemetry.instrumentation.agent.okhttp.v3_0.callback;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
+import java.io.IOException;
+import java.util.regex.Pattern;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.build.Plugin;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.dynamic.ClassFileLocator;
 import net.bytebuddy.dynamic.DynamicType;
-
-import java.io.IOException;
-import java.util.regex.Pattern;
-
 import okhttp3.Callback;
 
 public class OkHttpCallbackPlugin implements Plugin {
@@ -27,10 +25,9 @@ public class OkHttpCallbackPlugin implements Plugin {
             DynamicType.Builder<?> builder,
             TypeDescription typeDescription,
             ClassFileLocator classFileLocator) {
-        return builder.visit(Advice.to(OkHttpCallbackAdvice.class)
-                .on(named("enqueue")
-                        .and(takesArgument(0, Callback.class))));
-
+        return builder.visit(
+                Advice.to(OkHttpCallbackAdvice.class)
+                        .on(named("enqueue").and(takesArgument(0, Callback.class))));
     }
 
     @Override

--- a/auto-instrumentation/okhttp/okhttp-3.0/agent/src/main/resources/META-INF/net.bytebuddy/build.plugins
+++ b/auto-instrumentation/okhttp/okhttp-3.0/agent/src/main/resources/META-INF/net.bytebuddy/build.plugins
@@ -1,1 +1,2 @@
 io.opentelemetry.instrumentation.agent.okhttp.v3_0.OkHttpClientPlugin
+io.opentelemetry.instrumentation.agent.okhttp.v3_0.callback.OkHttpCallbackPlugin

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttp3Singletons.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttp3Singletons.java
@@ -47,7 +47,8 @@ public final class OkHttp3Singletons {
     public static final Interceptor CALLBACK_CONTEXT_INTERCEPTOR =
             chain -> {
                 Request request = chain.request();
-                Context context = OkHttpCallbackAdviceHelper.tryRecoverPropagatedContextFromCallback(request);
+                Context context =
+                        OkHttpCallbackAdviceHelper.tryRecoverPropagatedContextFromCallback(request);
                 if (context != null) {
                     try (Scope ignored = context.makeCurrent()) {
                         return chain.proceed(request);
@@ -70,6 +71,5 @@ public final class OkHttp3Singletons {
     public static final Interceptor TRACING_INTERCEPTOR =
             new TracingInterceptor(INSTRUMENTER, GlobalOpenTelemetry.getPropagators());
 
-    private OkHttp3Singletons() {
-    }
+    private OkHttp3Singletons() {}
 }

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttp3Singletons.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttp3Singletons.java
@@ -44,7 +44,20 @@ public final class OkHttp3Singletons {
                                     OkHttpInstrumentationConfig.getPeerServiceMapping())),
                     OkHttpInstrumentationConfig.emitExperimentalHttpClientMetrics());
 
-    public static final Interceptor CONTEXT_INTERCEPTOR =
+    public static final Interceptor CALLBACK_CONTEXT_INTERCEPTOR =
+            chain -> {
+                Request request = chain.request();
+                Context context = OkHttpCallbackAdviceHelper.tryRecoverPropagatedContextFromCallback(request);
+                if (context != null) {
+                    try (Scope ignored = context.makeCurrent()) {
+                        return chain.proceed(request);
+                    }
+                }
+
+                return chain.proceed(request);
+            };
+
+    public static final Interceptor RESEND_COUNT_CONTEXT_INTERCEPTOR =
             chain -> {
                 try (Scope ignored = HttpClientResend.initialize(Context.current()).makeCurrent()) {
                     return chain.proceed(chain.request());
@@ -57,5 +70,6 @@ public final class OkHttp3Singletons {
     public static final Interceptor TRACING_INTERCEPTOR =
             new TracingInterceptor(INSTRUMENTER, GlobalOpenTelemetry.getPropagators());
 
-    private OkHttp3Singletons() {}
+    private OkHttp3Singletons() {
+    }
 }

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttpCallbackAdviceHelper.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttpCallbackAdviceHelper.java
@@ -1,0 +1,31 @@
+package io.opentelemetry.instrumentation.library.okhttp.v3_0.internal;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.instrumentation.api.util.VirtualField;
+import okhttp3.Call;
+import okhttp3.Request;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class OkHttpCallbackAdviceHelper {
+
+    public static void onEnterDispatcherEnqueue(Call call) {
+        Context context = Context.current();
+        if (shouldPropagateContext(context)) {
+            VirtualField<Request, Context> virtualField =
+                    VirtualField.find(Request.class, Context.class);
+            virtualField.set(call.request(), context);
+        }
+    }
+
+    public static Context tryRecoverPropagatedContextFromCallback(Request request) {
+        VirtualField<Request, Context> virtualField = VirtualField.find(Request.class, Context.class);
+        return virtualField.get(request);
+    }
+
+    private static boolean shouldPropagateContext(Context context) {
+        return context != Context.root();
+    }
+}

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttpCallbackAdviceHelper.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttpCallbackAdviceHelper.java
@@ -11,13 +11,16 @@ import okhttp3.Request;
  */
 public final class OkHttpCallbackAdviceHelper {
 
-    public static void onEnterDispatcherEnqueue(Call call) {
+    public static boolean propagateContext(Call call) {
         Context context = Context.current();
         if (shouldPropagateContext(context)) {
             VirtualField<Request, Context> virtualField =
                     VirtualField.find(Request.class, Context.class);
             virtualField.set(call.request(), context);
+            return true;
         }
+
+        return false;
     }
 
     public static Context tryRecoverPropagatedContextFromCallback(Request request) {

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttpCallbackAdviceHelper.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttpCallbackAdviceHelper.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.instrumentation.library.okhttp.v3_0.internal;
 
 import io.opentelemetry.context.Context;
@@ -24,7 +29,8 @@ public final class OkHttpCallbackAdviceHelper {
     }
 
     public static Context tryRecoverPropagatedContextFromCallback(Request request) {
-        VirtualField<Request, Context> virtualField = VirtualField.find(Request.class, Context.class);
+        VirtualField<Request, Context> virtualField =
+                VirtualField.find(Request.class, Context.class);
         return virtualField.get(request);
     }
 

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/TracingCallback.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/TracingCallback.java
@@ -1,0 +1,37 @@
+package io.opentelemetry.instrumentation.library.okhttp.v3_0.internal;
+
+import java.io.IOException;
+
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
+import okhttp3.Call;
+import okhttp3.Callback;
+import okhttp3.Response;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public final class TracingCallback implements Callback {
+    private final Callback delegate;
+    private final Context callingContext;
+
+    public TracingCallback(Callback delegate, Context callingContext) {
+        this.delegate = delegate;
+        this.callingContext = callingContext;
+    }
+
+    @Override
+    public void onFailure(Call call, IOException e) {
+        try (Scope scope = callingContext.makeCurrent()) {
+            delegate.onFailure(call, e);
+        }
+    }
+
+    @Override
+    public void onResponse(Call call, Response response) throws IOException {
+        try (Scope scope = callingContext.makeCurrent()) {
+            delegate.onResponse(call, response);
+        }
+    }
+}

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/TracingCallback.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/TracingCallback.java
@@ -1,9 +1,13 @@
-package io.opentelemetry.instrumentation.library.okhttp.v3_0.internal;
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 
-import java.io.IOException;
+package io.opentelemetry.instrumentation.library.okhttp.v3_0.internal;
 
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import java.io.IOException;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.Response;

--- a/auto-instrumentation/okhttp/okhttp-3.0/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/InstrumentationTest.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/InstrumentationTest.java
@@ -8,19 +8,29 @@ package io.opentelemetry.instrumentation.library.okhttp.v3_0;
 import static org.junit.Assert.assertEquals;
 
 import androidx.annotation.NonNull;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
-import java.io.IOException;
+import okhttp3.Call;
+import okhttp3.Callback;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
 
 public class InstrumentationTest {
     private MockWebServer server;
@@ -34,27 +44,62 @@ public class InstrumentationTest {
     @After
     public void tearDown() throws IOException {
         server.shutdown();
+        GlobalOpenTelemetry.resetForTest();
     }
 
     @Test
     public void okhttpTraces() throws IOException {
-        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
-        OpenTelemetrySdk.builder()
-                .setTracerProvider(getSimpleTracerProvider(spanExporter))
-                .buildAndRegisterGlobal();
+        InMemorySpanExporter spanExporter = getInMemorySpanExporter();
 
         server.enqueue(new MockResponse().setResponseCode(200));
 
         OkHttpClient client = new OkHttpClient();
-        executeRequest(client, "/test/");
+        createCall(client, "/test/").execute();
 
         assertEquals(1, spanExporter.getFinishedSpanItems().size());
     }
 
-    private void executeRequest(OkHttpClient client, String urlPath) throws IOException {
+    @Test
+    public void okhttpTraces_with_callback() throws InterruptedException {
+        CountDownLatch lock = new CountDownLatch(1);
+        InMemorySpanExporter spanExporter = getInMemorySpanExporter();
+        Span span = GlobalOpenTelemetry.getTracer("TestTracer").spanBuilder("A Span").startSpan();
+
+        try (Scope ignored = span.makeCurrent()) {
+            server.enqueue(new MockResponse().setResponseCode(200));
+
+            OkHttpClient client = new OkHttpClient();
+            createCall(client, "/test/").enqueue(new Callback() {
+                @Override
+                public void onFailure(@NonNull Call call, @NonNull IOException e) {
+                }
+
+                @Override
+                public void onResponse(@NonNull Call call, @NonNull Response response) {
+                    assertEquals(Context.root().with(span), Context.current());
+                    lock.countDown();
+                }
+            });
+
+        }
+
+        lock.await();
+
+        assertEquals(1, spanExporter.getFinishedSpanItems().size());
+    }
+
+    @NonNull
+    private static InMemorySpanExporter getInMemorySpanExporter() {
+        InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
+        OpenTelemetrySdk.builder()
+                .setTracerProvider(getSimpleTracerProvider(spanExporter))
+                .buildAndRegisterGlobal();
+        return spanExporter;
+    }
+
+    private Call createCall(OkHttpClient client, String urlPath) {
         Request request = new Request.Builder().url(server.url(urlPath)).build();
-        Response response = client.newCall(request).execute();
-        response.body().bytes();
+        return client.newCall(request);
     }
 
     @NonNull

--- a/auto-instrumentation/okhttp/okhttp-3.0/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/InstrumentationTest.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/InstrumentationTest.java
@@ -62,7 +62,6 @@ public class InstrumentationTest {
             OkHttpClient client = new OkHttpClient.Builder()
                     .addInterceptor(chain -> {
                         SpanContext currentSpan = Span.current().getSpanContext();
-                        assertNotEquals(span.getSpanContext().getSpanId(), currentSpan.getSpanId());
                         assertEquals(span.getSpanContext().getTraceId(), currentSpan.getTraceId());
                         return chain.proceed(chain.request());
                     })
@@ -87,7 +86,6 @@ public class InstrumentationTest {
             OkHttpClient client = new OkHttpClient.Builder()
                     .addInterceptor(chain -> {
                         SpanContext currentSpan = Span.current().getSpanContext();
-                        assertNotEquals(span.getSpanContext().getSpanId(), currentSpan.getSpanId());
                         assertEquals(span.getSpanContext().getTraceId(), currentSpan.getTraceId());
                         return chain.proceed(chain.request());
                     })

--- a/auto-instrumentation/okhttp/okhttp-3.0/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/InstrumentationTest.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/InstrumentationTest.java
@@ -97,7 +97,7 @@ public class InstrumentationTest {
 
                 @Override
                 public void onResponse(@NonNull Call call, @NonNull Response response) {
-                    assertEquals(Context.root().with(span), Context.current());
+                    assertEquals(span, Span.current());
                     lock.countDown();
                 }
             });
@@ -105,6 +105,7 @@ public class InstrumentationTest {
         }
 
         lock.await();
+        span.end();
 
         assertEquals(2, spanExporter.getFinishedSpanItems().size());
     }

--- a/auto-instrumentation/okhttp/okhttp-3.0/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/InstrumentationTest.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/InstrumentationTest.java
@@ -87,6 +87,7 @@ public class InstrumentationTest {
             OkHttpClient client = new OkHttpClient.Builder()
                     .addInterceptor(chain -> {
                         SpanContext currentSpan = Span.current().getSpanContext();
+                        // Verify context propagation.
                         assertEquals(span.getSpanContext().getTraceId(), currentSpan.getTraceId());
                         return chain.proceed(chain.request());
                     })
@@ -98,6 +99,7 @@ public class InstrumentationTest {
 
                 @Override
                 public void onResponse(@NonNull Call call, @NonNull Response response) {
+                    // Verify that the original caller's context is the current one here.
                     assertEquals(span, Span.current());
                     lock.countDown();
                 }


### PR DESCRIPTION
Adds support for instrumenting and properly propagating the Context when making calls using OkHttp callbacks (by calling [Call.enqueue](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-call/enqueue/))