### PR TITLE
Release branch settings

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -11,7 +11,14 @@ settings](https://github.com/open-telemetry/community/blob/main/docs/how-to-conf
 - Require branches to be up to date before merging: UNCHECKED
   (PR jobs take too long, and leaving this unchecked has not been a significant problem)
 
+### `release/*`
 
+Same settings as above for `main`, except:
+
+* Restrict pushes that create matching branches: UNCHECKED
+
+  (So that opentelemetrybot can create release branches)
+ 
 ## Secrets and variables > Actions
 
 * `GPG_PASSWORD` - stored in OpenTelemetry-Java 1Password

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,3 +40,13 @@ jobs:
     uses: ./.github/workflows/reusable-workflow-notification.yml
     with:
       success: ${{ needs.build.result == 'success' }}
+
+  required-status-check:
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - if: |
+          needs.build.result != 'success' ||
+        run: exit 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,5 +48,5 @@ jobs:
     if: always()
     steps:
       - if: |
-          needs.build.result != 'success' ||
+          needs.build.result != 'success'
         run: exit 1


### PR DESCRIPTION
So we need to set up branch protection on the `release/*` branches, and it will need to require `required-status-check` like the other java-based builds. 