### PR TITLE
Adding default known http methods to the okhttp instrumentation

### DIFF
--- a/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/OkHttpInstrumentationConfig.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/OkHttpInstrumentationConfig.java
@@ -18,7 +18,7 @@ import java.util.Set;
 public final class OkHttpInstrumentationConfig {
     private static List<String> capturedRequestHeaders = new ArrayList<>();
     private static List<String> capturedResponseHeaders = new ArrayList<>();
-    private static Set<String> knownMethods = new HashSet<>();
+    private static Set<String> knownMethods = HttpConstants.KNOWN_METHODS;
     private static Map<String, String> peerServiceMapping = new HashMap<>();
     private static boolean emitExperimentalHttpClientMetrics;
 

--- a/auto-instrumentation/okhttp/okhttp-3.0/library/src/test/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/OkHttpInstrumentationConfigTest.java
+++ b/auto-instrumentation/okhttp/okhttp-3.0/library/src/test/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/OkHttpInstrumentationConfigTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.library.okhttp.v3_0;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class OkHttpInstrumentationConfigTest {
+    @Test
+    void validateDefaultHttpMethods() {
+        assertThat(OkHttpInstrumentationConfig.getKnownMethods())
+                .containsExactlyInAnyOrder(
+                        "CONNECT", "DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT",
+                        "TRACE");
+    }
+}


### PR DESCRIPTION
We're currently overriding the default known methods from [here](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/b3530840644cda051e101b688dd32ea964d213ce/instrumentation-api/src/main/java/io/opentelemetry/instrumentation/api/semconv/http/HttpClientAttributesExtractorBuilder.java#L37) with an empty list when initializing the OkHttp instrumenter [here](https://github.com/open-telemetry/opentelemetry-android/blob/d7d5045c8178b0a6069ae93c1cd0b11dc6641fe0/auto-instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttp3Singletons.java#L48).

These changes will make sure that, when no custom HTTP methods are provided, we go with the default methods as they are defined in the OTel Java Instrumentation API library.