### PR TITLE
Add network change monitoring

### DIFF
--- a/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -37,7 +37,6 @@ import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
-
 import javax.annotation.Nullable;
 
 /**
@@ -68,8 +67,7 @@ public final class OpenTelemetryRumBuilder {
             (a) -> a;
 
     private Resource resource;
-    @Nullable
-    private CurrentNetworkProvider currentNetworkProvider = null;
+    @Nullable private CurrentNetworkProvider currentNetworkProvider = null;
     private InitializationEvents initializationEvents = InitializationEvents.NO_OP;
 
     private static TextMapPropagator buildDefaultPropagator() {

--- a/instrumentation/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
@@ -23,6 +23,7 @@ public class OtelRumConfig {
     private boolean includeScreenAttributes = true;
     private DiskBufferingConfiguration diskBufferingConfiguration =
             DiskBufferingConfiguration.builder().build();
+    private boolean networkChangeMonitoringEnabled = true;
 
     /**
      * Configures the set of global attributes to emit with every span and event. Any existing
@@ -102,5 +103,13 @@ public class OtelRumConfig {
     public void setDiskBufferingConfiguration(
             DiskBufferingConfiguration diskBufferingConfiguration) {
         this.diskBufferingConfiguration = diskBufferingConfiguration;
+    }
+
+    public void disableNetworkChangeMonitoring() {
+        this.networkChangeMonitoringEnabled = false;
+    }
+
+    public boolean isNetworkChangeMonitoringEnabled() {
+        return this.networkChangeMonitoringEnabled;
     }
 }

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/InitializationEvents.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/InitializationEvents.java
@@ -15,6 +15,8 @@ public interface InitializationEvents {
 
     void currentNetworkProviderInitialized();
 
+    void networkMonitorInitialized();
+
     InitializationEvents NO_OP =
             new InitializationEvents() {
                 @Override
@@ -25,5 +27,8 @@ public interface InitializationEvents {
 
                 @Override
                 public void currentNetworkProviderInitialized() {}
+
+                @Override
+                public void networkMonitorInitialized() {}
             };
 }

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEvents.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEvents.java
@@ -23,4 +23,9 @@ public class SdkInitializationEvents implements InitializationEvents {
     public void currentNetworkProviderInitialized() {
         // TODO: Build me
     }
+
+    @Override
+    public void networkMonitorInitialized() {
+        // TOOD: Build me "networkMonitorInitialized"
+    }
 }

--- a/instrumentation/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -34,6 +34,7 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.time.Duration;
 import java.util.List;
 import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -49,10 +50,16 @@ class OpenTelemetryRumBuilderTest {
     final InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
 
     @Mock Application application;
+    @Mock android.content.Context applicationContext;
     @Mock Activity activity;
     @Mock ApplicationStateListener listener;
 
     @Captor ArgumentCaptor<Application.ActivityLifecycleCallbacks> activityCallbacksCaptor;
+
+    @BeforeEach
+    void setup() {
+        when(application.getApplicationContext()).thenReturn(applicationContext);
+    }
 
     @Test
     void shouldRegisterApplicationStateWatcher() {


### PR DESCRIPTION
The instrumentation that reports network changes has not yet been wired up. This adds it to the configuration and enables the instrumentation in the builder's `build()`.

One additional aspect is that the `CurrentNetworkProvider` now has a setter on the `OpenTelemetryRumBuilder`. This allows existing components that may rely on this functionality to share the instance.  The creation is lazy, so that if the builder user didn't create one, it is created at build time on demand.

I expect this `CurrentNetworkProvider` sharing to hopefully not be necessary in the long term, but right now there are existing disk buffering implementations (eg. Splunk's distro) that also need to determine information about the current network availability before attempting export.