### PR TITLE
Change name of output artifact used when creating GH release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cp android-agent/build/outputs/aar/opentelemetry-android.aar opentelemetry-android.aar
+          cp android-agent/build/outputs/aar/opentelemetry-android-release.aar opentelemetry-android.aar
           gh release create --target $GITHUB_REF_NAME \
                             --title "Version $VERSION" \
                             --notes-file /tmp/release-notes.txt \


### PR DESCRIPTION
So we have code in our build (https://github.com/open-telemetry/opentelemetry-android/blob/main/android-agent/build.gradle.kts#L36) that renames the release artifact to a plainly named artifact (`opentelemetry-android.aar`), but for some unknown reason in the publish cycle  (likely the incomprehensible and nightmarish complexities of the gradle build lifecycle) that step isn't happening I guess, or is happening later. 

See [this build failure from the last release](https://github.com/open-telemetry/opentelemetry-android/actions/runs/8808081467/job/24176448700#step:11:20) as an example.

Let's just copy the release artifact for release builds.