### PR TITLE
Add descriptions for OkHttp poms

### DIFF
--- a/auto-instrumentation/okhttp/okhttp-3.0/agent/build.gradle.kts
+++ b/auto-instrumentation/okhttp/okhttp-3.0/agent/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     id("otel.publish-conventions")
 }
 
+description = "OpenTelemetry build-time auto-instrumentation for OkHttp on Android"
+
 dependencies {
     implementation(project(":auto-instrumentation:okhttp:okhttp-3.0:library"))
     implementation(libs.okhttp)

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/build.gradle.kts
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     id("otel.publish-conventions")
 }
 
+description = "OpenTelemetry OkHttp library instrumentation for Android"
+
 dependencies {
     compileOnly(libs.okhttp)
     api(libs.opentelemetry.instrumentation.okhttp)


### PR DESCRIPTION
The release failed in sonatype due to missing descriptions in these poms.

<img width="828" alt="image" src="https://github.com/open-telemetry/opentelemetry-android/assets/75337021/428c105b-58eb-4d3e-8412-c2c6889fe164">
