### PR TITLE
Additional instrumentation configs

### DIFF
--- a/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -18,6 +18,7 @@ import io.opentelemetry.android.instrumentation.anr.AnrDetector;
 import io.opentelemetry.android.instrumentation.network.CurrentNetworkProvider;
 import io.opentelemetry.android.instrumentation.network.NetworkAttributesSpanAppender;
 import io.opentelemetry.android.instrumentation.network.NetworkChangeMonitor;
+import io.opentelemetry.android.instrumentation.slowrendering.SlowRenderingDetector;
 import io.opentelemetry.android.instrumentation.startup.InitializationEvents;
 import io.opentelemetry.android.instrumentation.startup.SdkInitializationEvents;
 import io.opentelemetry.android.internal.features.persistence.DiskManager;
@@ -333,8 +334,18 @@ public final class OpenTelemetryRumBuilder {
                     });
         }
 
+        if (config.isSlowRenderingDetectionEnabled()) {
+            addInstrumentation(
+                    instrumentedApplication -> {
+                        SlowRenderingDetector.builder()
+                                .setSlowRenderingDetectionPollInterval(
+                                        config.getSlowRenderingDetectionPollInterval())
+                                .build()
+                                .installOn(instrumentedApplication);
+                        initializationEvents.slowRenderingDetectorInitialized();
+                    });
+        }
     }
