### PR TITLE
Adding disk buffering, part 2

### DIFF
--- a/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -324,7 +324,7 @@ public final class OpenTelemetryRumBuilder {
             try {
                 spanExporter = createDiskExporter(defaultExporter, diskBufferingConfiguration);
             } catch (IOException e) {
-                LOGGER.log(Level.WARNING, "Could not create span disk exporter", e);
+                LOGGER.log(Level.WARNING, "Could not create span disk exporter.", e);
             }
         }
         return spanExporterCustomizer.apply(spanExporter);

--- a/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -8,6 +8,7 @@ package io.opentelemetry.android;
 import static java.util.Objects.requireNonNull;
 
 import android.app.Application;
+import android.util.Log;
 import io.opentelemetry.android.config.DiskBufferingConfiguration;
 import io.opentelemetry.android.config.OtelRumConfig;
 import io.opentelemetry.android.instrumentation.InstrumentedApplication;
@@ -42,8 +43,6 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * A builder of {@link OpenTelemetryRum}. It enabled configuring the OpenTelemetry SDK and disabling
@@ -64,7 +63,6 @@ public final class OpenTelemetryRumBuilder {
             loggerProviderCustomizers = new ArrayList<>();
     private final OtelRumConfig config;
     private final VisibleScreenTracker visibleScreenTracker = new VisibleScreenTracker();
-    private static final Logger LOGGER = Logger.getLogger("OpenTelemetryRumBuilder");
 
     private Function<? super SpanExporter, ? extends SpanExporter> spanExporterCustomizer = a -> a;
     private final List<Consumer<InstrumentedApplication>> instrumentationInstallers =
@@ -324,7 +322,7 @@ public final class OpenTelemetryRumBuilder {
             try {
                 spanExporter = createDiskExporter(defaultExporter, diskBufferingConfiguration);
             } catch (IOException e) {
-                LOGGER.log(Level.WARNING, "Could not create span disk exporter.", e);
+                Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Could not create span disk exporter.", e);
             }
         }
         return spanExporterCustomizer.apply(spanExporter);

--- a/instrumentation/src/main/java/io/opentelemetry/android/internal/features/persistence/DiskManager.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/internal/features/persistence/DiskManager.java
@@ -5,21 +5,20 @@
 
 package io.opentelemetry.android.internal.features.persistence;
 
+import android.util.Log;
+import io.opentelemetry.android.RumConstants;
 import io.opentelemetry.android.config.DiskBufferingConfiguration;
 import io.opentelemetry.android.internal.services.CacheStorageService;
 import io.opentelemetry.android.internal.services.PreferencesService;
 import io.opentelemetry.android.internal.services.ServiceManager;
 import java.io.File;
 import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * This class is internal and not for public use. Its APIs are unstable and can change at any time.
  */
 public final class DiskManager {
     private static final String MAX_FOLDER_SIZE_KEY = "max_signal_folder_size";
-    private static final Logger logger = Logger.getLogger("DiskManager");
     private final CacheStorageService cacheStorageService;
     private final PreferencesService preferencesService;
     private final DiskBufferingConfiguration diskBufferingConfiguration;
@@ -75,8 +74,8 @@ public final class DiskManager {
     public int getMaxFolderSize() {
         int storedSize = preferencesService.retrieveInt(MAX_FOLDER_SIZE_KEY, -1);
         if (storedSize > 0) {
-            logger.log(
-                    Level.FINER,
+            Log.d(
+                    RumConstants.OTEL_RUM_LOG_TAG,
                     String.format("Returning max folder size from preferences: %s", storedSize));
             return storedSize;
         }
@@ -88,8 +87,8 @@ public final class DiskManager {
         int maxCacheFileSize = getMaxCacheFileSize();
         int calculatedSize = (availableCacheSize / 3) - maxCacheFileSize;
         if (calculatedSize < maxCacheFileSize) {
-            logger.log(
-                    Level.WARNING,
+            Log.w(
+                    RumConstants.OTEL_RUM_LOG_TAG,
                     String.format(
                             "Insufficient folder cache size: %s, it must be at least: %s",
                             calculatedSize, maxCacheFileSize));
@@ -97,8 +96,8 @@ public final class DiskManager {
         }
         preferencesService.store(MAX_FOLDER_SIZE_KEY, calculatedSize);
 
-        logger.log(
-                Level.FINER,
+        Log.d(
+                RumConstants.OTEL_RUM_LOG_TAG,
                 String.format(
                         "Requested cache size: %s, available cache size: %s, folder size: %s",
                         requestedSize, availableCacheSize, calculatedSize));

--- a/instrumentation/src/main/java/io/opentelemetry/android/internal/features/persistence/DiskManager.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/internal/features/persistence/DiskManager.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.android.internal.features.persistence;
 
 import io.opentelemetry.android.config.DiskBufferingConfiguration;
-import io.opentelemetry.android.config.OtelRumConfig;
 import io.opentelemetry.android.internal.services.CacheStorageService;
 import io.opentelemetry.android.internal.services.PreferencesService;
 import io.opentelemetry.android.internal.services.ServiceManager;
@@ -25,12 +24,12 @@ public final class DiskManager {
     private final PreferencesService preferencesService;
     private final DiskBufferingConfiguration diskBufferingConfiguration;
 
-    public static DiskManager create(OtelRumConfig config) {
+    public static DiskManager create(DiskBufferingConfiguration config) {
         ServiceManager serviceManager = ServiceManager.get();
         return new DiskManager(
                 serviceManager.getService(CacheStorageService.class),
                 serviceManager.getService(PreferencesService.class),
-                config.getDiskBufferingConfiguration());
+                config);
     }
 
     private DiskManager(

--- a/instrumentation/src/main/java/io/opentelemetry/android/internal/features/persistence/SimpleTemporaryFileProvider.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/internal/features/persistence/SimpleTemporaryFileProvider.java
@@ -7,6 +7,7 @@ package io.opentelemetry.android.internal.features.persistence;
 
 import io.opentelemetry.contrib.disk.buffering.internal.files.TemporaryFileProvider;
 import java.io.File;
+import java.util.UUID;
 
 /**
  * This class is internal and not for public use. Its APIs are unstable and can change at any time.
@@ -21,6 +22,6 @@ public final class SimpleTemporaryFileProvider implements TemporaryFileProvider 
     /** Creates a unique file instance using the provided prefix and the current time in millis. */
     @Override
     public File createTemporaryFile(String prefix) {
-        return new File(tempDir, prefix + "_" + System.currentTimeMillis() + ".tmp");
+        return new File(tempDir, prefix + "_" + UUID.randomUUID() + ".tmp");
     }
 }

--- a/instrumentation/src/main/java/io/opentelemetry/android/internal/features/persistence/SimpleTemporaryFileProvider.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/internal/features/persistence/SimpleTemporaryFileProvider.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.internal.features.persistence;
+
+import io.opentelemetry.contrib.disk.buffering.internal.files.TemporaryFileProvider;
+import java.io.File;
+
+/**
+ * This class is internal and not for public use. Its APIs are unstable and can change at any time.
+ */
+public final class SimpleTemporaryFileProvider implements TemporaryFileProvider {
+    private final File tempDir;
+
+    public SimpleTemporaryFileProvider(File tempDir) {
+        this.tempDir = tempDir;
+    }
+
+    @Override
+    public File createTemporaryFile(String prefix) {
+        return new File(tempDir, prefix + "_" + System.currentTimeMillis() + ".tmp");
+    }
+}

--- a/instrumentation/src/main/java/io/opentelemetry/android/internal/features/persistence/SimpleTemporaryFileProvider.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/internal/features/persistence/SimpleTemporaryFileProvider.java
@@ -18,6 +18,7 @@ public final class SimpleTemporaryFileProvider implements TemporaryFileProvider 
         this.tempDir = tempDir;
     }
 
+    /** Creates a unique file instance using the provided prefix and the current time in millis. */
     @Override
     public File createTemporaryFile(String prefix) {
         return new File(tempDir, prefix + "_" + System.currentTimeMillis() + ".tmp");

--- a/instrumentation/src/main/java/io/opentelemetry/android/internal/services/CacheStorageService.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/internal/services/CacheStorageService.java
@@ -8,13 +8,13 @@ package io.opentelemetry.android.internal.services;
 import android.content.Context;
 import android.os.Build;
 import android.os.storage.StorageManager;
+import android.util.Log;
 import androidx.annotation.RequiresApi;
 import androidx.annotation.WorkerThread;
+import io.opentelemetry.android.RumConstants;
 import java.io.File;
 import java.io.IOException;
 import java.util.UUID;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Utility to get information about the host app.
@@ -24,7 +24,6 @@ import java.util.logging.Logger;
  */
 public class CacheStorageService implements Service {
     private final Context appContext;
-    private static final Logger logger = Logger.getLogger("CacheStorageService");
 
     public CacheStorageService(Context appContext) {
         this.appContext = appContext;
@@ -53,8 +52,8 @@ public class CacheStorageService implements Service {
 
     @RequiresApi(api = Build.VERSION_CODES.O)
     private long getAvailableSpace(File directory, long maxSpaceNeeded) {
-        logger.log(
-                Level.FINER,
+        Log.d(
+                RumConstants.OTEL_RUM_LOG_TAG,
                 String.format(
                         "Getting available space for %s, max needed is: %s",
                         directory, maxSpaceNeeded));
@@ -70,14 +69,14 @@ public class CacheStorageService implements Service {
             storageManager.allocateBytes(appSpecificInternalDirUuid, spaceToAllocate);
             return spaceToAllocate;
         } catch (IOException e) {
-            logger.log(Level.WARNING, "Failed to get available space", e);
+            Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to get available space", e);
             return getLegacyAvailableSpace(directory, maxSpaceNeeded);
         }
     }
 
     private long getLegacyAvailableSpace(File directory, long maxSpaceNeeded) {
-        logger.log(
-                Level.FINER,
+        Log.d(
+                RumConstants.OTEL_RUM_LOG_TAG,
                 String.format(
                         "Getting legacy available space for %s max needed is: %s",
                         directory, maxSpaceNeeded));

--- a/instrumentation/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -11,7 +11,10 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.asser
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.isA;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -19,18 +22,25 @@ import static org.mockito.Mockito.when;
 import android.app.Activity;
 import android.app.Application;
 import androidx.annotation.NonNull;
+import io.opentelemetry.android.config.DiskBufferingConfiguration;
 import io.opentelemetry.android.config.OtelRumConfig;
 import io.opentelemetry.android.instrumentation.ApplicationStateListener;
+import io.opentelemetry.android.internal.services.CacheStorageService;
+import io.opentelemetry.android.internal.services.PreferencesService;
+import io.opentelemetry.android.internal.services.Service;
+import io.opentelemetry.android.internal.services.ServiceManager;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.contrib.disk.buffering.SpanDiskExporter;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.function.Function;
@@ -156,6 +166,69 @@ class OpenTelemetryRumBuilderTest {
         // 5 sec is default
         await().atMost(Duration.ofSeconds(30))
                 .untilAsserted(() -> verify(exporter).export(anyCollection()));
+    }
+
+    @Test
+    void diskBufferingEnabled() {
+        PreferencesService preferences = mock();
+        CacheStorageService cacheStorage = mock();
+        doReturn(60 * 1024 * 1024L).when(cacheStorage).ensureCacheSpaceAvailable(anyLong());
+        setUpServiceManager(preferences, cacheStorage);
+        OtelRumConfig config = buildConfig();
+        config.setDiskBufferingConfiguration(
+                DiskBufferingConfiguration.builder().setEnabled(true).build());
+
+        OpenTelemetryRum.builder(application, config)
+                .addSpanExporterCustomizer(
+                        spanExporter -> {
+                            assertThat(spanExporter).isInstanceOf(SpanDiskExporter.class);
+                            return spanExporter;
+                        })
+                .build();
+    }
+
+    @Test
+    void diskBufferingEnabled_when_exception_thrown() {
+        PreferencesService preferences = mock();
+        CacheStorageService cacheStorage = mock();
+        doReturn(60 * 1024 * 1024L).when(cacheStorage).ensureCacheSpaceAvailable(anyLong());
+        doAnswer(
+                        invocation -> {
+                            throw new IOException();
+                        })
+                .when(cacheStorage)
+                .getCacheDir();
+        setUpServiceManager(preferences, cacheStorage);
+        OtelRumConfig config = buildConfig();
+        config.setDiskBufferingConfiguration(
+                DiskBufferingConfiguration.builder().setEnabled(true).build());
+
+        OpenTelemetryRum.builder(application, config)
+                .addSpanExporterCustomizer(
+                        spanExporter -> {
+                            assertThat(spanExporter).isNotInstanceOf(SpanDiskExporter.class);
+                            return spanExporter;
+                        })
+                .build();
+    }
+
+    @Test
+    void diskBufferingDisabled() {
+        makeBuilder()
+                .addSpanExporterCustomizer(
+                        spanExporter -> {
+                            assertThat(spanExporter).isNotInstanceOf(SpanDiskExporter.class);
+                            return spanExporter;
+                        })
+                .build();
+    }
+
+    private static void setUpServiceManager(Service... services) {
+        ServiceManager serviceManager = mock();
+        for (Service service : services) {
+            doReturn(service).when(serviceManager).getService(service.getClass());
+        }
+        ServiceManager.setForTest(serviceManager);
     }
 
     @NonNull

--- a/instrumentation/src/test/java/io/opentelemetry/android/internal/features/persistence/DiskManagerTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/internal/features/persistence/DiskManagerTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import io.opentelemetry.android.config.DiskBufferingConfiguration;
-import io.opentelemetry.android.config.OtelRumConfig;
 import io.opentelemetry.android.internal.services.CacheStorageService;
 import io.opentelemetry.android.internal.services.PreferencesService;
 import io.opentelemetry.android.internal.services.ServiceManager;
@@ -41,13 +40,11 @@ class DiskManagerTest {
 
     @BeforeEach
     void setUp() {
-        OtelRumConfig config = mock();
         ServiceManager serviceManager = mock();
-        doReturn(diskBufferingConfiguration).when(config).getDiskBufferingConfiguration();
         doReturn(cacheStorageService).when(serviceManager).getService(CacheStorageService.class);
         doReturn(preferencesService).when(serviceManager).getService(PreferencesService.class);
         ServiceManager.setForTest(serviceManager);
-        diskManager = DiskManager.create(config);
+        diskManager = DiskManager.create(diskBufferingConfiguration);
     }
 
     @Test

--- a/instrumentation/src/test/java/io/opentelemetry/android/internal/features/persistence/SimpleTemporaryFileProviderTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/internal/features/persistence/SimpleTemporaryFileProviderTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.internal.features.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SimpleTemporaryFileProviderTest {
+    @TempDir File tempDir;
+
+    @Test
+    void createUniqueFilesBasedOnCurrentTimeAndPrefix() throws InterruptedException {
+        SimpleTemporaryFileProvider provider = new SimpleTemporaryFileProvider(tempDir);
+        File first = provider.createTemporaryFile("a");
+        File second = provider.createTemporaryFile("b");
+        Thread.sleep(1);
+        File third = provider.createTemporaryFile("a");
+
+        assertThat(first.getName()).startsWith("a").endsWith(".tmp");
+        assertThat(second.getName()).startsWith("b").endsWith(".tmp");
+        assertThat(third.getName()).startsWith("a").endsWith(".tmp");
+        assertThat(first).isNotEqualTo(third);
+    }
+}

--- a/instrumentation/src/test/java/io/opentelemetry/android/internal/features/persistence/SimpleTemporaryFileProviderTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/internal/features/persistence/SimpleTemporaryFileProviderTest.java
@@ -26,5 +26,9 @@ class SimpleTemporaryFileProviderTest {
         assertThat(second.getName()).startsWith("b").endsWith(".tmp");
         assertThat(third.getName()).startsWith("a").endsWith(".tmp");
         assertThat(first).isNotEqualTo(third);
+
+        assertThat(first.getParentFile()).isEqualTo(tempDir);
+        assertThat(second.getParentFile()).isEqualTo(tempDir);
+        assertThat(third.getParentFile()).isEqualTo(tempDir);
     }
 }


### PR DESCRIPTION
Related to #132 

This part connects the tools added in the previous part to the OpenTelemetryRumBuilder class.

#### For the next part, "Fun with Threads":

* Make sure the initialization happens in a secondary thread, more info: https://github.com/open-telemetry/opentelemetry-android/issues/149.
* Set up configurable, periodic calls to export cached data as background work.