### PR TITLE
Setting minimum compileSdk version to 33

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@ android.useAndroidX=true
 
 android.minSdk=21
 android.targetSdk=23
-android.compileSdk=34
+android.compileSdk=33
 
 version=0.4.0
 group=io.opentelemetry.android

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,8 +13,8 @@ kotlin = "1.9.22"
 [libraries]
 opentelemetry-platform = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetry-alpha" }
 androidx-appcompat = "androidx.appcompat:appcompat:1.6.1"
-androidx-navigation-fragment = "androidx.navigation:navigation-fragment:2.7.6"
-androidx-core = "androidx.core:core:1.12.0"
+androidx-navigation-fragment = "androidx.navigation:navigation-fragment:2.6.0"
+androidx-core = "androidx.core:core:1.10.1"
 findbugs-jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 byteBuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "byteBuddy" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }


### PR DESCRIPTION
Android's compileSdk version `34` [uses Java 17 APIs](https://developer.android.com/build/jdks#compileSdk) which can cause compilation errors when using JDK 11 (at least it happened to me when using Robolectric in a project that depends on opentelemetry-android). I think the switch to a newer JDK version can be problematic for some projects, therefore I believe libs shouldn't enforce it (or at least not too soon), especially in this case where the AGP started to require Java 17 [fairly recently](https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes).

Another, less problematic, side effect of using compileSdk 34 is that it requires [upgrading Android Studio](https://developer.android.com/build/releases/gradle-plugin#api-level-support) which I know several users avoid doing for a while until they have no other choice, and I wouldn't like OTel Android to be that annoying dependency...

I'm up for using the latest compileSdk version if it's necessary but at the moment that doesn't seem to be the case, so it's probably best to avoid causing these kinds of issues unless we have a good reason for it.