### PR TITLE
Adding disk buffering, part 4

### DIFF
--- a/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -84,11 +84,10 @@ public final class OpenTelemetryRumBuilder {
 
     private Resource resource;
     @Nullable private CurrentNetworkProvider currentNetworkProvider = null;
-
+    @Nullable private SignalDiskExporter.Builder signalDiskExporterBuilder = null;
     private InitializationEvents initializationEvents = InitializationEvents.NO_OP;
     private Consumer<AnrDetectorBuilder> anrCustomizer = x -> {};
     private Consumer<CrashReporterBuilder> crashReporterCustomizer = x -> {};
-    @Nullable private SignalDiskExporter.Builder signalDiskExporterBuilder;
 
     private static TextMapPropagator buildDefaultPropagator() {
         return TextMapPropagator.composite(

--- a/instrumentation/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfiguration.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfiguration.java
@@ -5,16 +5,22 @@
 
 package io.opentelemetry.android.features.diskbuffering;
 
+import io.opentelemetry.android.features.diskbuffering.scheduler.DefaultExportScheduleHandler;
+import io.opentelemetry.android.features.diskbuffering.scheduler.DefaultExportScheduler;
+import io.opentelemetry.android.features.diskbuffering.scheduler.ExportScheduleHandler;
+
 /** Configuration for disk buffering. */
 public final class DiskBufferingConfiguration {
     private final boolean enabled;
     private final int maxCacheSize;
+    private final ExportScheduleHandler exportScheduleHandler;
     private static final int DEFAULT_MAX_CACHE_SIZE = 60 * 1024 * 1024;
     private static final int MAX_FILE_SIZE = 1024 * 1024;
 
     private DiskBufferingConfiguration(Builder builder) {
         this.enabled = builder.enabled;
         this.maxCacheSize = builder.maxCacheSize;
+        this.exportScheduleHandler = builder.exportScheduleHandler;
     }
 
     public static Builder builder() {
@@ -33,9 +39,15 @@ public final class DiskBufferingConfiguration {
         return MAX_FILE_SIZE;
     }
 
+    public ExportScheduleHandler getExportScheduleHandler() {
+        return exportScheduleHandler;
+    }
+
     public static final class Builder {
         private boolean enabled;
         private int maxCacheSize;
+        private ExportScheduleHandler exportScheduleHandler =
+                new DefaultExportScheduleHandler(new DefaultExportScheduler());
 
         private Builder(boolean enabled, int maxCacheSize) {
             this.enabled = enabled;
@@ -55,6 +67,15 @@ public final class DiskBufferingConfiguration {
          */
         public Builder setMaxCacheSize(int maxCacheSize) {
             this.maxCacheSize = maxCacheSize;
+            return this;
+        }
+
+        /**
+         * Sets a scheduler that will take care of periodically read data stored in disk and export
+         * it.
+         */
+        public Builder setExportScheduleHandler(ExportScheduleHandler exportScheduleHandler) {
+            this.exportScheduleHandler = exportScheduleHandler;
             return this;
         }
 

--- a/instrumentation/src/main/java/io/opentelemetry/android/features/diskbuffering/SignalDiskExporter.kt
+++ b/instrumentation/src/main/java/io/opentelemetry/android/features/diskbuffering/SignalDiskExporter.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.features.diskbuffering
+
+import androidx.annotation.WorkerThread
+import io.opentelemetry.contrib.disk.buffering.LogRecordDiskExporter
+import io.opentelemetry.contrib.disk.buffering.MetricDiskExporter
+import io.opentelemetry.contrib.disk.buffering.SpanDiskExporter
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+/**
+ * Entrypoint to read and export previously cached signals.
+ */
+class SignalDiskExporter internal constructor(
+    private val spanDiskExporter: SpanDiskExporter?,
+    private val metricDiskExporter: MetricDiskExporter?,
+    private val logRecordDiskExporter: LogRecordDiskExporter?,
+    private val exportTimeoutInMillis: Long,
+) {
+    @WorkerThread
+    @Throws(IOException::class)
+    fun exportBatchOfSpans(): Boolean {
+        return spanDiskExporter?.exportStoredBatch(
+            exportTimeoutInMillis,
+            TimeUnit.MILLISECONDS,
+        ) ?: false
+    }
+
+    @WorkerThread
+    @Throws(IOException::class)
+    fun exportBatchOfMetrics(): Boolean {
+        return metricDiskExporter?.exportStoredBatch(
+            exportTimeoutInMillis,
+            TimeUnit.MILLISECONDS,
+        ) ?: false
+    }
+
+    @WorkerThread
+    @Throws(IOException::class)
+    fun exportBatchOfLogs(): Boolean {
+        return logRecordDiskExporter?.exportStoredBatch(
+            exportTimeoutInMillis,
+            TimeUnit.MILLISECONDS,
+        ) ?: false
+    }
+
+    @WorkerThread
+    @Throws(IOException::class)
+    fun exportBatchOfEach(): Boolean {
+        var atLeastOneWorked = exportBatchOfSpans()
+        if (exportBatchOfMetrics()) {
+            atLeastOneWorked = true
+        }
+        if (exportBatchOfLogs()) {
+            atLeastOneWorked = true
+        }
+        return atLeastOneWorked
+    }
+
+    class Builder {
+        private var spanDiskExporter: SpanDiskExporter? = null
+        private var metricDiskExporter: MetricDiskExporter? = null
+        private var logRecordDiskExporter: LogRecordDiskExporter? = null
+        private var exportTimeoutInMillis = TimeUnit.SECONDS.toMillis(5)
+
+        fun setSpanDiskExporter(spanDiskExporter: SpanDiskExporter) =
+            apply {
+                this.spanDiskExporter = spanDiskExporter
+            }
+
+        fun setMetricDiskExporter(metricDiskExporter: MetricDiskExporter) =
+            apply {
+                this.metricDiskExporter = metricDiskExporter
+            }
+
+        fun setLogRecordDiskExporter(logRecordDiskExporter: LogRecordDiskExporter) =
+            apply {
+                this.logRecordDiskExporter = logRecordDiskExporter
+            }
+
+        fun setExportTimeoutInMillis(exportTimeoutInMillis: Long) =
+            apply {
+                this.exportTimeoutInMillis = exportTimeoutInMillis
+            }
+
+        fun build(): SignalDiskExporter {
+            return SignalDiskExporter(
+                spanDiskExporter,
+                metricDiskExporter,
+                logRecordDiskExporter,
+                exportTimeoutInMillis,
+            )
+        }
+    }
+
+    companion object {
+        private var instance: SignalDiskExporter? = null
+
+        @JvmStatic
+        fun get(): SignalDiskExporter? {
+            return instance
+        }
+
+        @JvmStatic
+        fun set(signalDiskExporter: SignalDiskExporter) {
+            check(instance == null) { "An instance is already set. You can only set it once." }
+            instance = signalDiskExporter
+        }
+
+        @JvmStatic
+        fun resetForTesting() {
+            instance = null
+        }
+
+        @Throws(IOException::class)
+        @JvmStatic
+        fun builder(): Builder {
+            return Builder()
+        }
+    }
+}

--- a/instrumentation/src/main/java/io/opentelemetry/android/features/diskbuffering/SignalDiskExporter.kt
+++ b/instrumentation/src/main/java/io/opentelemetry/android/features/diskbuffering/SignalDiskExporter.kt
@@ -21,6 +21,14 @@ class SignalDiskExporter internal constructor(
     private val logRecordDiskExporter: LogRecordDiskExporter?,
     private val exportTimeoutInMillis: Long,
 ) {
+    /**
+     * A batch contains all the signals that arrived in one call to [SpanDiskExporter.export]. So if
+     * that function is called 5 times, then there will be 5 batches in disk. This function reads
+     * and exports ONE batch every time is called.
+     *
+     * @return TRUE if it found data in disk and the exporter succeeded. FALSE if any of those conditions were
+     * not met.
+     */
     @WorkerThread
     @Throws(IOException::class)
     fun exportBatchOfSpans(): Boolean {
@@ -30,6 +38,14 @@ class SignalDiskExporter internal constructor(
         ) ?: false
     }
 
+    /**
+     * A batch contains all the signals that arrived in one call to [MetricDiskExporter.export]. So if
+     * that function is called 5 times, then there will be 5 batches in disk. This function reads
+     * and exports ONE batch every time is called.
+     *
+     * @return TRUE if it found data in disk and the exporter succeeded. FALSE if any of those conditions were
+     * not met.
+     */
     @WorkerThread
     @Throws(IOException::class)
     fun exportBatchOfMetrics(): Boolean {
@@ -39,6 +55,14 @@ class SignalDiskExporter internal constructor(
         ) ?: false
     }
 
+    /**
+     * A batch contains all the signals that arrived in one call to [LogRecordDiskExporter.export]. So if
+     * that function is called 5 times, then there will be 5 batches in disk. This function reads
+     * and exports ONE batch every time is called.
+     *
+     * @return TRUE if it found data in disk and the exporter succeeded. FALSE if any of those conditions were
+     * not met.
+     */
     @WorkerThread
     @Throws(IOException::class)
     fun exportBatchOfLogs(): Boolean {
@@ -48,6 +72,12 @@ class SignalDiskExporter internal constructor(
         ) ?: false
     }
 
+    /**
+     * Convenience method that attempts to export all kinds of signals from disk.
+     *
+     * @return TRUE if at least one of the signals were successfully exported, FALSE if no signal
+     * of any kind was exported.
+     */
     @WorkerThread
     @Throws(IOException::class)
     fun exportBatchOfEach(): Boolean {

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/InitializationEvents.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/InitializationEvents.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.android.instrumentation.startup;
 
 import io.opentelemetry.android.config.OtelRumConfig;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 public interface InitializationEvents {
 
@@ -22,6 +23,8 @@ public interface InitializationEvents {
     void slowRenderingDetectorInitialized();
 
     void crashReportingInitialized();
+
+    void spanExporterInitialized(SpanExporter spanExporter);
 
     InitializationEvents NO_OP =
             new InitializationEvents() {
@@ -45,5 +48,8 @@ public interface InitializationEvents {
 
                 @Override
                 public void crashReportingInitialized() {}
+
+                @Override
+                public void spanExporterInitialized(SpanExporter spanExporter) {}
             };
 }

--- a/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEvents.java
+++ b/instrumentation/src/main/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEvents.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.android.instrumentation.startup;
 
 import io.opentelemetry.android.config.OtelRumConfig;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
 
 public class SdkInitializationEvents implements InitializationEvents {
 
@@ -42,5 +43,10 @@ public class SdkInitializationEvents implements InitializationEvents {
     @Override
     public void crashReportingInitialized() {
         // TODO: Build me "crashReportingInitialized"
+    }
+
+    @Override
+    public void spanExporterInitialized(SpanExporter spanExporter) {
+        // TODO: Build me "spanExporterInitialized"
     }
 }

--- a/instrumentation/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/instrumentation/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -25,6 +25,7 @@ import android.os.Looper;
 import androidx.annotation.NonNull;
 import io.opentelemetry.android.config.OtelRumConfig;
 import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfiguration;
+import io.opentelemetry.android.features.diskbuffering.SignalDiskExporter;
 import io.opentelemetry.android.instrumentation.ApplicationStateListener;
 import io.opentelemetry.android.internal.services.CacheStorageService;
 import io.opentelemetry.android.internal.services.PreferencesService;
@@ -46,6 +47,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -73,6 +75,11 @@ class OpenTelemetryRumBuilderTest {
     void setup() {
         when(application.getApplicationContext()).thenReturn(applicationContext);
         when(application.getMainLooper()).thenReturn(looper);
+    }
+
+    @AfterEach
+    void tearDown() {
+        SignalDiskExporter.resetForTesting();
     }
 
     @Test
@@ -198,7 +205,7 @@ class OpenTelemetryRumBuilderTest {
                         })
                 .build();
 
-        assertThat(capturedExporter.get()).isInstanceOf(SpanDiskExporter.class);
+        assertThat(SignalDiskExporter.get()).isNotNull();
     }
 
     @Test
@@ -227,6 +234,7 @@ class OpenTelemetryRumBuilderTest {
                 .build();
 
         assertThat(capturedExporter.get()).isNotInstanceOf(SpanDiskExporter.class);
+        assertThat(SignalDiskExporter.get()).isNull();
     }
 
     @Test
@@ -242,6 +250,7 @@ class OpenTelemetryRumBuilderTest {
                 .build();
 
         assertThat(capturedExporter.get()).isNotInstanceOf(SpanDiskExporter.class);
+        assertThat(SignalDiskExporter.get()).isNull();
     }
 
     private static void setUpServiceManager(Service... services) {

--- a/instrumentation/src/test/java/io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportSchedulerTest.kt
+++ b/instrumentation/src/test/java/io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportSchedulerTest.kt
@@ -5,9 +5,16 @@
 
 package io.opentelemetry.android.features.diskbuffering.scheduler
 
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.opentelemetry.android.features.diskbuffering.SignalDiskExporter
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.fail
+import java.io.IOException
 import java.util.concurrent.TimeUnit
 
 class DefaultExportSchedulerTest {
@@ -16,6 +23,48 @@ class DefaultExportSchedulerTest {
     @BeforeEach
     fun setUp() {
         scheduler = DefaultExportScheduler()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SignalDiskExporter.resetForTesting()
+    }
+
+    @Test
+    fun `Try to export all available signals when running`() {
+        val signalDiskExporter = mockk<SignalDiskExporter>()
+        every { signalDiskExporter.exportBatchOfEach() }.returns(true).andThen(true).andThen(false)
+        SignalDiskExporter.set(signalDiskExporter)
+
+        scheduler.onRun()
+
+        verify(exactly = 3) {
+            signalDiskExporter.exportBatchOfEach()
+        }
+    }
+
+    @Test
+    fun `Avoid crashing when an exception happens during execution`() {
+        val signalDiskExporter = mockk<SignalDiskExporter>()
+        every { signalDiskExporter.exportBatchOfEach() }.throws(IOException())
+        SignalDiskExporter.set(signalDiskExporter)
+
+        try {
+            scheduler.onRun()
+        } catch (e: IOException) {
+            fail(e)
+        }
+    }
+
+    @Test
+    fun `Stop running if it can't export from disk`() {
+        assertThat(scheduler.shouldStopRunning()).isTrue()
+    }
+
+    @Test
+    fun `Continue to run if it can export from disk`() {
+        SignalDiskExporter.set(mockk())
+        assertThat(scheduler.shouldStopRunning()).isFalse()
     }
 
     @Test

--- a/instrumentation/src/test/java/io/opentelemetry/android/features/diskbuffering/scheduler/SignalDiskExporterTest.kt
+++ b/instrumentation/src/test/java/io/opentelemetry/android/features/diskbuffering/scheduler/SignalDiskExporterTest.kt
@@ -1,0 +1,177 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.features.diskbuffering.scheduler
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import io.opentelemetry.android.features.diskbuffering.SignalDiskExporter
+import io.opentelemetry.contrib.disk.buffering.LogRecordDiskExporter
+import io.opentelemetry.contrib.disk.buffering.MetricDiskExporter
+import io.opentelemetry.contrib.disk.buffering.SpanDiskExporter
+import io.opentelemetry.contrib.disk.buffering.StoredBatchExporter
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
+
+class SignalDiskExporterTest {
+    companion object {
+        private val DEFAULT_EXPORT_TIMEOUT_IN_MILLIS: Long = TimeUnit.SECONDS.toMillis(5)
+    }
+
+    @MockK
+    private lateinit var spanDiskExporter: SpanDiskExporter
+
+    @MockK
+    private lateinit var metricDiskExporter: MetricDiskExporter
+
+    @MockK
+    private lateinit var logRecordDiskExporter: LogRecordDiskExporter
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this)
+    }
+
+    @Test
+    fun `Verify exporting with custom timeout time`() {
+        val timeoutInMillis = TimeUnit.SECONDS.toMillis(10)
+        val instance =
+            createInstance(
+                spanDiskExporter,
+                metricDiskExporter,
+                logRecordDiskExporter,
+                timeoutInMillis,
+            )
+        every { spanDiskExporter.exportStoredBatch(any(), any()) }.returns(true)
+        assertThat(instance.exportBatchOfSpans()).isTrue()
+        verifyExportStoredBatchCall(spanDiskExporter, timeoutInMillis)
+    }
+
+    @Test
+    fun verifyExportingSpans() {
+        val instance = createInstance(spanDiskExporter, metricDiskExporter, logRecordDiskExporter)
+        every { spanDiskExporter.exportStoredBatch(any(), any()) }.returns(true)
+        assertThat(instance.exportBatchOfSpans()).isTrue()
+        verifyExportStoredBatchCall(spanDiskExporter, DEFAULT_EXPORT_TIMEOUT_IN_MILLIS)
+    }
+
+    @Test
+    fun verifyExportingMetrics() {
+        val instance = createInstance(spanDiskExporter, metricDiskExporter, logRecordDiskExporter)
+        every { metricDiskExporter.exportStoredBatch(any(), any()) }.returns(true)
+        assertThat(instance.exportBatchOfMetrics()).isTrue()
+        verifyExportStoredBatchCall(metricDiskExporter, DEFAULT_EXPORT_TIMEOUT_IN_MILLIS)
+    }
+
+    @Test
+    fun verifyExportingLogs() {
+        val instance = createInstance(spanDiskExporter, metricDiskExporter, logRecordDiskExporter)
+        every { logRecordDiskExporter.exportStoredBatch(any(), any()) }.returns(true)
+        assertThat(instance.exportBatchOfLogs()).isTrue()
+        verifyExportStoredBatchCall(logRecordDiskExporter, DEFAULT_EXPORT_TIMEOUT_IN_MILLIS)
+    }
+
+    @Test
+    fun verifyExportingEach_whenAllReturnFalse() {
+        val instance = createInstance(spanDiskExporter, metricDiskExporter, logRecordDiskExporter)
+        every { spanDiskExporter.exportStoredBatch(any(), any()) }.returns(false)
+        every { metricDiskExporter.exportStoredBatch(any(), any()) }.returns(false)
+        every { logRecordDiskExporter.exportStoredBatch(any(), any()) }.returns(false)
+        assertThat(instance.exportBatchOfEach()).isFalse()
+        verifyExportStoredBatchCall(spanDiskExporter, DEFAULT_EXPORT_TIMEOUT_IN_MILLIS)
+        verifyExportStoredBatchCall(metricDiskExporter, DEFAULT_EXPORT_TIMEOUT_IN_MILLIS)
+        verifyExportStoredBatchCall(logRecordDiskExporter, DEFAULT_EXPORT_TIMEOUT_IN_MILLIS)
+    }
+
+    @Test
+    fun verifyExportingEach_whenSpansReturnTrue() {
+        val instance = createInstance(spanDiskExporter, metricDiskExporter, logRecordDiskExporter)
+        every { spanDiskExporter.exportStoredBatch(any(), any()) }.returns(true)
+        every { metricDiskExporter.exportStoredBatch(any(), any()) }.returns(false)
+        every { logRecordDiskExporter.exportStoredBatch(any(), any()) }.returns(false)
+        assertThat(instance.exportBatchOfEach()).isTrue()
+        verifyExportStoredBatchCall(spanDiskExporter, DEFAULT_EXPORT_TIMEOUT_IN_MILLIS)
+        verifyExportStoredBatchCall(metricDiskExporter, DEFAULT_EXPORT_TIMEOUT_IN_MILLIS)
+        verifyExportStoredBatchCall(logRecordDiskExporter, DEFAULT_EXPORT_TIMEOUT_IN_MILLIS)
+    }
+
+    @Test
+    fun verifyExportingEach_whenMetricsReturnTrue() {
+        val instance = createInstance(spanDiskExporter, metricDiskExporter, logRecordDiskExporter)
+        every { spanDiskExporter.exportStoredBatch(any(), any()) }.returns(false)
+        every { metricDiskExporter.exportStoredBatch(any(), any()) }.returns(true)
+        every { logRecordDiskExporter.exportStoredBatch(any(), any()) }.returns(false)
+        assertThat(instance.exportBatchOfEach()).isTrue()
+        verifyExportStoredBatchCall(spanDiskExporter, DEFAULT_EXPORT_TIMEOUT_IN_MILLIS)
+        verifyExportStoredBatchCall(metricDiskExporter, DEFAULT_EXPORT_TIMEOUT_IN_MILLIS)
+        verifyExportStoredBatchCall(logRecordDiskExporter, DEFAULT_EXPORT_TIMEOUT_IN_MILLIS)
+    }
+
+    @Test
+    fun verifyExportingEach_whenLogsReturnTrue() {
+        val instance = createInstance(spanDiskExporter, metricDiskExporter, logRecordDiskExporter)
+        every { spanDiskExporter.exportStoredBatch(any(), any()) }.returns(false)
+        every { metricDiskExporter.exportStoredBatch(any(), any()) }.returns(false)
+        every { logRecordDiskExporter.exportStoredBatch(any(), any()) }.returns(true)
+        assertThat(instance.exportBatchOfEach()).isTrue()
+        verifyExportStoredBatchCall(spanDiskExporter, DEFAULT_EXPORT_TIMEOUT_IN_MILLIS)
+        verifyExportStoredBatchCall(metricDiskExporter, DEFAULT_EXPORT_TIMEOUT_IN_MILLIS)
+        verifyExportStoredBatchCall(logRecordDiskExporter, DEFAULT_EXPORT_TIMEOUT_IN_MILLIS)
+    }
+
+    @Test
+    fun whenSpansExporterIsNull_returnFalse() {
+        val instance = createInstance(null, metricDiskExporter, logRecordDiskExporter)
+        assertThat(instance.exportBatchOfSpans()).isFalse()
+    }
+
+    @Test
+    fun whenMetricsExporterIsNull_returnFalse() {
+        val instance = createInstance(spanDiskExporter, null, logRecordDiskExporter)
+        assertThat(instance.exportBatchOfMetrics()).isFalse()
+    }
+
+    @Test
+    fun whenLogsExporterIsNull_returnFalse() {
+        val instance = createInstance(spanDiskExporter, metricDiskExporter, null)
+        assertThat(instance.exportBatchOfLogs()).isFalse()
+    }
+
+    private fun verifyExportStoredBatchCall(
+        exporter: StoredBatchExporter,
+        timeoutInMillis: Long,
+    ) {
+        verify {
+            exporter.exportStoredBatch(timeoutInMillis, TimeUnit.MILLISECONDS)
+        }
+    }
+
+    private fun createInstance(
+        spanDiskExporter: SpanDiskExporter?,
+        metricDiskExporter: MetricDiskExporter?,
+        logRecordDiskExporter: LogRecordDiskExporter?,
+        exportTimeoutInMillis: Long? = null,
+    ): SignalDiskExporter {
+        val builder = SignalDiskExporter.builder()
+        if (spanDiskExporter != null) {
+            builder.setSpanDiskExporter(spanDiskExporter)
+        }
+        if (metricDiskExporter != null) {
+            builder.setMetricDiskExporter(metricDiskExporter)
+        }
+        if (logRecordDiskExporter != null) {
+            builder.setLogRecordDiskExporter(logRecordDiskExporter)
+        }
+        if (exportTimeoutInMillis != null) {
+            builder.setExportTimeoutInMillis(exportTimeoutInMillis)
+        }
+
+        return builder.build()
+    }
+}

--- a/instrumentation/src/test/java/io/opentelemetry/android/features/diskbuffering/scheduler/SignalDiskExporterTest.kt
+++ b/instrumentation/src/test/java/io/opentelemetry/android/features/diskbuffering/scheduler/SignalDiskExporterTest.kt
@@ -39,7 +39,7 @@ class SignalDiskExporterTest {
     }
 
     @Test
-    fun `Verify exporting with custom timeout time`() {
+    fun `Exporting with custom timeout time`() {
         val timeoutInMillis = TimeUnit.SECONDS.toMillis(10)
         val instance =
             createInstance(
@@ -54,7 +54,7 @@ class SignalDiskExporterTest {
     }
 
     @Test
-    fun verifyExportingSpans() {
+    fun `Verify exporting spans`() {
         val instance = createInstance(spanDiskExporter, metricDiskExporter, logRecordDiskExporter)
         every { spanDiskExporter.exportStoredBatch(any(), any()) }.returns(true)
         assertThat(instance.exportBatchOfSpans()).isTrue()
@@ -62,7 +62,7 @@ class SignalDiskExporterTest {
     }
 
     @Test
-    fun verifyExportingMetrics() {
+    fun `Verify exporting metrics`() {
         val instance = createInstance(spanDiskExporter, metricDiskExporter, logRecordDiskExporter)
         every { metricDiskExporter.exportStoredBatch(any(), any()) }.returns(true)
         assertThat(instance.exportBatchOfMetrics()).isTrue()
@@ -70,7 +70,7 @@ class SignalDiskExporterTest {
     }
 
     @Test
-    fun verifyExportingLogs() {
+    fun `Verify exporting logs`() {
         val instance = createInstance(spanDiskExporter, metricDiskExporter, logRecordDiskExporter)
         every { logRecordDiskExporter.exportStoredBatch(any(), any()) }.returns(true)
         assertThat(instance.exportBatchOfLogs()).isTrue()
@@ -78,7 +78,7 @@ class SignalDiskExporterTest {
     }
 
     @Test
-    fun verifyExportingEach_whenAllReturnFalse() {
+    fun `Return false when all exports fail`() {
         val instance = createInstance(spanDiskExporter, metricDiskExporter, logRecordDiskExporter)
         every { spanDiskExporter.exportStoredBatch(any(), any()) }.returns(false)
         every { metricDiskExporter.exportStoredBatch(any(), any()) }.returns(false)
@@ -90,7 +90,7 @@ class SignalDiskExporterTest {
     }
 
     @Test
-    fun verifyExportingEach_whenSpansReturnTrue() {
+    fun `Return true when spans export succeeds`() {
         val instance = createInstance(spanDiskExporter, metricDiskExporter, logRecordDiskExporter)
         every { spanDiskExporter.exportStoredBatch(any(), any()) }.returns(true)
         every { metricDiskExporter.exportStoredBatch(any(), any()) }.returns(false)
@@ -102,7 +102,7 @@ class SignalDiskExporterTest {
     }
 
     @Test
-    fun verifyExportingEach_whenMetricsReturnTrue() {
+    fun `Return true when metrics export succeeds`() {
         val instance = createInstance(spanDiskExporter, metricDiskExporter, logRecordDiskExporter)
         every { spanDiskExporter.exportStoredBatch(any(), any()) }.returns(false)
         every { metricDiskExporter.exportStoredBatch(any(), any()) }.returns(true)
@@ -114,7 +114,7 @@ class SignalDiskExporterTest {
     }
 
     @Test
-    fun verifyExportingEach_whenLogsReturnTrue() {
+    fun `Return true when logs export succeeds`() {
         val instance = createInstance(spanDiskExporter, metricDiskExporter, logRecordDiskExporter)
         every { spanDiskExporter.exportStoredBatch(any(), any()) }.returns(false)
         every { metricDiskExporter.exportStoredBatch(any(), any()) }.returns(false)
@@ -126,19 +126,19 @@ class SignalDiskExporterTest {
     }
 
     @Test
-    fun whenSpansExporterIsNull_returnFalse() {
+    fun `Return false when spans exporter is not available`() {
         val instance = createInstance(null, metricDiskExporter, logRecordDiskExporter)
         assertThat(instance.exportBatchOfSpans()).isFalse()
     }
 
     @Test
-    fun whenMetricsExporterIsNull_returnFalse() {
+    fun `Return false when metrics exporter is not available`() {
         val instance = createInstance(spanDiskExporter, null, logRecordDiskExporter)
         assertThat(instance.exportBatchOfMetrics()).isFalse()
     }
 
     @Test
-    fun whenLogsExporterIsNull_returnFalse() {
+    fun `Return false when logs exporter is not available`() {
         val instance = createInstance(spanDiskExporter, metricDiskExporter, null)
         assertThat(instance.exportBatchOfLogs()).isFalse()
     }


### PR DESCRIPTION
This is the final PR to get the first iteration of the disk buffering feature fully running.

The changes added here do the following:

- Providing config option to set custom `ExportScheduleHandler`s.
- Using `DefaultExportScheduleHandler` if none is set.
- Wrapping the final version (after customizers) of the `SpanExporter` into a `SpanDiskExporter` when disk buffering is enabled.
- Created `SignalDiskExporter` to handle the reading and exporting processes of all signals.
- Exporting all signals inside `DefaultExportScheduler`.