### PR TITLE
Tell renovate to include alpha packages in updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -5,6 +5,18 @@
   ],
   "packageRules": [
     {
+      "matchPackageNames": [
+        "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha",
+        "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv",
+        "io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0"
+      ],
+      // Renovate's default behavior is only to update from unstable -> unstable if it's for the
+      // major.minor.patch, under the assumption that you would want to update to the stable version
+      // of that release instead of the unstable version for a future release (but there's never any
+      // stable version of opentelemetry-instrumentation-bom-alpha so this logic doesn't apply
+      "ignoreUnstable": false
+    },
+    {
       // navigation-fragment 2.7.0 and above require android api 34+, which we are not ready for
       // yet due to android gradle plugin only supporting min 33.
       "matchPackagePrefixes": ["androidx.navigation"],


### PR DESCRIPTION
See the comment in the code. This is borrowed right from [contrib](https://github.com/open-telemetry/opentelemetry-java-contrib/blob/7f1560254eac36b3d5e25af1439c14a21c3f3d4d/.github/renovate.json5#L7-L16) just updated for our 3 packages.