### PR TITLE
Fix how next version is calculated during pre-release

### DIFF
--- a/.github/workflows/prepare-release-branch.yml
+++ b/.github/workflows/prepare-release-branch.yml
@@ -89,7 +89,7 @@ jobs:
             echo "unexpected version: $version"
             exit 1
           fi
-          echo "NEXT_VERSION=${next_version}-SNAPSHOT" >> $GITHUB_ENV
+          echo "NEXT_VERSION=${next_version}" >> $GITHUB_ENV
           echo "VERSION=$version" >> $GITHUB_ENV
 
       - name: Update version


### PR DESCRIPTION
We append -SNAPSHOT in all non -Pfinal=true builds, so this is not needed.