-
 
     private CurrentNetworkProvider getOrCreateCurrentNetworkProvider() {
         if (currentNetworkProvider == null) {

--- a/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -357,7 +357,7 @@ public final class OpenTelemetryRumBuilder {
 
         // Add ANR detection if enabled
         if (config.isAnrDetectionEnabled()) {
-            Looper mainLooper = Looper.getMainLooper();
+            Looper mainLooper = application.getMainLooper();
             addInstrumentation(
                     instrumentedApplication -> {
                         AnrDetectorBuilder builder =

--- a/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -8,6 +8,7 @@ package io.opentelemetry.android;
 import static java.util.Objects.requireNonNull;
 
 import android.app.Application;
+import android.content.Context;
 import android.os.Looper;
 import android.util.Log;
 import io.opentelemetry.android.config.DiskBufferingConfiguration;
@@ -15,6 +16,9 @@ import io.opentelemetry.android.config.OtelRumConfig;
 import io.opentelemetry.android.instrumentation.InstrumentedApplication;
 import io.opentelemetry.android.instrumentation.activity.VisibleScreenTracker;
 import io.opentelemetry.android.instrumentation.anr.AnrDetector;
+import io.opentelemetry.android.instrumentation.anr.AnrDetectorBuilder;
+import io.opentelemetry.android.instrumentation.crash.CrashReporter;
+import io.opentelemetry.android.instrumentation.crash.CrashReporterBuilder;
 import io.opentelemetry.android.instrumentation.network.CurrentNetworkProvider;
 import io.opentelemetry.android.instrumentation.network.NetworkAttributesSpanAppender;
 import io.opentelemetry.android.instrumentation.network.NetworkChangeMonitor;
@@ -79,6 +83,8 @@ public final class OpenTelemetryRumBuilder {
     private Resource resource;
     @Nullable private CurrentNetworkProvider currentNetworkProvider = null;
     private InitializationEvents initializationEvents = InitializationEvents.NO_OP;
+    private Consumer<AnrDetectorBuilder> anrCustomizer = x -> {};
+    private Consumer<CrashReporterBuilder> crashReporterCustomizer = x -> {};
 
     private static TextMapPropagator buildDefaultPropagator() {
         return TextMapPropagator.composite(
@@ -145,6 +151,34 @@ public final class OpenTelemetryRumBuilder {
             BiFunction<SdkTracerProviderBuilder, Application, SdkTracerProviderBuilder>
                     customizer) {
         tracerProviderCustomizers.add(customizer);
+        return this;
+    }
+
+    /**
+     * Pass a Consumer that will receive the AnrDetectorBuilder in order to perform additional
+     * specific customizations. If ANR detection is disabled, this method is effectively a no-op.
+     *
+     * @param customizer A Consumer that will receive the {@link AnrDetectorBuilder} before the
+     *     {@link AnrDetector} is built.
+     * @return this.
+     */
+    public OpenTelemetryRumBuilder addAnrCustomization(Consumer<AnrDetectorBuilder> customizer) {
+        this.anrCustomizer = customizer;
+        return this;
+    }
+
+    /**
+     * Pass a Consumer that will receive the CrashReporterBuilder in order to perform additional
+     * specific customizations. If crash reporting is disabled via config, this method is
+     * effectively a no-op.
+     *
+     * @param customizer A Consumer that will recieve the {@link CrashReporterBuilder} before the
+     *     {@link CrashReporter} is built.
+     * @return this.
+     */
+    public OpenTelemetryRumBuilder addCrashReportingCustomization(
+            Consumer<CrashReporterBuilder> customizer) {
+        this.crashReporterCustomizer = customizer;
         return this;
     }
 
@@ -326,14 +360,15 @@ public final class OpenTelemetryRumBuilder {
             Looper mainLooper = Looper.getMainLooper();
             addInstrumentation(
                     instrumentedApplication -> {
-                        AnrDetector.builder()
-                                .setMainLooper(mainLooper)
-                                .build()
-                                .installOn(instrumentedApplication);
+                        AnrDetectorBuilder builder =
+                                AnrDetector.builder().setMainLooper(mainLooper);
+                        anrCustomizer.accept(builder);
+                        builder.build().installOn(instrumentedApplication);
                         initializationEvents.anrMonitorInitialized();
                     });
         }
 
+        // Enable slow rendering detection if enabled
         if (config.isSlowRenderingDetectionEnabled()) {
             addInstrumentation(
                     instrumentedApplication -> {
@@ -343,6 +378,23 @@ public final class OpenTelemetryRumBuilder {
                                 .build()
                                 .installOn(instrumentedApplication);
                         initializationEvents.slowRenderingDetectorInitialized();
+                    });
+        }
+
+        // Enable crash reporting instrumentation
+        if (config.isCrashReportingEnabled()) {
+            addInstrumentation(
+                    instrumentedApplication -> {
+                        Context context =
+                                instrumentedApplication.getApplication().getApplicationContext();
+                        CrashReporterBuilder builder =
+                                CrashReporter.builder()
+                                        .addAttributesExtractor(
+                                                RuntimeDetailsExtractor.create(context));
+                        crashReporterCustomizer.accept(builder);
+                        builder.build().installOn(instrumentedApplication);
+
+                        initializationEvents.crashReportingInitialized();
                     });
         }
     }

--- a/instrumentation/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
@@ -8,6 +8,7 @@ package io.opentelemetry.android.config;
 import io.opentelemetry.android.ScreenAttributesSpanProcessor;
 import io.opentelemetry.android.instrumentation.network.CurrentNetworkProvider;
 import io.opentelemetry.api.common.Attributes;
+import java.time.Duration;
 import java.util.function.Supplier;
 
 /**
@@ -17,6 +18,9 @@ import java.util.function.Supplier;
  */
 public class OtelRumConfig {
 
+    private static final Duration DEFAULT_SLOW_RENDERING_DETECTION_POLL_INTERVAL =
+            Duration.ofSeconds(1);
+
     private Supplier<Attributes> globalAttributesSupplier = Attributes::empty;
     private boolean includeNetworkAttributes = true;
     private boolean generateSdkInitializationEvents = true;
@@ -25,6 +29,9 @@ public class OtelRumConfig {
             DiskBufferingConfiguration.builder().build();
     private boolean networkChangeMonitoringEnabled = true;
     private boolean anrDetectionEnabled = true;
+    private boolean slowRenderingDetectionEnabled = true;
+    private Duration slowRenderingDetectionPollInterval =
+            DEFAULT_SLOW_RENDERING_DETECTION_POLL_INTERVAL;
 
     /**
      * Configures the set of global attributes to emit with every span and event. Any existing
@@ -71,7 +78,7 @@ public class OtelRumConfig {
      * @return this
      */
     public OtelRumConfig disableSdkInitializationEvents() {
-        this.generateSdkInitializationEvents = false;
+        generateSdkInitializationEvents = false;
         return this;
     }
 
@@ -87,7 +94,7 @@ public class OtelRumConfig {
      * @return this
      */
     public OtelRumConfig disableScreenAttributes() {
-        this.includeScreenAttributes = false;
+        includeScreenAttributes = false;
         return this;
     }
 
@@ -100,38 +107,73 @@ public class OtelRumConfig {
         return diskBufferingConfiguration;
     }
 
-    /** Sets the parameters for caching signals in disk in order to export them later. */
-    public void setDiskBufferingConfiguration(
+    /**
+     * Sets the parameters for caching signals in disk in order to export them later.
+     *
+     * @return this
+     */
+    public OtelRumConfig setDiskBufferingConfiguration(
             DiskBufferingConfiguration diskBufferingConfiguration) {
         this.diskBufferingConfiguration = diskBufferingConfiguration;
+        return this;
     }
 
     /**
      * Sets the configuration so that network change monitoring, which is enabled by default, will
      * not be started.
      */
-    public void disableNetworkChangeMonitoring() {
-        this.networkChangeMonitoringEnabled = false;
+    public OtelRumConfig disableNetworkChangeMonitoring() {
+        networkChangeMonitoringEnabled = false;
+        return this;
     }
 
-    /**
-     * Returns true if network change monitoring is enabled (default = true).
-     */
+    /** Returns true if network change monitoring is enabled (default = true). */
     public boolean isNetworkChangeMonitoringEnabled() {
-        return this.networkChangeMonitoringEnabled;
+        return networkChangeMonitoringEnabled;
     }
 
-    /**
-     * Returns true if ANR (application not responding) detection is enabled (default = true).
-     */
+    /** Returns true if ANR (application not responding) detection is enabled (default = true). */
     public boolean isAnrDetectionEnabled() {
-        return this.anrDetectionEnabled;
+        return anrDetectionEnabled;
     }
 
     /**
      * Call this method to disable ANR (application not responding) detection.
+     *
+     * @return this
      */
-    public void disableAnrDetection(){
-        this.anrDetectionEnabled = false;
+    public OtelRumConfig disableAnrDetection() {
+        anrDetectionEnabled = false;
+        return this;
+    }
+
+    /** Returns true if the slow rendering detection instrumentation is enabled. */
+    public boolean isSlowRenderingDetectionEnabled() {
+        return slowRenderingDetectionEnabled;
+    }
+
+    /**
+     * Call this method to disable the slow rendering detection instrumentation.
+     *
+     * @return this
+     */
+    public OtelRumConfig disableSlowRenderingDetection() {
+        slowRenderingDetectionEnabled = false;
+        return this;
+    }
+
+    /** Returns the Duration at which slow renders are polled. Default = 1s. */
+    public Duration getSlowRenderingDetectionPollInterval() {
+        return slowRenderingDetectionPollInterval;
+    }
+
+    /**
+     * Call this to configure the duration for polling for slow renders.
+     *
+     * @return this
+     */
+    public OtelRumConfig setSlowRenderingDetectionPollInterval(Duration duration) {
+        slowRenderingDetectionPollInterval = duration;
+        return this;
     }
 }

--- a/instrumentation/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
@@ -24,6 +24,7 @@ public class OtelRumConfig {
     private DiskBufferingConfiguration diskBufferingConfiguration =
             DiskBufferingConfiguration.builder().build();
     private boolean networkChangeMonitoringEnabled = true;
+    private boolean anrDetectionEnabled = true;
 
     /**
      * Configures the set of global attributes to emit with every span and event. Any existing
@@ -114,9 +115,23 @@ public class OtelRumConfig {
     }
 
     /**
-     * @return true if network change monitoring is enabled (default).
+     * Returns true if network change monitoring is enabled (default = true).
      */
     public boolean isNetworkChangeMonitoringEnabled() {
         return this.networkChangeMonitoringEnabled;
+    }
+
+    /**
+     * Returns true if ANR (application not responding) detection is enabled (default = true).
+     */
+    public boolean isAnrDetectionEnabled() {
+        return this.anrDetectionEnabled;
+    }
+
+    /**
+     * Call this method to disable ANR (application not responding) detection.
+     */
+    public void disableAnrDetection(){
+        this.anrDetectionEnabled = false;
     }
 }

--- a/instrumentation/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
@@ -32,6 +32,7 @@ public class OtelRumConfig {
     private boolean slowRenderingDetectionEnabled = true;
     private Duration slowRenderingDetectionPollInterval =
             DEFAULT_SLOW_RENDERING_DETECTION_POLL_INTERVAL;
+    private boolean crashReportingEnabled = true;
 
     /**
      * Configures the set of global attributes to emit with every span and event. Any existing
@@ -174,6 +175,17 @@ public class OtelRumConfig {
      */
     public OtelRumConfig setSlowRenderingDetectionPollInterval(Duration duration) {
         slowRenderingDetectionPollInterval = duration;
+        return this;
+    }
+
+    /** Returns true if crash reporting is enabled. */
+    public boolean isCrashReportingEnabled() {
+        return crashReportingEnabled;
+    }
+
+    /** Call this method to disable crash reporting. */
+    public OtelRumConfig disableCrashReporting() {
+        crashReportingEnabled = false;
         return this;
     }
 }

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/InitializationEvents.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/InitializationEvents.java
@@ -21,6 +21,8 @@ public interface InitializationEvents {
 
     void slowRenderingDetectorInitialized();
 
+    void crashReportingInitialized();
+
     InitializationEvents NO_OP =
             new InitializationEvents() {
                 @Override
@@ -40,5 +42,8 @@ public interface InitializationEvents {
 
                 @Override
                 public void slowRenderingDetectorInitialized() {}
+
+                @Override
+                public void crashReportingInitialized() {}
             };
 }

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/InitializationEvents.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/InitializationEvents.java
@@ -19,6 +19,8 @@ public interface InitializationEvents {
 
     void anrMonitorInitialized();
 
+    void slowRenderingDetectorInitialized();
+
     InitializationEvents NO_OP =
             new InitializationEvents() {
                 @Override
@@ -34,8 +36,9 @@ public interface InitializationEvents {
                 public void networkMonitorInitialized() {}
 
                 @Override
-                public void anrMonitorInitialized() {
+                public void anrMonitorInitialized() {}
 
-                }
+                @Override
+                public void slowRenderingDetectorInitialized() {}
             };
 }

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/InitializationEvents.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/InitializationEvents.java
@@ -17,6 +17,8 @@ public interface InitializationEvents {
 
     void networkMonitorInitialized();
 
+    void anrMonitorInitialized();
+
     InitializationEvents NO_OP =
             new InitializationEvents() {
                 @Override
@@ -30,5 +32,10 @@ public interface InitializationEvents {
 
                 @Override
                 public void networkMonitorInitialized() {}
+
+                @Override
+                public void anrMonitorInitialized() {
+
+                }
             };
 }

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEvents.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEvents.java
@@ -33,4 +33,14 @@ public class SdkInitializationEvents implements InitializationEvents {
     public void anrMonitorInitialized() {
         // TODO: Build me "anrMonitorInitialized"
     }
+
+    @Override
+    public void slowRenderingDetectorInitialized() {
+        // TODO: Build me "slowRenderingDetectorInitialized"
+    }
+
+    @Override
+    public void crashReportingInitialized() {
+        // TODO: Build me "crashReportingInitialized"
+    }
 }

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEvents.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEvents.java
@@ -26,6 +26,11 @@ public class SdkInitializationEvents implements InitializationEvents {
 
     @Override
     public void networkMonitorInitialized() {
-        // TOOD: Build me "networkMonitorInitialized"
+        // TODO: Build me "networkMonitorInitialized"
+    }
+
+    @Override
+    public void anrMonitorInitialized() {
+        // TODO: Build me "anrMonitorInitialized"
     }
 }

--- a/instrumentation/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import android.app.Activity;
 import android.app.Application;
+import android.os.Looper;
 import androidx.annotation.NonNull;
 import io.opentelemetry.android.config.DiskBufferingConfiguration;
 import io.opentelemetry.android.config.OtelRumConfig;
@@ -61,6 +62,7 @@ class OpenTelemetryRumBuilderTest {
     final InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
 
     @Mock Application application;
+    @Mock Looper looper;
     @Mock android.content.Context applicationContext;
     @Mock Activity activity;
     @Mock ApplicationStateListener listener;
@@ -70,6 +72,7 @@ class OpenTelemetryRumBuilderTest {
     @BeforeEach
     void setup() {
         when(application.getApplicationContext()).thenReturn(applicationContext);
+        when(application.getMainLooper()).thenReturn(looper);
     }
 
     @Test


### PR DESCRIPTION
Add configs and automatically wire up instrumentation for:

* ANR (application not responding) detector
* Crash reporting
* Slow rendering detection

All of these instrumentations will be enabled by default, and there are config methods to disable them. There is also config to specify the polling interval for slow rendering.

Furthermore, the `OpenTelemetryRumBuilder` also allows users to provide customizers for the `CrashReporterBuilder` and `AnrDetectorBuilder`. These can be used by users or 3rd party distributions in order to provide custom/specific attribute extraction. 