### PR TITLE
Update session.previous_id spelling

### DIFF
--- a/instrumentation/src/main/java/io/opentelemetry/android/RumConstants.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/RumConstants.java
@@ -30,7 +30,7 @@ public class RumConstants {
     public static final AttributeKey<Double> BATTERY_PERCENT_KEY = doubleKey("battery.percent");
 
     public static final AttributeKey<String> PREVIOUS_SESSION_ID_KEY =
-            stringKey("rum.session.previous_id");
+            stringKey("session.previous_id");
 
     public static final String APP_START_SPAN_NAME = "AppStart";
 


### PR DESCRIPTION
Now that [#348](https://github.com/open-telemetry/semantic-conventions/pull/348) has landed, let's use the new spelling for `session.previous_id`.