### PR TITLE
Use the BuildConfig for version property

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -16,8 +16,6 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
 
-# generate the BuildConfig class that contains the app version
-android.defaults.buildfeatures.buildconfig=true
 android.minSdk=21
 android.targetSdk=23
 android.compileSdk=34

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -63,7 +63,6 @@ dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core)
     implementation(libs.androidx.navigation.fragment)
-    coreLibraryDesugaring(libs.desugarJdkLibs)
 
     api(platform(libs.opentelemetry.platform))
     api(libs.opentelemetry.api)

--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -1,3 +1,4 @@
+
 plugins {
     id("otel.android-library-conventions")
     id("otel.publish-conventions")
@@ -14,6 +15,7 @@ android {
     defaultConfig {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
+        buildConfigField("String", "OTEL_ANDROID_VERSION", "\"$version\"")
     }
 
     buildTypes {
@@ -51,12 +53,17 @@ android {
         unitTests.isReturnDefaultValues = true
         unitTests.isIncludeAndroidResources = true
     }
+
+    buildFeatures {
+        buildConfig = true
+    }
 }
 
 dependencies {
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core)
     implementation(libs.androidx.navigation.fragment)
+    coreLibraryDesugaring(libs.desugarJdkLibs)
 
     api(platform(libs.opentelemetry.platform))
     api(libs.opentelemetry.api)

--- a/instrumentation/src/main/java/io/opentelemetry/android/AndroidResource.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/AndroidResource.java
@@ -29,7 +29,7 @@ final class AndroidResource {
                 Resource.getDefault().toBuilder().put(SERVICE_NAME, appName);
 
         return resourceBuilder
-                .put(RUM_SDK_VERSION, detectRumVersion(application))
+                .put(RUM_SDK_VERSION, BuildConfig.OTEL_ANDROID_VERSION)
                 .put(DEVICE_MODEL_NAME, Build.MODEL)
                 .put(DEVICE_MODEL_IDENTIFIER, Build.MODEL)
                 .put(DEVICE_MANUFACTURER, Build.MANUFACTURER)
@@ -48,19 +48,6 @@ final class AndroidResource {
                     return application.getApplicationContext().getString(stringId);
                 },
                 "unknown_service:android");
-    }
-
-    private static String detectRumVersion(Application application) {
-        return trapTo(
-                () -> {
-                    // TODO: Verify that this will be in the lib/jar at runtime.
-                    // TODO: After donation, package of R file will change
-                    return application
-                            .getApplicationContext()
-                            .getResources()
-                            .getString(R.string.rum_version);
-                },
-                "unknown");
     }
 
     private static String trapTo(Supplier<String> fn, String defaultValue) {

--- a/instrumentation/src/test/java/io/opentelemetry/android/AndroidResourceTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/AndroidResourceTest.java
@@ -31,7 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class AndroidResourceTest {
 
     String appName = "robotron";
-    String rumSdkVersion = "1.2.3";
+    String rumSdkVersion = BuildConfig.OTEL_ANDROID_VERSION;
     String osDescription =
             new StringBuilder()
                     .append("Android Version ")
@@ -53,8 +53,6 @@ class AndroidResourceTest {
 
         when(app.getApplicationContext().getApplicationInfo()).thenReturn(appInfo);
         when(app.getApplicationContext().getString(appInfo.labelRes)).thenReturn(appName);
-        when(app.getApplicationContext().getResources().getString(R.string.rum_version))
-                .thenReturn(rumSdkVersion);
 
         Resource expected =
                 Resource.getDefault()
@@ -86,7 +84,7 @@ class AndroidResourceTest {
                         .merge(
                                 Resource.builder()
                                         .put(SERVICE_NAME, "unknown_service:android")
-                                        .put(RUM_SDK_VERSION, "unknown")
+                                        .put(RUM_SDK_VERSION, rumSdkVersion)
                                         .put(DEVICE_MODEL_NAME, Build.MODEL)
                                         .put(DEVICE_MODEL_IDENTIFIER, Build.MODEL)
                                         .put(DEVICE_MANUFACTURER, Build.MANUFACTURER)


### PR DESCRIPTION
Resolves #7. This uses an AGP built-in to support for generating BuildConfig and adds the version number as a constant field. It then updates the AndroidResource to use this field instead of the resource string.

This also removes the `android.defaults.buildfeatures.buildconfig` deprecated gradle property.