### PR TITLE
Make span debug logging a first-class config component

### DIFF
--- a/instrumentation/build.gradle.kts
+++ b/instrumentation/build.gradle.kts
@@ -70,6 +70,7 @@ dependencies {
     implementation(libs.opentelemetry.exporter.zipkin)
     implementation(libs.zipkin.sender.okhttp3)
     implementation(libs.opentelemetry.exporter.logging)
+    implementation(libs.opentelemetry.exporter.otlp)
     implementation(libs.opentelemetry.instrumentation.api)
     implementation(libs.opentelemetry.semconv)
     implementation(libs.opentelemetry.diskBuffering)

--- a/instrumentation/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
@@ -24,6 +24,7 @@ public class OtelRumConfig {
     private DiskBufferingConfiguration diskBufferingConfiguration =
             DiskBufferingConfiguration.builder().build();
     private boolean networkChangeMonitoringEnabled = true;
+    private boolean debugLogEnabled = false;
 
     /**
      * Configures the set of global attributes to emit with every span and event. Any existing
@@ -113,10 +114,18 @@ public class OtelRumConfig {
         this.networkChangeMonitoringEnabled = false;
     }
 
-    /**
-     * @return true if network change monitoring is enabled (default).
-     */
+    /** Returns true if network change monitoring is enabled (default). */
     public boolean isNetworkChangeMonitoringEnabled() {
         return this.networkChangeMonitoringEnabled;
+    }
+
+    /** Call this method to turn on debug/verbose telemetry logging. */
+    public void enableDebugLogging() {
+        this.debugLogEnabled = true;
+    }
+
+    /** Returns true if debug logging is enabled (default = false). */
+    public boolean isDebugLogEnabled() {
+        return this.debugLogEnabled;
     }
 }

--- a/instrumentation/src/main/java/io/opentelemetry/android/export/SpanDataModifier.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/export/SpanDataModifier.java
@@ -14,25 +14,16 @@ import java.util.function.Predicate;
 
 /**
  * A utility that can be used to create a SpanExporter that allows filtering and modification of
- * span data before it is sent to Allows modification of span data before it is sent to a delegate
+ * span data before it is sent. Allows modification of span data before it is sent to a delegate
  * exporter. Spans can be rejected entirely based on their name or attribute content, or their
  * attributes may be modified.
  */
 public final class SpanDataModifier {
 
-    private final SpanExporter delegate;
     private Predicate<String> rejectSpanNamesPredicate = spanName -> false;
     private final Map<AttributeKey<?>, Predicate<?>> rejectSpanAttributesPredicates =
             new HashMap<>();
     private final Map<AttributeKey<?>, Function<?, ?>> spanAttributeReplacements = new HashMap<>();
-
-    public static SpanDataModifier builder(SpanExporter delegate) {
-        return new SpanDataModifier(delegate);
-    }
-
-    private SpanDataModifier(SpanExporter delegate) {
-        this.delegate = delegate;
-    }
 
     /**
      * Remove matching spans from the exporter pipeline.
@@ -127,7 +118,7 @@ public final class SpanDataModifier {
         return this;
     }
 
-    public SpanExporter build() {
+    public SpanExporter wrap(SpanExporter delegate) {
         SpanExporter modifier = delegate;
         if (!spanAttributeReplacements.isEmpty()) {
             modifier =

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/InitializationEvents.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/InitializationEvents.java
@@ -17,6 +17,8 @@ public interface InitializationEvents {
 
     void networkMonitorInitialized();
 
+    void debugSpanExporterInitialized();
+
     InitializationEvents NO_OP =
             new InitializationEvents() {
                 @Override
@@ -30,5 +32,8 @@ public interface InitializationEvents {
 
                 @Override
                 public void networkMonitorInitialized() {}
+
+                @Override
+                public void debugSpanExporterInitialized() {}
             };
 }

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEvents.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEvents.java
@@ -26,6 +26,11 @@ public class SdkInitializationEvents implements InitializationEvents {
 
     @Override
     public void networkMonitorInitialized() {
-        // TOOD: Build me "networkMonitorInitialized"
+        // TODO: Build me "networkMonitorInitialized"
+    }
+
+    @Override
+    public void debugSpanExporterInitialized() {
+        // TODO: Build me "debugSpanExporterInitialized"
     }
 }

--- a/instrumentation/src/test/java/io/opentelemetry/android/export/SpanDataModifierTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/export/SpanDataModifierTest.java
@@ -45,10 +45,10 @@ class SpanDataModifierTest {
     void shouldRejectSpansByName() {
         // given
         SpanExporter underTest =
-                SpanDataModifier.builder(delegate)
+                new SpanDataModifier()
                         .rejectSpansByName(spanName -> spanName.equals("span2"))
                         .rejectSpansByName(spanName -> spanName.equals("span4"))
-                        .build();
+                        .wrap(delegate);
 
         SpanData span1 = TestSpanHelper.span("span1");
         SpanData span2 = TestSpanHelper.span("span2");
@@ -74,11 +74,11 @@ class SpanDataModifierTest {
     void shouldRejectSpansByAttributeValue() {
         // given
         SpanExporter underTest =
-                SpanDataModifier.builder(delegate)
+                new SpanDataModifier()
                         .rejectSpansByAttributeValue(ATTRIBUTE, value -> value.equals("test"))
                         .rejectSpansByAttributeValue(ATTRIBUTE, value -> value.equals("rejected!"))
                         .rejectSpansByAttributeValue(LONG_ATTRIBUTE, value -> value > 100)
-                        .build();
+                        .wrap(delegate);
 
         SpanData rejected = TestSpanHelper.span("span", Attributes.of(ATTRIBUTE, "test"));
         SpanData differentKey =
@@ -123,11 +123,11 @@ class SpanDataModifierTest {
     void shouldRemoveSpanAttributes() {
         // given
         SpanExporter underTest =
-                SpanDataModifier.builder(delegate)
+                new SpanDataModifier()
                         .removeSpanAttribute(ATTRIBUTE, value -> value.equals("test"))
                         // make sure that attribute types are taken into account
                         .removeSpanAttribute(stringKey("long_attribute"))
-                        .build();
+                        .wrap(delegate);
 
         SpanData span1 =
                 TestSpanHelper.span("first", Attributes.of(ATTRIBUTE, "test", LONG_ATTRIBUTE, 42L));
@@ -158,13 +158,13 @@ class SpanDataModifierTest {
     void shouldReplaceSpanAttributes() {
         // given
         SpanExporter underTest =
-                SpanDataModifier.builder(delegate)
+                new SpanDataModifier()
                         .replaceSpanAttribute(ATTRIBUTE, value -> value + "!!!")
                         .replaceSpanAttribute(ATTRIBUTE, value -> value + "1")
                         .replaceSpanAttribute(LONG_ATTRIBUTE, value -> value + 1)
                         // make sure that attribute types are taken into account
                         .replaceSpanAttribute(stringKey("long_attribute"), value -> "abc")
-                        .build();
+                        .wrap(delegate);
 
         SpanData span1 =
                 TestSpanHelper.span("first", Attributes.of(ATTRIBUTE, "test", LONG_ATTRIBUTE, 42L));
@@ -193,9 +193,9 @@ class SpanDataModifierTest {
     void shouldReplaceSpanAttributes_removeAttributeByReturningNull() {
         // given
         SpanExporter underTest =
-                SpanDataModifier.builder(delegate)
+                new SpanDataModifier()
                         .replaceSpanAttribute(ATTRIBUTE, value -> null)
-                        .build();
+                        .wrap(delegate);
 
         SpanData span =
                 TestSpanHelper.span("first", Attributes.of(ATTRIBUTE, "test", LONG_ATTRIBUTE, 42L));
@@ -218,8 +218,8 @@ class SpanDataModifierTest {
     @Test
     void builderChangesShouldNotApplyToAlreadyDecoratedExporter() {
         // given
-        SpanDataModifier builder = SpanDataModifier.builder(delegate);
-        SpanExporter underTest = builder.build();
+        SpanDataModifier builder = new SpanDataModifier();
+        SpanExporter underTest = builder.wrap(delegate);
 
         builder.rejectSpansByName(spanName -> spanName.equals("span"))
                 .rejectSpansByAttributeValue(ATTRIBUTE, value -> true)
@@ -247,7 +247,7 @@ class SpanDataModifierTest {
 
     @Test
     void shouldDelegateCalls() {
-        SpanExporter underTest = SpanDataModifier.builder(delegate).build();
+        SpanExporter underTest = new SpanDataModifier().wrap(delegate);
 
         underTest.flush();
         verify(delegate).flush();


### PR DESCRIPTION
This is baby steps on #130.

It does include the otlp http exporter, but just uses the defaults (which is localhost, not what most android users will want 😄 ).

This allows us to first pull the logging exporter into a configurable setting that is disabled by default. When enabled, it wires up another separate span processor to do the logging. The logging exporter also has the customizer applied.