### PR TITLE
Enable core desugaring for instrumentation

### DIFF
--- a/auto-instrumentation/okhttp/okhttp-3.0/testing/build.gradle.kts
+++ b/auto-instrumentation/okhttp/okhttp-3.0/testing/build.gradle.kts
@@ -11,6 +11,9 @@ android {
             testProguardFile("proguard-test-rules.pro")
         }
     }
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+    }
 }
 
 dependencies {
@@ -19,4 +22,5 @@ dependencies {
     implementation(libs.okhttp)
     implementation(libs.opentelemetry.exporter.otlp)
     androidTestImplementation(libs.okhttp.mockwebserver)
+    coreLibraryDesugaring(libs.desugarJdkLibs)
 }


### PR DESCRIPTION
This is needed to fix the currently broken build.