### PR TITLE
Change from fixed rate to fixed delay

### DIFF
--- a/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrDetectorToggler.java
+++ b/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrDetectorToggler.java
@@ -26,7 +26,7 @@ final class AnrDetectorToggler implements ApplicationStateListener {
     @Override
     public void onApplicationForegrounded() {
         if (future == null) {
-            future = anrScheduler.scheduleAtFixedRate(anrWatcher, 1, 1, TimeUnit.SECONDS);
+            future = anrScheduler.scheduleWithFixedDelay(anrWatcher, 1, 1, TimeUnit.SECONDS);
         }
     }
 

--- a/instrumentation/anr/src/test/java/io/opentelemetry/android/instrumentation/anr/AnrDetectorTest.java
+++ b/instrumentation/anr/src/test/java/io/opentelemetry/android/instrumentation/anr/AnrDetectorTest.java
@@ -44,7 +44,7 @@ class AnrDetectorTest {
 
         // verify that the ANR scheduler was started
         verify(scheduler)
-                .scheduleAtFixedRate(isA(AnrWatcher.class), eq(1L), eq(1L), eq(TimeUnit.SECONDS));
+                .scheduleWithFixedDelay(isA(AnrWatcher.class), eq(1L), eq(1L), eq(TimeUnit.SECONDS));
         // verify that an application listener was installed
         verify(instrumentedApplication)
                 .registerApplicationStateListener(isA(AnrDetectorToggler.class));

--- a/instrumentation/anr/src/test/java/io/opentelemetry/android/instrumentation/anr/AnrDetectorTogglerTest.java
+++ b/instrumentation/anr/src/test/java/io/opentelemetry/android/instrumentation/anr/AnrDetectorTogglerTest.java
@@ -29,18 +29,18 @@ class AnrDetectorTogglerTest {
 
     @Test
     void testOnApplicationForegrounded() {
-        doReturn(future).when(scheduler).scheduleAtFixedRate(anrWatcher, 1, 1, TimeUnit.SECONDS);
+        doReturn(future).when(scheduler).scheduleWithFixedDelay(anrWatcher, 1, 1, TimeUnit.SECONDS);
 
         underTest.onApplicationForegrounded();
         underTest.onApplicationForegrounded();
         underTest.onApplicationForegrounded();
 
-        verify(scheduler, times(1)).scheduleAtFixedRate(anrWatcher, 1, 1, TimeUnit.SECONDS);
+        verify(scheduler, times(1)).scheduleWithFixedDelay(anrWatcher, 1, 1, TimeUnit.SECONDS);
     }
 
     @Test
     void testOnApplicationBackgrounded() {
-        doReturn(future).when(scheduler).scheduleAtFixedRate(anrWatcher, 1, 1, TimeUnit.SECONDS);
+        doReturn(future).when(scheduler).scheduleWithFixedDelay(anrWatcher, 1, 1, TimeUnit.SECONDS);
 
         underTest.onApplicationForegrounded();
 

--- a/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderListener.java
+++ b/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderListener.java
@@ -85,7 +85,7 @@ class SlowRenderListener implements DefaultingActivityLifecycleCallbacks {
     // the returned future is very unlikely to fail
     @SuppressWarnings("FutureReturnValueIgnored")
     void start() {
-        executorService.scheduleAtFixedRate(
+        executorService.scheduleWithFixedDelay(
                 this::reportSlowRenders,
                 pollInterval.toMillis(),
                 pollInterval.toMillis(),

--- a/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderListenerTest.java
+++ b/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderListenerTest.java
@@ -147,7 +147,7 @@ public class SlowRenderListenerTest {
                             return null;
                         })
                 .when(exec)
-                .scheduleAtFixedRate(any(), eq(1001L), eq(1001L), eq(TimeUnit.MILLISECONDS));
+                .scheduleWithFixedDelay(any(), eq(1001L), eq(1001L), eq(TimeUnit.MILLISECONDS));
 
         SlowRenderListener testInstance =
                 new SlowRenderListener(tracer, exec, frameMetricsHandler, Duration.ofMillis(1001));


### PR DESCRIPTION
The linter is currently catching a problem with our use of `scheduleAtFixedRate`:

```
Error: Use of scheduleAtFixedRate is strongly discouraged because it can lead to unexpected behavior when Android processes become cached (tasks may unexpectedly execute hundreds or thousands of times in quick succession when a process changes from cached to uncached); prefer using scheduleWithFixedDelay [DiscouragedApi]
```

This PR changes it per the recommendation and should get the build passing again. I don't see anything immediately problematic with using delay instead of rate, and it will avoid problems in the cached case.