### PR TITLE
Making android min sdk configurable per auto-instrumentation subproject

### DIFF
--- a/buildSrc/src/main/kotlin/otel.java-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.java-library-conventions.gradle.kts
@@ -6,6 +6,15 @@ plugins {
     id("ru.vyarus.animalsniffer")
 }
 
+// Extension to configure android parameters for non-android projects.
+interface OtelAndroidExtension {
+    val minSdk: Property<Int>
+}
+
+val otelAndroidExtension =
+    project.extensions.create("otelAndroid", OtelAndroidExtension::class.java)
+otelAndroidExtension.minSdk.convention((project.property("android.minSdk") as String).toInt())
+
 java {
     val javaVersion = rootProject.extra["java_version"] as JavaVersion
     sourceCompatibility = javaVersion
@@ -14,7 +23,6 @@ java {
 
 val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 dependencies {
-    signature("com.toasttab.android:gummy-bears-api-${project.property("android.minSdk")}:0.5.1:coreLib@signature")
     implementation(libs.findLibrary("findbugs-jsr305").get())
 }
 
@@ -30,4 +38,10 @@ tasks.withType<AnimalSniffer> {
 // Attaching animalsniffer check to the compilation process.
 tasks.named("classes").configure {
     finalizedBy("animalsnifferMain")
+}
+
+afterEvaluate {
+    dependencies {
+        signature("com.toasttab.android:gummy-bears-api-${otelAndroidExtension.minSdk.get()}:0.5.1:coreLib@signature")
+    }
 }


### PR DESCRIPTION
Closes #138 

This should allow to set the minimum Android SDK supported by a specific `auto-instrumentation` subproject like so:

```kotlin
// library build.gradle.kts file

plugins {
    id("otel.java-library-conventions")
    //...
}

otelAndroid.minSdk = 26
```

This will prevent animal sniffer from complaining about code references used by the auto-instrumentation project that aren't available neither in the Android SDK 21 (the current core lib min SDK supported) nor in the desugar lib.

The README of the auto-instrumentation subproject that changes this value should mention what's the minimum supported Android API level for the auto-instrumentation to work properly, this is because some auto-instrumentations might target code found on versions above 21 while still providing some functionality and being safe to run on devices with API level 21 (since the code from higher SDK versions would just be ignored as it wouldn't be found in devices with SDK version 21). In some other cases, the auto-instrumentation could cause issues when running on devices with the SDK version 21, so that's why it should be specified in the README what's the minimum version supported.