### PR TITLE
Add the required-status-check to PR builds. 

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -15,3 +15,13 @@ jobs:
           java-version: 17
       - name: run gradle
         run: ./gradlew check
+
+  required-status-check:
+    needs:
+      - pr-checks
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - if: |
+          needs.pr-checks.result != 'success'
+        run: exit 1


### PR DESCRIPTION
In keeping consistency with the other projects, we have this new `required-status-check` requirement in the branch protection rules....but until this status is actually added to the PR builds, they will hang.