### PR TITLE
Add missing javadocs on public methods

### DIFF
--- a/instrumentation/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
@@ -105,10 +105,17 @@ public class OtelRumConfig {
         this.diskBufferingConfiguration = diskBufferingConfiguration;
     }
 
+    /**
+     * Sets the configuration so that network change monitoring, which is enabled by default, will
+     * not be started.
+     */
     public void disableNetworkChangeMonitoring() {
         this.networkChangeMonitoringEnabled = false;
     }
 
+    /**
+     * @return true if network change monitoring is enabled (default).
+     */
     public boolean isNetworkChangeMonitoringEnabled() {
         return this.networkChangeMonitoringEnabled;
     }


### PR DESCRIPTION
Noticed that this public api surface was missing javadoc.