### PR TITLE
Update upstream otel deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## Unreleased
 
-- tbd
+- Update to java instrumentation 1.31.0
+- Update to java sdk 1.31.0
+- BREAKING - Update to latest java semantic conventions
+ - `net.host.connection.type` -> `network.connection.type`
+ - `net.host.carrier.icc` -> `network.carrier.icc`
+ - `net.host.carrier.mcc` -> `network.carrier.mcc`
+ - `net.host.carrier.mnc` -> `network.carrier.mnc`
+ - `net.host.carrier.name` -> `network.carrier.name`
+ - `net.host.connection.type` -> `network.connection.type`
+ - `net.host.connection.subtype` -> `network.connection.subtype`
 
 ## Version 0.1.0 (2023-09-13)
 

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/OkHttpInstrumentationConfig.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/OkHttpInstrumentationConfig.java
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.instrumentation.library.okhttp.v3_0;
 
+import io.opentelemetry.instrumentation.api.instrumenter.net.PeerServiceResolver;
 import io.opentelemetry.instrumentation.api.internal.HttpConstants;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -95,8 +96,8 @@ public final class OkHttpInstrumentationConfig {
         OkHttpInstrumentationConfig.peerServiceMapping = new HashMap<>(peerServiceMapping);
     }
 
-    public static Map<String, String> getPeerServiceMapping() {
-        return peerServiceMapping;
+    public static PeerServiceResolver newPeerServiceResolver(){
+        return PeerServiceResolver.create(peerServiceMapping);
     }
 
     /**

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttp3Singletons.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttp3Singletons.java
@@ -11,7 +11,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientResend;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientResendCount;
 import io.opentelemetry.instrumentation.api.instrumenter.net.PeerServiceAttributesExtractor;
 import io.opentelemetry.instrumentation.library.okhttp.v3_0.OkHttpInstrumentationConfig;
 import io.opentelemetry.instrumentation.okhttp.v3_0.internal.ConnectionErrorSpanInterceptor;
@@ -38,15 +38,18 @@ public final class OkHttp3Singletons {
                                             OkHttpInstrumentationConfig
                                                     .getCapturedResponseHeaders())
                                     .setKnownMethods(OkHttpInstrumentationConfig.getKnownMethods()),
+                    spanNameExtractorConfigurer -> {
+                        //nop?
+                    },
                     singletonList(
-                            PeerServiceAttributesExtractor.create(
-                                    OkHttpAttributesGetter.INSTANCE,
-                                    OkHttpInstrumentationConfig.getPeerServiceMapping())),
+                                    PeerServiceAttributesExtractor.create(
+                                            OkHttpAttributesGetter.INSTANCE,
+                                            OkHttpInstrumentationConfig.newPeerServiceResolver())),
                     OkHttpInstrumentationConfig.emitExperimentalHttpClientMetrics());
 
     public static final Interceptor CONTEXT_INTERCEPTOR =
             chain -> {
-                try (Scope ignored = HttpClientResend.initialize(Context.current()).makeCurrent()) {
+                try (Scope ignored = HttpClientResendCount.initialize(Context.current()).makeCurrent()) {
                     return chain.proceed(chain.request());
                 }
             };

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 opentelemetry = "1.31.0"
 opentelemetry-alpha = "1.31.0-alpha"
+opentelemetry-semconv-version = "1.21.0-alpha"
 mockito = "5.6.0"
 junit = "5.10.0"
 byteBuddy = "1.14.9"
@@ -17,6 +18,7 @@ byteBuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "byteBuddy" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 opentelemetry-instrumentation-apiSemconv = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv", version.ref = "opentelemetry-alpha" }
 opentelemetry-instrumentation-okhttp = { module = "io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0", version.ref = "opentelemetry-alpha" }
+opentelemetry-semconv = { module = "io.opentelemetry.semconv:opentelemetry-semconv", version.ref = "opentelemetry-semconv-version" }
 
 #Test tools
 opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing", version.ref = "opentelemetry" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 opentelemetry = "1.31.0"
-opentelemetry-alpha = "1.29.0-alpha"
+opentelemetry-alpha = "1.31.0-alpha"
 mockito = "5.6.0"
 junit = "5.10.0"
 byteBuddy = "1.14.9"

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     implementation("io.zipkin.reporter2:zipkin-sender-okhttp3")
     implementation("io.opentelemetry:opentelemetry-exporter-logging")
     implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api")
-    implementation("io.opentelemetry:opentelemetry-semconv")
+    implementation("io.opentelemetry.semconv:opentelemetry-semconv")
 
     testImplementation(libs.bundles.mockito)
     testImplementation(libs.bundles.junit)

--- a/instrumentation/src/main/java/io/opentelemetry/android/AndroidResource.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/AndroidResource.java
@@ -6,14 +6,14 @@
 package io.opentelemetry.android;
 
 import static io.opentelemetry.android.RumConstants.RUM_SDK_VERSION;
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.DEVICE_MANUFACTURER;
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.DEVICE_MODEL_IDENTIFIER;
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.DEVICE_MODEL_NAME;
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_DESCRIPTION;
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_NAME;
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_TYPE;
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_VERSION;
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.ResourceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.ResourceAttributes.DEVICE_MANUFACTURER;
+import static io.opentelemetry.semconv.ResourceAttributes.DEVICE_MODEL_IDENTIFIER;
+import static io.opentelemetry.semconv.ResourceAttributes.DEVICE_MODEL_NAME;
+import static io.opentelemetry.semconv.ResourceAttributes.OS_DESCRIPTION;
+import static io.opentelemetry.semconv.ResourceAttributes.OS_NAME;
+import static io.opentelemetry.semconv.ResourceAttributes.OS_TYPE;
+import static io.opentelemetry.semconv.ResourceAttributes.OS_VERSION;
 
 import android.app.Application;
 import android.os.Build;

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/anr/StackTraceFormatter.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/anr/StackTraceFormatter.java
@@ -5,10 +5,11 @@
 
 package io.opentelemetry.android.instrumentation.anr;
 
+import static io.opentelemetry.semconv.SemanticAttributes.EXCEPTION_STACKTRACE;
+
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 
 final class StackTraceFormatter implements AttributesExtractor<StackTraceElement[], Void> {
 
@@ -19,7 +20,7 @@ final class StackTraceFormatter implements AttributesExtractor<StackTraceElement
         for (StackTraceElement stackTraceElement : stackTrace) {
             stackTraceString.append(stackTraceElement).append("\n");
         }
-        attributes.put(SemanticAttributes.EXCEPTION_STACKTRACE, stackTraceString.toString());
+        attributes.put(EXCEPTION_STACKTRACE, stackTraceString.toString());
     }
 
     @Override

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashDetailsAttributesExtractor.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashDetailsAttributesExtractor.java
@@ -8,7 +8,7 @@ package io.opentelemetry.android.instrumentation.crash;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 
 final class CrashDetailsAttributesExtractor implements AttributesExtractor<CrashDetails, Void> {
 

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/network/CurrentNetworkAttributesExtractor.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/network/CurrentNetworkAttributesExtractor.java
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.android.instrumentation.network;
 
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_CARRIER_ICC;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_CARRIER_MCC;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_CARRIER_MNC;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_CARRIER_NAME;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_CONNECTION_SUBTYPE;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_CONNECTION_TYPE;
+import static io.opentelemetry.semconv.SemanticAttributes.NETWORK_CARRIER_ICC;
+import static io.opentelemetry.semconv.SemanticAttributes.NETWORK_CARRIER_MCC;
+import static io.opentelemetry.semconv.SemanticAttributes.NETWORK_CARRIER_MNC;
+import static io.opentelemetry.semconv.SemanticAttributes.NETWORK_CARRIER_NAME;
+import static io.opentelemetry.semconv.SemanticAttributes.NETWORK_CONNECTION_SUBTYPE;
+import static io.opentelemetry.semconv.SemanticAttributes.NETWORK_CONNECTION_TYPE;
 
 import androidx.annotation.Nullable;
 import io.opentelemetry.api.common.AttributeKey;
@@ -22,13 +22,13 @@ final class CurrentNetworkAttributesExtractor {
     Attributes extract(CurrentNetwork network) {
         AttributesBuilder builder =
                 Attributes.builder()
-                        .put(NET_HOST_CONNECTION_TYPE, network.getState().getHumanName());
+                        .put(NETWORK_CONNECTION_TYPE, network.getState().getHumanName());
 
-        setIfNotNull(builder, NET_HOST_CONNECTION_SUBTYPE, network.getSubType());
-        setIfNotNull(builder, NET_HOST_CARRIER_NAME, network.getCarrierName());
-        setIfNotNull(builder, NET_HOST_CARRIER_MCC, network.getCarrierCountryCode());
-        setIfNotNull(builder, NET_HOST_CARRIER_MNC, network.getCarrierNetworkCode());
-        setIfNotNull(builder, NET_HOST_CARRIER_ICC, network.getCarrierIsoCountryCode());
+        setIfNotNull(builder, NETWORK_CONNECTION_SUBTYPE, network.getSubType());
+        setIfNotNull(builder, NETWORK_CARRIER_NAME, network.getCarrierName());
+        setIfNotNull(builder, NETWORK_CARRIER_MCC, network.getCarrierCountryCode());
+        setIfNotNull(builder, NETWORK_CARRIER_MNC, network.getCarrierNetworkCode());
+        setIfNotNull(builder, NETWORK_CARRIER_ICC, network.getCarrierIsoCountryCode());
 
         return builder.build();
     }

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeAttributesExtractor.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeAttributesExtractor.java
@@ -6,8 +6,7 @@
 package io.opentelemetry.android.instrumentation.network;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
-import static io.opentelemetry.semconv.trace.attributes.SemanticAttributes.NET_HOST_CONNECTION_TYPE;
-
+import static io.opentelemetry.semconv.SemanticAttributes.NETWORK_CONNECTION_TYPE;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
@@ -40,7 +39,7 @@ final class NetworkChangeAttributesExtractor implements AttributesExtractor<Curr
         // put these after span start to override what might be set in the
         // NetworkAttributesSpanAppender.
         if (currentNetwork.getState() == NetworkState.NO_NETWORK_AVAILABLE) {
-            attributes.put(NET_HOST_CONNECTION_TYPE, currentNetwork.getState().getHumanName());
+            attributes.put(NETWORK_CONNECTION_TYPE, currentNetwork.getState().getHumanName());
         } else {
             attributes.putAll(networkAttributesExtractor.extract(currentNetwork));
         }

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkState.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkState.java
@@ -5,13 +5,13 @@
 
 package io.opentelemetry.android.instrumentation.network;
 
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 
 enum NetworkState {
-    NO_NETWORK_AVAILABLE(SemanticAttributes.NetHostConnectionTypeValues.UNAVAILABLE),
-    TRANSPORT_CELLULAR(SemanticAttributes.NetHostConnectionTypeValues.CELL),
-    TRANSPORT_WIFI(SemanticAttributes.NetHostConnectionTypeValues.WIFI),
-    TRANSPORT_UNKNOWN(SemanticAttributes.NetHostConnectionTypeValues.UNKNOWN),
+    NO_NETWORK_AVAILABLE(SemanticAttributes.NetworkConnectionTypeValues.UNAVAILABLE),
+    TRANSPORT_CELLULAR(SemanticAttributes.NetworkConnectionTypeValues.CELL),
+    TRANSPORT_WIFI(SemanticAttributes.NetworkConnectionTypeValues.WIFI),
+    TRANSPORT_UNKNOWN(SemanticAttributes.NetworkConnectionTypeValues.UNKNOWN),
     // this one doesn't seem to have an otel value at this point.
     TRANSPORT_VPN("vpn");
 

--- a/instrumentation/src/test/java/io/opentelemetry/android/AndroidResourceTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/AndroidResourceTest.java
@@ -6,14 +6,14 @@
 package io.opentelemetry.android;
 
 import static io.opentelemetry.android.RumConstants.RUM_SDK_VERSION;
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.DEVICE_MANUFACTURER;
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.DEVICE_MODEL_IDENTIFIER;
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.DEVICE_MODEL_NAME;
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_DESCRIPTION;
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_NAME;
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_TYPE;
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.OS_VERSION;
-import static io.opentelemetry.semconv.resource.attributes.ResourceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.ResourceAttributes.DEVICE_MANUFACTURER;
+import static io.opentelemetry.semconv.ResourceAttributes.DEVICE_MODEL_IDENTIFIER;
+import static io.opentelemetry.semconv.ResourceAttributes.DEVICE_MODEL_NAME;
+import static io.opentelemetry.semconv.ResourceAttributes.OS_DESCRIPTION;
+import static io.opentelemetry.semconv.ResourceAttributes.OS_NAME;
+import static io.opentelemetry.semconv.ResourceAttributes.OS_TYPE;
+import static io.opentelemetry.semconv.ResourceAttributes.OS_VERSION;
+import static io.opentelemetry.semconv.ResourceAttributes.SERVICE_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 

--- a/instrumentation/src/test/java/io/opentelemetry/android/instrumentation/anr/StackTraceFormatterTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/instrumentation/anr/StackTraceFormatterTest.java
@@ -10,7 +10,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.asser
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import org.junit.jupiter.api.Test;
 
 class StackTraceFormatterTest {

--- a/instrumentation/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReporterTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReporterTest.java
@@ -18,7 +18,7 @@ import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.testing.assertj.TraceAssert;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
 import io.opentelemetry.sdk.trace.data.StatusData;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import java.time.Duration;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterAll;

--- a/instrumentation/src/test/java/io/opentelemetry/android/instrumentation/network/CurrentNetworkAttributesExtractorTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/instrumentation/network/CurrentNetworkAttributesExtractorTest.java
@@ -9,7 +9,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.asser
 import static org.assertj.core.api.Assertions.entry;
 
 import android.os.Build;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;

--- a/instrumentation/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkAttributesSpanAppenderTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkAttributesSpanAppenderTest.java
@@ -13,7 +13,7 @@ import static org.mockito.Mockito.when;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;

--- a/instrumentation/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeMonitorTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeMonitorTest.java
@@ -18,7 +18,7 @@ import io.opentelemetry.android.instrumentation.InstrumentedApplication;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;


### PR DESCRIPTION
Supersedes #113.

In addition to the instrumentation update in #113, this also switches over to the newer semantic conventions that were pulled into the separate repo.