### PR TITLE
Adding '-alpha' to all modules' versions

### DIFF
--- a/android-agent/build.gradle.kts
+++ b/android-agent/build.gradle.kts
@@ -1,11 +1,7 @@
-
 plugins {
     id("otel.android-library-conventions")
     id("otel.publish-conventions")
 }
-
-// This submodule is alpha and is not yet intended to be used by itself
-version = project.version.toString().replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
 
 android {
     namespace = "io.opentelemetry.android"

--- a/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -5,6 +5,8 @@ plugins {
     id("signing")
 }
 
+version = project.version.toString().replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
+
 val isARelease = System.getenv("CI") != null
 
 val android = extensions.findByType(LibraryExtension::class.java)


### PR DESCRIPTION
Right now the version of the released artifacts from this project don't match. The `android-agent` one has the format: `0.x.x-alpha`, while all the other modules have this other one: `0.x.x`.

These changes aim to change the version formatting of all the artifacts in this project to match the one used by `android-agent`, i.e. appending `-alpha` to it.