### PR TITLE
Introduce configuration for instrumentation components (phase 1)

### DIFF
--- a/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRum.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRum.java
@@ -21,15 +21,32 @@ import io.opentelemetry.sdk.trace.SdkTracerProvider;
 public interface OpenTelemetryRum {
 
     /**
-     * Returns a new {@link OpenTelemetryRumBuilder} for {@link OpenTelemetryRum}. Use this version
-     * if you would like to configure individual aspects of the OpenTelemetry SDK but would still
-     * prefer to allow OpenTelemetry RUM to create the SDK for you. If you would like to "bring your
-     * own" SDK, call the two-argument version.
+     * Returns a new {@link OpenTelemetryRumBuilder} for {@link OpenTelemetryRum} with a default
+     * configuration. Use this version if you would like to configure individual aspects of the
+     * OpenTelemetry SDK but would still prefer to allow OpenTelemetry RUM to create the SDK for
+     * you. For additional configuration, call the two-argument version of build and pass it your
+     * {@link OtelAndroidConfig} instance. If you would like to "bring your own" SDK, call the
+     * two-argument version that takes the SDK as a parameter.
      *
      * @param application The {@link Application} that is being instrumented.
      */
     static OpenTelemetryRumBuilder builder(Application application) {
-        return new OpenTelemetryRumBuilder(application);
+        return builder(application, new OtelAndroidConfig());
+    }
+
+    /**
+     * Returns a new {@link OpenTelemetryRumBuilder} for {@link OpenTelemetryRum} with the given
+     * configuration. Use this version if you would like to configure individual aspects of the
+     * OpenTelemetry SDK but would still prefer to allow OpenTelemetry RUM to create the SDK for
+     * you. If you would like to "bring your own" SDK, call the two-argument version that takes the
+     * SDK as a parameter.
+     *
+     * @param application
+     * @param config
+     * @return
+     */
+    static OpenTelemetryRumBuilder builder(Application application, OtelAndroidConfig config) {
+        return new OpenTelemetryRumBuilder(application, config);
     }
 
     /**

--- a/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRum.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRum.java
@@ -25,13 +25,13 @@ public interface OpenTelemetryRum {
      * configuration. Use this version if you would like to configure individual aspects of the
      * OpenTelemetry SDK but would still prefer to allow OpenTelemetry RUM to create the SDK for
      * you. For additional configuration, call the two-argument version of build and pass it your
-     * {@link OtelAndroidConfig} instance. If you would like to "bring your own" SDK, call the
+     * {@link OtelRumConfig} instance. If you would like to "bring your own" SDK, call the
      * two-argument version that takes the SDK as a parameter.
      *
      * @param application The {@link Application} that is being instrumented.
      */
     static OpenTelemetryRumBuilder builder(Application application) {
-        return builder(application, new OtelAndroidConfig());
+        return builder(application, new OtelRumConfig());
     }
 
     /**
@@ -45,7 +45,7 @@ public interface OpenTelemetryRum {
      * @param config
      * @return
      */
-    static OpenTelemetryRumBuilder builder(Application application, OtelAndroidConfig config) {
+    static OpenTelemetryRumBuilder builder(Application application, OtelRumConfig config) {
         return new OpenTelemetryRumBuilder(application, config);
     }
 

--- a/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -9,6 +9,11 @@ import static java.util.Objects.requireNonNull;
 
 import android.app.Application;
 import io.opentelemetry.android.instrumentation.InstrumentedApplication;
+import io.opentelemetry.android.instrumentation.activity.VisibleScreenTracker;
+import io.opentelemetry.android.instrumentation.network.CurrentNetworkProvider;
+import io.opentelemetry.android.instrumentation.network.NetworkAttributesSpanAppender;
+import io.opentelemetry.android.instrumentation.startup.InitializationEvents;
+import io.opentelemetry.android.instrumentation.startup.SdkInitializationEvents;
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
 import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
 import io.opentelemetry.context.propagation.ContextPropagators;
@@ -22,6 +27,7 @@ import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
+import io.opentelemetry.sdk.trace.SpanProcessor;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.ArrayList;
@@ -47,6 +53,8 @@ public final class OpenTelemetryRumBuilder {
             meterProviderCustomizers = new ArrayList<>();
     private final List<BiFunction<SdkLoggerProviderBuilder, Application, SdkLoggerProviderBuilder>>
             loggerProviderCustomizers = new ArrayList<>();
+    private final OtelAndroidConfig config;
+    private final VisibleScreenTracker visibleScreenTracker = new VisibleScreenTracker();
 
     private Function<? super SpanExporter, ? extends SpanExporter> spanExporterCustomizer = a -> a;
     private final List<Consumer<InstrumentedApplication>> instrumentationInstallers =
@@ -56,17 +64,19 @@ public final class OpenTelemetryRumBuilder {
             (a) -> a;
 
     private Resource resource;
+    private InitializationEvents initializationEvents = InitializationEvents.NO_OP;
 
     private static TextMapPropagator buildDefaultPropagator() {
         return TextMapPropagator.composite(
                 W3CTraceContextPropagator.getInstance(), W3CBaggagePropagator.getInstance());
     }
 
-    OpenTelemetryRumBuilder(Application application) {
+    OpenTelemetryRumBuilder(Application application, OtelAndroidConfig config) {
         this.application = application;
         SessionIdTimeoutHandler timeoutHandler = new SessionIdTimeoutHandler();
         this.sessionId = new SessionId(timeoutHandler);
         this.resource = AndroidResource.createDefault(application);
+        this.config = config;
     }
 
     /**
@@ -216,6 +226,9 @@ public final class OpenTelemetryRumBuilder {
      * @return A new {@link OpenTelemetryRum} instance.
      */
     public OpenTelemetryRum build() {
+
+        applyConfiguration();
+
         OpenTelemetrySdk sdk =
                 OpenTelemetrySdk.builder()
                         .setTracerProvider(buildTracerProvider(sessionId, application))
@@ -228,6 +241,50 @@ public final class OpenTelemetryRumBuilder {
                 new SdkPreconfiguredRumBuilder(application, sdk, sessionId);
         instrumentationInstallers.forEach(delegate::addInstrumentation);
         return delegate.build();
+    }
+
+    /** Leverage the configuration to wire up various instrumentation components. */
+    private void applyConfiguration() {
+        if (config.shouldGenerateSdkInitializationEvents()) {
+            initializationEvents = new SdkInitializationEvents();
+            initializationEvents.recordConfiguration(config);
+        }
+        initializationEvents.sdkInitializationStarted();
+
+        // Global attributes
+        if (config.hasGlobalAttributes()) {
+            // Add span processor that appends global attributes.
+            GlobalAttributesSpanAppender appender =
+                    GlobalAttributesSpanAppender.create(config.getGlobalAttributes());
+            addTracerProviderCustomizer(
+                    (tracerProviderBuilder, app) ->
+                            tracerProviderBuilder.addSpanProcessor(appender));
+        }
+
+        // Network specific attributes
+        if (config.shouldIncludeNetworkAttributes()) {
+            // Add span processor that appends network attributes.
+            CurrentNetworkProvider currentNetworkProvider =
+                    CurrentNetworkProvider.createAndStart(application);
+            addTracerProviderCustomizer(
+                    (tracerProviderBuilder, app) -> {
+                        SpanProcessor networkAttributesSpanAppender =
+                                NetworkAttributesSpanAppender.create(currentNetworkProvider);
+                        return tracerProviderBuilder.addSpanProcessor(
+                                networkAttributesSpanAppender);
+                    });
+            initializationEvents.currentNetworkProviderInitialized();
+        }
+
+        // Add span processor that appends screen attribute(s)
+        if (config.shouldIncludeScreenAttributes()) {
+            addTracerProviderCustomizer(
+                    (tracerProviderBuilder, app) -> {
+                        SpanProcessor screenAttributesAppender =
+                                new ScreenAttributesSpanProcessor(visibleScreenTracker);
+                        return tracerProviderBuilder.addSpanProcessor(screenAttributesAppender);
+                    });
+        }
     }
 
     private SdkTracerProvider buildTracerProvider(SessionId sessionId, Application application) {

--- a/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -53,7 +53,7 @@ public final class OpenTelemetryRumBuilder {
             meterProviderCustomizers = new ArrayList<>();
     private final List<BiFunction<SdkLoggerProviderBuilder, Application, SdkLoggerProviderBuilder>>
             loggerProviderCustomizers = new ArrayList<>();
-    private final OtelAndroidConfig config;
+    private final OtelRumConfig config;
     private final VisibleScreenTracker visibleScreenTracker = new VisibleScreenTracker();
 
     private Function<? super SpanExporter, ? extends SpanExporter> spanExporterCustomizer = a -> a;
@@ -71,7 +71,7 @@ public final class OpenTelemetryRumBuilder {
                 W3CTraceContextPropagator.getInstance(), W3CBaggagePropagator.getInstance());
     }
 
-    OpenTelemetryRumBuilder(Application application, OtelAndroidConfig config) {
+    OpenTelemetryRumBuilder(Application application, OtelRumConfig config) {
         this.application = application;
         SessionIdTimeoutHandler timeoutHandler = new SessionIdTimeoutHandler();
         this.sessionId = new SessionId(timeoutHandler);

--- a/instrumentation/src/main/java/io/opentelemetry/android/OtelAndroidConfig.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/OtelAndroidConfig.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android;
+
+import io.opentelemetry.android.instrumentation.network.CurrentNetworkProvider;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+
+/**
+ * Configuration object for OpenTelemetry Android. The configuration items in this class will be
+ * used in the OpenTelemetryRumBuilder to wire up and enable/disable various mobile instrumentation
+ * components.
+ */
+public class OtelAndroidConfig {
+
+    private AttributesBuilder globalAttributes = Attributes.builder();
+    private boolean includeNetworkAttributes = true;
+    private boolean generateSdkInitializationEvents = true;
+    private boolean includeScreenAttributes = true;
+
+    /**
+     * Configures the set of global attributes to emit with every span and event. Any existing
+     * configured attributes will be dropped. Default = none.
+     */
+    public OtelAndroidConfig setGlobalAttributes(Attributes attributes) {
+        globalAttributes = attributes.toBuilder();
+        return this;
+    }
+
+    boolean hasGlobalAttributes() {
+        return !globalAttributes.build().isEmpty();
+    }
+
+    Attributes getGlobalAttributes() {
+        return globalAttributes.build();
+    }
+
+    /**
+     * Disables the collection of runtime network attributes. See {@link CurrentNetworkProvider} for
+     * more information. Default = true.
+     *
+     * @return this
+     */
+    public OtelAndroidConfig disableNetworkAttributes() {
+        includeNetworkAttributes = false;
+        return this;
+    }
+
+    /** Returns true if runtime network attributes are enabled, false otherwise. */
+    public boolean shouldIncludeNetworkAttributes() {
+        return includeNetworkAttributes;
+    }
+
+    /**
+     * Disables the collection of events related to the initialization of the OTel Android SDK
+     * itself. Default = true.
+     *
+     * @return this
+     */
+    public OtelAndroidConfig disableSdkInitializationEvents() {
+        this.generateSdkInitializationEvents = false;
+        return this;
+    }
+
+    /** Returns true if the SDK is configured to generate initialization events, false otherwise. */
+    public boolean shouldGenerateSdkInitializationEvents() {
+        return generateSdkInitializationEvents;
+    }
+
+    /**
+     * Call this to disable the collection of screen attributes. See {@link
+     * ScreenAttributesSpanProcessor} for more information. Default = true.
+     *
+     * @return this
+     */
+    public OtelAndroidConfig disableScreenAttributes() {
+        this.includeScreenAttributes = false;
+        return this;
+    }
+
+    /** Return true if the SDK should be configured to report screen attributes. */
+    public boolean shouldIncludeScreenAttributes() {
+        return includeScreenAttributes;
+    }
+}

--- a/instrumentation/src/main/java/io/opentelemetry/android/OtelRumConfig.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/OtelRumConfig.java
@@ -14,7 +14,7 @@ import io.opentelemetry.api.common.AttributesBuilder;
  * used in the OpenTelemetryRumBuilder to wire up and enable/disable various mobile instrumentation
  * components.
  */
-public class OtelAndroidConfig {
+public class OtelRumConfig {
 
     private AttributesBuilder globalAttributes = Attributes.builder();
     private boolean includeNetworkAttributes = true;
@@ -25,7 +25,7 @@ public class OtelAndroidConfig {
      * Configures the set of global attributes to emit with every span and event. Any existing
      * configured attributes will be dropped. Default = none.
      */
-    public OtelAndroidConfig setGlobalAttributes(Attributes attributes) {
+    public OtelRumConfig setGlobalAttributes(Attributes attributes) {
         globalAttributes = attributes.toBuilder();
         return this;
     }
@@ -44,7 +44,7 @@ public class OtelAndroidConfig {
      *
      * @return this
      */
-    public OtelAndroidConfig disableNetworkAttributes() {
+    public OtelRumConfig disableNetworkAttributes() {
         includeNetworkAttributes = false;
         return this;
     }
@@ -60,7 +60,7 @@ public class OtelAndroidConfig {
      *
      * @return this
      */
-    public OtelAndroidConfig disableSdkInitializationEvents() {
+    public OtelRumConfig disableSdkInitializationEvents() {
         this.generateSdkInitializationEvents = false;
         return this;
     }
@@ -76,7 +76,7 @@ public class OtelAndroidConfig {
      *
      * @return this
      */
-    public OtelAndroidConfig disableScreenAttributes() {
+    public OtelRumConfig disableScreenAttributes() {
         this.includeScreenAttributes = false;
         return this;
     }

--- a/instrumentation/src/main/java/io/opentelemetry/android/ScreenAttributesSpanProcessor.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/ScreenAttributesSpanProcessor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android;
+
+import static io.opentelemetry.android.RumConstants.SCREEN_NAME_KEY;
+
+import io.opentelemetry.android.instrumentation.activity.VisibleScreenTracker;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import io.opentelemetry.sdk.trace.SpanProcessor;
+
+class ScreenAttributesSpanProcessor implements SpanProcessor {
+
+    private final VisibleScreenTracker visibleScreenTracker;
+
+    public ScreenAttributesSpanProcessor(VisibleScreenTracker visibleScreenTracker) {
+        this.visibleScreenTracker = visibleScreenTracker;
+    }
+
+    @Override
+    public void onStart(Context parentContext, ReadWriteSpan span) {
+        String currentScreen = visibleScreenTracker.getCurrentlyVisibleScreen();
+        span.setAttribute(SCREEN_NAME_KEY, currentScreen);
+    }
+
+    @Override
+    public boolean isStartRequired() {
+        return true;
+    }
+
+    @Override
+    public void onEnd(ReadableSpan span) {
+        // nop
+    }
+
+    @Override
+    public boolean isEndRequired() {
+        return false;
+    }
+}

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/InitializationEvents.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/InitializationEvents.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.startup;
+
+import io.opentelemetry.android.OtelAndroidConfig;
+
+public interface InitializationEvents {
+
+    void sdkInitializationStarted();
+
+    void recordConfiguration(OtelAndroidConfig config);
+
+    void currentNetworkProviderInitialized();
+
+    InitializationEvents NO_OP =
+            new InitializationEvents() {
+                @Override
+                public void sdkInitializationStarted() {}
+
+                @Override
+                public void recordConfiguration(OtelAndroidConfig config) {}
+
+                @Override
+                public void currentNetworkProviderInitialized() {}
+            };
+}

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/InitializationEvents.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/InitializationEvents.java
@@ -5,13 +5,13 @@
 
 package io.opentelemetry.android.instrumentation.startup;
 
-import io.opentelemetry.android.OtelAndroidConfig;
+import io.opentelemetry.android.OtelRumConfig;
 
 public interface InitializationEvents {
 
     void sdkInitializationStarted();
 
-    void recordConfiguration(OtelAndroidConfig config);
+    void recordConfiguration(OtelRumConfig config);
 
     void currentNetworkProviderInitialized();
 
@@ -21,7 +21,7 @@ public interface InitializationEvents {
                 public void sdkInitializationStarted() {}
 
                 @Override
-                public void recordConfiguration(OtelAndroidConfig config) {}
+                public void recordConfiguration(OtelRumConfig config) {}
 
                 @Override
                 public void currentNetworkProviderInitialized() {}

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEvents.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEvents.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.startup;
+
+import io.opentelemetry.android.OtelAndroidConfig;
+
+public class SdkInitializationEvents implements InitializationEvents {
+
+    @Override
+    public void sdkInitializationStarted() {
+        // TODO: Build me
+    }
+
+    @Override
+    public void recordConfiguration(OtelAndroidConfig config) {
+        // TODO: Build me (create event containing the config params for the sdk)
+    }
+
+    @Override
+    public void currentNetworkProviderInitialized() {
+        // TODO: Build me
+    }
+}

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEvents.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEvents.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.android.instrumentation.startup;
 
-import io.opentelemetry.android.OtelAndroidConfig;
+import io.opentelemetry.android.OtelRumConfig;
 
 public class SdkInitializationEvents implements InitializationEvents {
 
@@ -15,7 +15,7 @@ public class SdkInitializationEvents implements InitializationEvents {
     }
 
     @Override
-    public void recordConfiguration(OtelAndroidConfig config) {
+    public void recordConfiguration(OtelRumConfig config) {
         // TODO: Build me (create event containing the config params for the sdk)
     }
 

--- a/instrumentation/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -108,8 +108,8 @@ class OpenTelemetryRumBuilderTest {
         verify(listener).onApplicationBackgrounded();
     }
 
-    private OtelAndroidConfig buildConfig() {
-        return new OtelAndroidConfig().disableNetworkAttributes();
+    private OtelRumConfig buildConfig() {
+        return new OtelRumConfig().disableNetworkAttributes();
     }
 
     @Test

--- a/instrumentation/src/test/java/io/opentelemetry/android/ScreenAttributesSpanProcessorTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/ScreenAttributesSpanProcessorTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android;
+
+import static io.opentelemetry.android.RumConstants.SCREEN_NAME_KEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opentelemetry.android.instrumentation.activity.VisibleScreenTracker;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.sdk.trace.ReadWriteSpan;
+import io.opentelemetry.sdk.trace.ReadableSpan;
+import org.junit.jupiter.api.Test;
+
+class ScreenAttributesSpanProcessorTest {
+
+    @Test
+    void append() {
+        String screenName = "my cool screen";
+        VisibleScreenTracker visibleScreenTracker = mock(VisibleScreenTracker.class);
+        Context contenxt = mock(Context.class);
+        ReadWriteSpan span = mock(ReadWriteSpan.class);
+
+        when(visibleScreenTracker.getCurrentlyVisibleScreen()).thenReturn(screenName);
+
+        ScreenAttributesSpanProcessor testClass =
+                new ScreenAttributesSpanProcessor(visibleScreenTracker);
+        assertThat(testClass.isStartRequired()).isTrue();
+        assertThat(testClass.isEndRequired()).isFalse();
+        assertThatCode(() -> testClass.onEnd(mock(ReadableSpan.class))).doesNotThrowAnyException();
+
+        testClass.onStart(contenxt, span);
+        verify(span).setAttribute(SCREEN_NAME_KEY, screenName);
+    }
+}


### PR DESCRIPTION
Much of the existing instrumentation is somewhat burdensome for users to wire up correctly. The intent here is to introduce a configuration object that can be passed to the `OpenTelemetryRumBuilder` in order to more easily wire up various mobile components. This is intended to be first of several phases. This phase includes:

* Preconfigured global attributes. These are user-configured attributes that are intended to be included on every span and event.
* Network attributes (for things like connection type/subtype and carrier information)
* Screen attributes (the name of the currently visible screen)
* SDK initialization events - for tracking the startup of the sdk itself. NOTE: To keep this PR small and more easily reviewable, this implementation is left as a stub. Future PRs will fill in these events.

The behavior here should appear similar to Splunk's `RumInitializer` class, but is implemented within the builder to prevent confusion between building and initialization. This change should also still be backwards compatible -- users who want to configure their own components manually may continue doing so.