### PR TITLE
Fix spotless warnings during build

### DIFF
--- a/buildSrc/src/main/kotlin/otel.spotless-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.spotless-conventions.gradle.kts
@@ -4,17 +4,17 @@ plugins {
     id("com.diffplug.spotless")
 }
 
-extensions.configure<SpotlessExtension>("spotless") {
+spotless {
     java {
         googleJavaFormat().aosp()
         licenseHeaderFile(rootProject.file("gradle/spotless.license.java"), "(package|import|public)")
         target("src/**/*.java")
     }
     plugins.withId("org.jetbrains.kotlin.jvm") {
-        configureKotlin(this@configure)
+        configureKotlin(this@spotless)
     }
     plugins.withId("org.jetbrains.kotlin.android") {
-        configureKotlin(this@configure)
+        configureKotlin(this@spotless)
     }
     kotlinGradle {
         ktlint()
@@ -35,6 +35,25 @@ extensions.configure<SpotlessExtension>("spotless") {
         indentWithSpaces()
         trimTrailingWhitespace()
         endWithNewline()
+    }
+}
+
+// Use root declared tool deps to avoid issues with high concurrency.
+// see https://github.com/diffplug/spotless/tree/main/plugin-gradle#dependency-resolution-modes
+if (project == rootProject) {
+    spotless {
+        predeclareDeps()
+    }
+    with(extensions["spotlessPredeclare"] as SpotlessExtension) {
+        java {
+            googleJavaFormat()
+        }
+        kotlin {
+            ktlint()
+        }
+        kotlinGradle {
+            ktlint()
+        }
     }
 }
 


### PR DESCRIPTION
The build output in GHA is generating a lot of warnings like this:

```
"Install Android SDK Platform-Tools v.35.0.1" finished.
Configuration 'spotless996156776' was resolved during configuration time.
This is a build performance and scalability issue.
See https://github.com/gradle/gradle/issues/2298
Run with --info for a stacktrace.
Configuration 'spotless865459188' was resolved during configuration time.
This is a build performance and scalability issue.
See https://github.com/gradle/gradle/issues/2298
Run with --info for a stacktrace.
Configuration 'spotless996156776' was resolved during configuration time.
This is a build performance and scalability issue.
See https://github.com/gradle/gradle/issues/2298
Run with --info for a stacktrace.
Configuration 'spotless865[45](https://github.com/open-telemetry/opentelemetry-android/actions/runs/8426861772/job/23076132602#step:4:46)9188' was resolved during configuration time.
This is a build performance and scalability issue.
See https://github.com/gradle/gradle/issues/2298
Run with --info for a stacktrace.
Configuration 'spotless865459188' was resolved during configuration time.
This is a build performance and scalability issue.
See https://github.com/gradle/gradle/issues/2298
Run with --info for a stacktrace.
Configuration 'spotless996156776' was resolved during configuration time.
This is a build performance and scalability issue.
See https://github.com/gradle/gradle/issues/2298
Run with --info for a stacktrace.
```

This change should resolve that by doing a pre-declaration of deps. 🤷🏻 
