### PR TITLE
Okhttp autoinstrumentation stabilization

### DIFF
--- a/auto-instrumentation/okhttp/okhttp-3.0/README.md
+++ b/auto-instrumentation/okhttp/okhttp-3.0/README.md
@@ -1,5 +1,7 @@
 # Android Instrumentation for OkHttp version 3.0 and higher
 
+## Status: Experimental
+
 Provides OpenTelemetry instrumentation for [okhttp3](https://square.github.io/okhttp/).
 
 ## Quickstart

--- a/auto-instrumentation/okhttp/okhttp-3.0/README.md
+++ b/auto-instrumentation/okhttp/okhttp-3.0/README.md
@@ -1,7 +1,5 @@
 # Android Instrumentation for OkHttp version 3.0 and higher
 
-# 🚧Work in progress 🚧
-
 Provides OpenTelemetry instrumentation for [okhttp3](https://square.github.io/okhttp/).
 
 ## Quickstart

--- a/auto-instrumentation/okhttp/okhttp-3.0/agent/build.gradle.kts
+++ b/auto-instrumentation/okhttp/okhttp-3.0/agent/build.gradle.kts
@@ -1,9 +1,13 @@
 plugins {
-    id("otel.java-library-conventions")
+    id("otel.android-library-conventions")
     id("otel.publish-conventions")
 }
 
 description = "OpenTelemetry build-time auto-instrumentation for OkHttp on Android"
+
+android {
+    namespace = "io.opentelemetry.android.okhttp.agent"
+}
 
 dependencies {
     implementation(project(":auto-instrumentation:okhttp:okhttp-3.0:library"))

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/build.gradle.kts
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/build.gradle.kts
@@ -1,9 +1,17 @@
 plugins {
-    id("otel.java-library-conventions")
+    id("otel.android-library-conventions")
     id("otel.publish-conventions")
 }
 
 description = "OpenTelemetry OkHttp library instrumentation for Android"
+
+android {
+    namespace = "io.opentelemetry.android.okhttp.library"
+
+    defaultConfig {
+        consumerProguardFiles("consumer-rules.pro")
+    }
+}
 
 dependencies {
     compileOnly(libs.okhttp)

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/consumer-rules.pro
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/consumer-rules.pro
@@ -1,0 +1,1 @@
+-keep class io.opentelemetry.exporter.internal.InstrumentationUtil { *; }

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/CachedSupplier.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/CachedSupplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.library.okhttp.v3_0.internal;
+
+import java.util.function.Supplier;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public class CachedSupplier<T> implements Supplier<T> {
+    private Supplier<T> supplier;
+    private T instance;
+
+    public static <T> CachedSupplier<T> create(Supplier<T> instance) {
+        return new CachedSupplier<>(instance);
+    }
+
+    private CachedSupplier(Supplier<T> supplier) {
+        this.supplier = supplier;
+    }
+
+    @Override
+    public T get() {
+        synchronized (this) {
+            if (instance == null) {
+                instance = supplier.get();
+                supplier = null;
+            }
+            return instance;
+        }
+    }
+}

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/CachedSupplier.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/CachedSupplier.java
@@ -14,6 +14,7 @@ import java.util.function.Supplier;
 public class CachedSupplier<T> implements Supplier<T> {
     private Supplier<T> supplier;
     private T instance;
+    private final Object lock = new Object();
 
     public static <T> CachedSupplier<T> create(Supplier<T> instance) {
         return new CachedSupplier<>(instance);
@@ -25,9 +26,12 @@ public class CachedSupplier<T> implements Supplier<T> {
 
     @Override
     public T get() {
-        synchronized (this) {
+        synchronized (lock) {
             if (instance == null) {
                 instance = supplier.get();
+                if (instance == null) {
+                    throw new NullPointerException("Supplier provided null.");
+                }
                 supplier = null;
             }
             return instance;

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/LazyInterceptor.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/LazyInterceptor.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.library.okhttp.v3_0.internal;
+
+import java.io.IOException;
+import okhttp3.Interceptor;
+import okhttp3.Response;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * This class is internal and is hence not for public use. Its APIs are unstable and can change at
+ * any time.
+ */
+public class LazyInterceptor<T extends Interceptor> implements Interceptor {
+    private final CachedSupplier<T> interceptorSupplier;
+
+    public LazyInterceptor(CachedSupplier<T> interceptorSupplier) {
+        this.interceptorSupplier = interceptorSupplier;
+    }
+
+    @NotNull
+    @Override
+    public Response intercept(@NotNull Chain chain) throws IOException {
+        return interceptorSupplier.get().intercept(chain);
+    }
+}

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttp3Singletons.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttp3Singletons.java
@@ -11,7 +11,7 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientResendCount;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientRequestResendCount;
 import io.opentelemetry.instrumentation.api.instrumenter.net.PeerServiceAttributesExtractor;
 import io.opentelemetry.instrumentation.library.okhttp.v3_0.OkHttpInstrumentationConfig;
 import io.opentelemetry.instrumentation.okhttp.v3_0.internal.ConnectionErrorSpanInterceptor;
@@ -72,7 +72,7 @@ public final class OkHttp3Singletons {
     public static final Interceptor RESEND_COUNT_CONTEXT_INTERCEPTOR =
             chain -> {
                 try (Scope ignored =
-                        HttpClientResendCount.initialize(Context.current()).makeCurrent()) {
+                        HttpClientRequestResendCount.initialize(Context.current()).makeCurrent()) {
                     return chain.proceed(chain.request());
                 }
             };

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttp3Singletons.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttp3Singletons.java
@@ -11,13 +11,14 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
-import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientRequestResendCount;
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpClientResendCount;
 import io.opentelemetry.instrumentation.api.instrumenter.net.PeerServiceAttributesExtractor;
 import io.opentelemetry.instrumentation.library.okhttp.v3_0.OkHttpInstrumentationConfig;
 import io.opentelemetry.instrumentation.okhttp.v3_0.internal.ConnectionErrorSpanInterceptor;
 import io.opentelemetry.instrumentation.okhttp.v3_0.internal.OkHttpAttributesGetter;
 import io.opentelemetry.instrumentation.okhttp.v3_0.internal.OkHttpInstrumenterFactory;
 import io.opentelemetry.instrumentation.okhttp.v3_0.internal.TracingInterceptor;
+import java.util.function.Supplier;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -28,24 +29,31 @@ import okhttp3.Response;
  */
 public final class OkHttp3Singletons {
 
-    private static final Instrumenter<Request, Response> INSTRUMENTER =
-            OkHttpInstrumenterFactory.create(
-                    GlobalOpenTelemetry.get(),
-                    builder ->
-                            builder.setCapturedRequestHeaders(
-                                            OkHttpInstrumentationConfig.getCapturedRequestHeaders())
-                                    .setCapturedResponseHeaders(
-                                            OkHttpInstrumentationConfig
-                                                    .getCapturedResponseHeaders())
-                                    .setKnownMethods(OkHttpInstrumentationConfig.getKnownMethods()),
-                    spanNameExtractorConfigurer ->
-                            spanNameExtractorConfigurer.setKnownMethods(
-                                    OkHttpInstrumentationConfig.getKnownMethods()),
-                    singletonList(
-                            PeerServiceAttributesExtractor.create(
-                                    OkHttpAttributesGetter.INSTANCE,
-                                    OkHttpInstrumentationConfig.newPeerServiceResolver())),
-                    OkHttpInstrumentationConfig.emitExperimentalHttpClientMetrics());
+    private static final Supplier<Instrumenter<Request, Response>> INSTRUMENTER =
+            CachedSupplier.create(
+                    () ->
+                            OkHttpInstrumenterFactory.create(
+                                    GlobalOpenTelemetry.get(),
+                                    builder ->
+                                            builder.setCapturedRequestHeaders(
+                                                            OkHttpInstrumentationConfig
+                                                                    .getCapturedRequestHeaders())
+                                                    .setCapturedResponseHeaders(
+                                                            OkHttpInstrumentationConfig
+                                                                    .getCapturedResponseHeaders())
+                                                    .setKnownMethods(
+                                                            OkHttpInstrumentationConfig
+                                                                    .getKnownMethods()),
+                                    spanNameExtractorConfigurer ->
+                                            spanNameExtractorConfigurer.setKnownMethods(
+                                                    OkHttpInstrumentationConfig.getKnownMethods()),
+                                    singletonList(
+                                            PeerServiceAttributesExtractor.create(
+                                                    OkHttpAttributesGetter.INSTANCE,
+                                                    OkHttpInstrumentationConfig
+                                                            .newPeerServiceResolver())),
+                                    OkHttpInstrumentationConfig
+                                            .emitExperimentalHttpClientMetrics()));
 
     public static final Interceptor CALLBACK_CONTEXT_INTERCEPTOR =
             chain -> {
@@ -64,16 +72,23 @@ public final class OkHttp3Singletons {
     public static final Interceptor RESEND_COUNT_CONTEXT_INTERCEPTOR =
             chain -> {
                 try (Scope ignored =
-                        HttpClientRequestResendCount.initialize(Context.current()).makeCurrent()) {
+                        HttpClientResendCount.initialize(Context.current()).makeCurrent()) {
                     return chain.proceed(chain.request());
                 }
             };
 
     public static final Interceptor CONNECTION_ERROR_INTERCEPTOR =
-            new ConnectionErrorSpanInterceptor(INSTRUMENTER);
+            new LazyInterceptor<>(
+                    CachedSupplier.create(
+                            () -> new ConnectionErrorSpanInterceptor(INSTRUMENTER.get())));
 
     public static final Interceptor TRACING_INTERCEPTOR =
-            new TracingInterceptor(INSTRUMENTER, GlobalOpenTelemetry.getPropagators());
+            new LazyInterceptor<>(
+                    CachedSupplier.create(
+                            () ->
+                                    new TracingInterceptor(
+                                            INSTRUMENTER.get(),
+                                            GlobalOpenTelemetry.getPropagators())));
 
     private OkHttp3Singletons() {}
 }

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/src/test/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/CachedSupplierTest.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/src/test/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/CachedSupplierTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.library.okhttp.v3_0.internal;
+
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import java.util.function.Supplier;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class CachedSupplierTest {
+
+    @Test
+    void provideAndCacheSuppliersResult() {
+        Supplier<String> original =
+                spy(
+                        new Supplier<String>() {
+                            @Override
+                            public String get() {
+                                return "Hello World";
+                            }
+                        });
+        CachedSupplier<String> cached = CachedSupplier.create(original);
+
+        for (int i = 0; i < 3; i++) {
+            Assertions.assertThat(cached.get()).isEqualTo("Hello World");
+        }
+        verify(original).get();
+    }
+
+    @Test
+    void validateSupplierDoesNotReturnNull() {
+        Supplier<String> original = () -> null;
+        CachedSupplier<String> cached = CachedSupplier.create(original);
+
+        try {
+            cached.get();
+            fail();
+        } catch (NullPointerException ignored) {
+        }
+    }
+}

--- a/auto-instrumentation/okhttp/okhttp-3.0/testing/build.gradle.kts
+++ b/auto-instrumentation/okhttp/okhttp-3.0/testing/build.gradle.kts
@@ -7,5 +7,6 @@ dependencies {
     byteBuddy(project(":auto-instrumentation:okhttp:okhttp-3.0:agent"))
     implementation(project(":auto-instrumentation:okhttp:okhttp-3.0:library"))
     implementation(libs.okhttp)
+    implementation(libs.opentelemetry.exporter.otlp)
     androidTestImplementation(libs.okhttp.mockwebserver)
 }

--- a/auto-instrumentation/okhttp/okhttp-3.0/testing/build.gradle.kts
+++ b/auto-instrumentation/okhttp/okhttp-3.0/testing/build.gradle.kts
@@ -3,6 +3,16 @@ plugins {
     id("net.bytebuddy.byte-buddy-gradle-plugin")
 }
 
+android {
+    buildTypes {
+        debug {
+            isMinifyEnabled = true
+            proguardFile("proguard-rules.pro")
+            testProguardFile("proguard-test-rules.pro")
+        }
+    }
+}
+
 dependencies {
     byteBuddy(project(":auto-instrumentation:okhttp:okhttp-3.0:agent"))
     implementation(project(":auto-instrumentation:okhttp:okhttp-3.0:library"))

--- a/auto-instrumentation/okhttp/okhttp-3.0/testing/proguard-rules.pro
+++ b/auto-instrumentation/okhttp/okhttp-3.0/testing/proguard-rules.pro
@@ -1,0 +1,7 @@
+-keep class kotlin.** {*;}
+-keep class okhttp3.** {*;}
+-keep class io.opentelemetry.api.** { *; }
+-keep class io.opentelemetry.sdk.** { *; }
+-keep class io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter { *; }
+-keep class io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder { *; }
+-dontwarn *

--- a/auto-instrumentation/okhttp/okhttp-3.0/testing/proguard-rules.pro
+++ b/auto-instrumentation/okhttp/okhttp-3.0/testing/proguard-rules.pro
@@ -1,5 +1,5 @@
--keep class kotlin.** {*;}
--keep class okhttp3.** {*;}
+-keep class kotlin.** { *; }
+-keep class okhttp3.** { *; }
 -keep class io.opentelemetry.api.** { *; }
 -keep class io.opentelemetry.sdk.** { *; }
 -keep class io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter { *; }

--- a/auto-instrumentation/okhttp/okhttp-3.0/testing/proguard-test-rules.pro
+++ b/auto-instrumentation/okhttp/okhttp-3.0/testing/proguard-test-rules.pro
@@ -1,0 +1,1 @@
+-include proguard-rules.pro

--- a/auto-instrumentation/okhttp/okhttp-3.0/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/InstrumentationTest.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/InstrumentationTest.java
@@ -12,10 +12,12 @@ import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import okhttp3.Call;
@@ -27,17 +29,11 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class InstrumentationTest {
     private MockWebServer server;
-    private static InMemorySpanExporter spanExporter;
-
-    @BeforeClass
-    public static void setUpAll() {
-        setUpInMemorySpanExporter();
-    }
+    private static final InMemorySpanExporter inMemorySpanExporter = InMemorySpanExporter.create();
 
     @Before
     public void setUp() throws IOException {
@@ -48,11 +44,12 @@ public class InstrumentationTest {
     @After
     public void tearDown() throws IOException {
         server.shutdown();
-        spanExporter.reset();
+        inMemorySpanExporter.reset();
     }
 
     @Test
     public void okhttpTraces() throws IOException {
+        setUpSpanExporter(inMemorySpanExporter);
         server.enqueue(new MockResponse().setResponseCode(200));
 
         Span span = getSpan();
@@ -74,11 +71,12 @@ public class InstrumentationTest {
 
         span.end();
 
-        assertEquals(2, spanExporter.getFinishedSpanItems().size());
+        assertEquals(2, inMemorySpanExporter.getFinishedSpanItems().size());
     }
 
     @Test
     public void okhttpTraces_with_callback() throws InterruptedException {
+        setUpSpanExporter(inMemorySpanExporter);
         CountDownLatch lock = new CountDownLatch(1);
         Span span = getSpan();
 
@@ -117,18 +115,46 @@ public class InstrumentationTest {
         lock.await();
         span.end();
 
-        assertEquals(2, spanExporter.getFinishedSpanItems().size());
+        assertEquals(2, inMemorySpanExporter.getFinishedSpanItems().size());
+    }
+
+    @Test
+    public void avoidCreatingSpansForInternalOkhttpRequests() throws InterruptedException {
+        OtlpHttpSpanExporter exporter =
+                OtlpHttpSpanExporter.builder().setEndpoint(server.url("").toString()).build();
+        setUpSpanExporter(exporter);
+
+        server.enqueue(new MockResponse().setResponseCode(200));
+
+        // This span should trigger 1 export okhttp call, which is the only okhttp call expected
+        // for this test case.
+        getSpan().end();
+
+        // Wait for unwanted extra okhttp requests.
+        int loop = 0;
+        while (loop < 10) {
+            Thread.sleep(100);
+            // Stop waiting if we get at least one unwanted request.
+            if (server.getRequestCount() > 1) {
+                break;
+            }
+            loop++;
+        }
+
+        assertEquals(1, server.getRequestCount());
     }
 
     private static Span getSpan() {
-        return GlobalOpenTelemetry.getTracer("TestTracer").spanBuilder("A Span").startSpan();
+        return GlobalOpenTelemetry.get().getTracer("TestTracer").spanBuilder("A Span").startSpan();
     }
 
-    private static void setUpInMemorySpanExporter() {
-        spanExporter = InMemorySpanExporter.create();
-        OpenTelemetrySdk.builder()
-                .setTracerProvider(getSimpleTracerProvider(spanExporter))
-                .buildAndRegisterGlobal();
+    private void setUpSpanExporter(SpanExporter spanExporter) {
+        OpenTelemetrySdk openTelemetry =
+                OpenTelemetrySdk.builder()
+                        .setTracerProvider(getSimpleTracerProvider(spanExporter))
+                        .build();
+        GlobalOpenTelemetry.resetForTest();
+        GlobalOpenTelemetry.set(openTelemetry);
     }
 
     private Call createCall(OkHttpClient client, String urlPath) {
@@ -137,7 +163,7 @@ public class InstrumentationTest {
     }
 
     @NonNull
-    private static SdkTracerProvider getSimpleTracerProvider(InMemorySpanExporter spanExporter) {
+    private SdkTracerProvider getSimpleTracerProvider(SpanExporter spanExporter) {
         return SdkTracerProvider.builder()
                 .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
                 .build();

--- a/auto-instrumentation/okhttp/okhttp-3.0/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/InstrumentationTest.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/InstrumentationTest.java
@@ -120,6 +120,9 @@ public class InstrumentationTest {
 
     @Test
     public void avoidCreatingSpansForInternalOkhttpRequests() throws InterruptedException {
+        // NOTE: For some reason this test always passes when running all the tests in this file at
+        // once,
+        // so it should be run isolated to actually get it to fail when it's expected to fail.
         OtlpHttpSpanExporter exporter =
                 OtlpHttpSpanExporter.builder().setEndpoint(server.url("").toString()).build();
         setUpSpanExporter(exporter);

--- a/auto-instrumentation/okhttp/okhttp-3.0/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/InstrumentationTest.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/InstrumentationTest.java
@@ -148,7 +148,7 @@ public class InstrumentationTest {
     }
 
     private static Span getSpan() {
-        return GlobalOpenTelemetry.get().getTracer("TestTracer").spanBuilder("A Span").startSpan();
+        return GlobalOpenTelemetry.getTracer("TestTracer").spanBuilder("A Span").startSpan();
     }
 
     private void setUpSpanExporter(SpanExporter spanExporter) {

--- a/buildSrc/src/main/kotlin/otel.android-app-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.android-app-conventions.gradle.kts
@@ -20,7 +20,6 @@ android {
         val javaVersion = rootProject.extra["java_version"] as JavaVersion
         sourceCompatibility(javaVersion)
         targetCompatibility(javaVersion)
-        isCoreLibraryDesugaringEnabled = true
     }
 }
 
@@ -28,5 +27,4 @@ val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 dependencies {
     androidTestImplementation(libs.findLibrary("androidx-test-runner").get())
     androidTestImplementation(libs.findLibrary("opentelemetry-sdk-testing").get())
-    coreLibraryDesugaring(libs.findLibrary("desugarJdkLibs").get())
 }

--- a/buildSrc/src/main/kotlin/otel.android-app-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.android-app-conventions.gradle.kts
@@ -20,6 +20,7 @@ android {
         val javaVersion = rootProject.extra["java_version"] as JavaVersion
         sourceCompatibility(javaVersion)
         targetCompatibility(javaVersion)
+        isCoreLibraryDesugaringEnabled = true
     }
 }
 
@@ -27,4 +28,5 @@ val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 dependencies {
     androidTestImplementation(libs.findLibrary("androidx-test-runner").get())
     androidTestImplementation(libs.findLibrary("opentelemetry-sdk-testing").get())
+    coreLibraryDesugaring(libs.findLibrary("desugarJdkLibs").get())
 }

--- a/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
@@ -28,8 +28,16 @@ android {
     }
 }
 
+tasks.withType<Test> {
+    useJUnitPlatform()
+}
+
 val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 dependencies {
     implementation(libs.findLibrary("findbugs-jsr305").get())
+    testImplementation(libs.findLibrary("assertj-core").get())
+    testImplementation(libs.findBundle("mockito").get())
+    testImplementation(libs.findBundle("junit").get())
+    testImplementation(libs.findLibrary("opentelemetry-sdk-testing").get())
     coreLibraryDesugaring(libs.findLibrary("desugarJdkLibs").get())
 }

--- a/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
@@ -24,10 +24,12 @@ android {
         val javaVersion = rootProject.extra["java_version"] as JavaVersion
         sourceCompatibility(javaVersion)
         targetCompatibility(javaVersion)
+        isCoreLibraryDesugaringEnabled = true
     }
 }
 
 val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 dependencies {
     implementation(libs.findLibrary("findbugs-jsr305").get())
+    coreLibraryDesugaring(libs.findLibrary("desugarJdkLibs").get())
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-opentelemetry = "1.31.0"
-opentelemetry-alpha = "1.31.0-alpha"
+opentelemetry = "1.32.0"
+opentelemetry-alpha = "1.32.0-alpha"
 opentelemetry-semconv = "1.21.0-alpha"
 opentelemetry-contrib = "1.31.0-alpha"
 mockito = "5.7.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-opentelemetry = "1.32.0"
-opentelemetry-alpha = "1.32.0-alpha"
+opentelemetry = "1.31.0"
+opentelemetry-alpha = "1.31.0-alpha"
 opentelemetry-semconv = "1.21.0-alpha"
 opentelemetry-contrib = "1.31.0-alpha"
 mockito = "5.7.0"
@@ -28,6 +28,7 @@ opentelemetry-exporter-zipkin = { module = "io.opentelemetry:opentelemetry-expor
 opentelemetry-exporter-logging = { module = "io.opentelemetry:opentelemetry-exporter-logging" }
 zipkin-sender-okhttp3 = { module = "io.zipkin.reporter2:zipkin-sender-okhttp3", version.ref = "zipkin-reporter" }
 opentelemetry-diskBuffering = { module = "io.opentelemetry.contrib:opentelemetry-disk-buffering", version.ref = "opentelemetry-contrib" }
+opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp", version.ref = "opentelemetry" }
 
 #Test tools
 opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing", version.ref = "opentelemetry" }

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -47,10 +47,6 @@ android {
         }
     }
 
-    compileOptions {
-        isCoreLibraryDesugaringEnabled = true
-    }
-
     testOptions {
         unitTests.isReturnDefaultValues = true
         unitTests.isIncludeAndroidResources = true
@@ -79,8 +75,6 @@ dependencies {
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.assertj.core)
     testImplementation(libs.awaitility)
-
-    coreLibraryDesugaring(libs.desugarJdkLibs)
 }
 
 tasks.withType<Test> {

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -68,17 +68,9 @@ dependencies {
     implementation(libs.opentelemetry.semconv)
     implementation(libs.opentelemetry.diskBuffering)
 
-    testImplementation(libs.bundles.mockito)
-    testImplementation(libs.bundles.junit)
-    testImplementation(libs.opentelemetry.sdk.testing)
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.test.core)
-    testImplementation(libs.assertj.core)
     testImplementation(libs.awaitility)
-}
-
-tasks.withType<Test> {
-    useJUnitPlatform()
 }
 
 extra["pomName"] = "OpenTelemetry Android Instrumentation"


### PR DESCRIPTION
The OkHttp auto-instrumentation tool had an issue where it would create spans for OkHttp requests created by OTel's exporters, causing an infinite amount of spans to be created since each export would mean a new OkHttp call. Said issue was addressed as part of these PRs:

- https://github.com/open-telemetry/opentelemetry-java/pull/5918
- https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/9739

This PR does the following:
* Adds tests to validate that the infinite spans issue is solved. 
* Adds proguard rules to avoid issues with a reflection call needed to identify OTel's okhttp requests, more info [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/9739#discussion_r1394507569). 
* Fixes an initialization racing issue where the global OpenTelemetry instance was being set statically [here](https://github.com/open-telemetry/opentelemetry-android/blob/3c5ca844e8b7925fa3ca0de8bfd9599b02e5694b/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttp3Singletons.java#L33) when creating an [OtlpHttpSpanExporter instance](https://github.com/open-telemetry/opentelemetry-java/blob/1e82b72f36d847e743a525ae8767a6badd8deb81/exporters/otlp/all/src/main/java/io/opentelemetry/exporter/otlp/http/trace/OtlpHttpSpanExporterBuilder.java#L163) which ends up creating a [new OkHttpClient](https://github.com/open-telemetry/opentelemetry-java/blob/1e82b72f36d847e743a525ae8767a6badd8deb81/exporters/sender/okhttp/src/main/java/io/opentelemetry/exporter/sender/okhttp/internal/OkHttpHttpSender.java#L60) instance before users could create and set their own GlobalOpenTelemetry instance.