### PR TITLE
Don't fail the build for new AGP versions.

### DIFF
--- a/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
@@ -20,6 +20,7 @@ android {
         // A newer version of androidx.appcompat:appcompat than 1.3.1 is available: 1.4.1 [GradleDependency]
         // we rely on dependabot for dependency updates
         disable.add("GradleDependency")
+        disable.add("AndroidGradlePluginVersion")
     }
 
     compileOptions {


### PR DESCRIPTION
We're getting [build failures](https://github.com/open-telemetry/opentelemetry-android/actions/runs/8912859718/job/24477172062?pr=334) any time a new version of AGP is released. Let's not do that. Renovate will help alert us to the new version anyway.