### PR TITLE
Update README re: desugaring

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,14 @@ of the [OpenTelemetry Java SDK](https://github.com/open-telemetry/opentelemetry-
 > If your project's minSdk is lower than 26, then you must enable
 > [corelib desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring).
 > See [#73](https://github.com/open-telemetry/opentelemetry-android/issues/73) for more information.
+> If your project's minSdk is lower than 24, in order to run instrumentation tests or run the app
+> built on debug, you must use AGP 8.3.0+ and set the `android.useFullClasspathForDexingTransform`
+> property in `gradle.properties` to `true` to ensure desugaring runs properly. For the full
+> context for this workaround, please see
+> [this issue](https://issuetracker.google.com/issues/230454566#comment18).
 
-For an overview of how to contribute, see the contributing guide in [CONTRIBUTING.md](CONTRIBUTING.md).
+For an overview of how to contribute, see the contributing guide
+in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 We are also available in the [#otel-android](https://cloud-native.slack.com/archives/C05J0T9K27Q)
 channel in the [CNCF slack](https://slack.cncf.io/). Please join us there for further discussions.
@@ -40,10 +46,10 @@ dependencies {
 }
 ```
 
-
 # Features
 
-This android library builds on top of the [OpenTelemetry Java SDK](https://github.com/open-telemetry/opentelemetry-java).
+This android library builds on top of
+the [OpenTelemetry Java SDK](https://github.com/open-telemetry/opentelemetry-java).
 Some of the additional features provided include:
 
 * Crash reporting
@@ -72,6 +78,9 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 - [Cesar Munoz](https://github.com/likethesalad), Elastic
 
 [ci-image]: https://github.com/open-telemetry/opentelemetry-android/actions/workflows/build.yaml/badge.svg
+
 [ci-url]: https://github.com/open-telemetry/opentelemetry-android/actions?query=workflow%3Abuild+branch%3Amain
+
 [maven-image]: https://maven-badges.herokuapp.com/maven-central/io.opentelemetry.android/instrumentation/badge.svg
+
 [maven-url]: https://maven-badges.herokuapp.com/maven-central/io.opentelemetry.android/instrumentation


### PR DESCRIPTION
Address issue #295 by updating the README to note the workaround required so desugaring on debug works properly to the Java semconv module's lack of direct dependency to the OTel Java API module.

If we want validate the workaround and ensure it keeps on working, I can add my instrumentation test and apply the workaround to the PR.

BTW, I'm not a big fan of the formatting, but I can't find a style guide to suggest something better. If you want me to turn the quoted paragraph to a call-out with two bullets or whatever, please let me know.

