### PR TITLE
Removing okhttp testing deobfuscation

### DIFF
--- a/auto-instrumentation/okhttp/okhttp-3.0/testing/build.gradle.kts
+++ b/auto-instrumentation/okhttp/okhttp-3.0/testing/build.gradle.kts
@@ -3,16 +3,6 @@ plugins {
     id("net.bytebuddy.byte-buddy-gradle-plugin")
 }
 
-android {
-    buildTypes {
-        debug {
-            isMinifyEnabled = true
-            proguardFile("proguard-rules.pro")
-            testProguardFile("proguard-test-rules.pro")
-        }
-    }
-}
-
 dependencies {
     byteBuddy(project(":auto-instrumentation:okhttp:okhttp-3.0:agent"))
     implementation(project(":auto-instrumentation:okhttp:okhttp-3.0:library"))

--- a/auto-instrumentation/okhttp/okhttp-3.0/testing/proguard-rules.pro
+++ b/auto-instrumentation/okhttp/okhttp-3.0/testing/proguard-rules.pro
@@ -1,7 +1,0 @@
--keep class kotlin.** { *; }
--keep class okhttp3.** { *; }
--keep class io.opentelemetry.api.** { *; }
--keep class io.opentelemetry.sdk.** { *; }
--keep class io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter { *; }
--keep class io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporterBuilder { *; }
--dontwarn *

--- a/auto-instrumentation/okhttp/okhttp-3.0/testing/proguard-test-rules.pro
+++ b/auto-instrumentation/okhttp/okhttp-3.0/testing/proguard-test-rules.pro
@@ -1,1 +1,0 @@
--include proguard-rules.pro

--- a/buildSrc/src/main/kotlin/otel.android-app-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.android-app-conventions.gradle.kts
@@ -1,6 +1,3 @@
-import com.android.build.api.dsl.LibraryExtension
-import org.gradle.api.publish.maven.MavenPublication
-
 plugins {
     id("com.android.application")
     id("otel.errorprone-conventions")
@@ -20,6 +17,7 @@ android {
         val javaVersion = rootProject.extra["java_version"] as JavaVersion
         sourceCompatibility(javaVersion)
         targetCompatibility(javaVersion)
+        isCoreLibraryDesugaringEnabled = true
     }
 }
 
@@ -27,4 +25,5 @@ val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 dependencies {
     androidTestImplementation(libs.findLibrary("androidx-test-runner").get())
     androidTestImplementation(libs.findLibrary("opentelemetry-sdk-testing").get())
+    coreLibraryDesugaring(libs.findLibrary("desugarJdkLibs").get())
 }

--- a/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
@@ -1,6 +1,3 @@
-import com.android.build.api.dsl.LibraryExtension
-import org.gradle.api.publish.maven.MavenPublication
-
 plugins {
     id("com.android.library")
     id("otel.errorprone-conventions")


### PR DESCRIPTION
I [wanted to include](https://github.com/open-telemetry/opentelemetry-android/pull/159) R8/ProGuard verifications to the okhttp instrumentation test, however, R8/ProGuard doesn't seem to work well when corelib desugaring is enabled, so I've deleted the R8/ProGuard verification in this PR to address [this issue](https://github.com/open-telemetry/opentelemetry-android/issues/178).