### PR TITLE
Disabling compose kotlin checks

### DIFF
--- a/buildSrc/src/main/kotlin/otel.errorprone-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.errorprone-conventions.gradle.kts
@@ -43,6 +43,7 @@ tasks {
                     isEnabled.set(true)
                     isCompilingTestOnlyCode.set(false)
                 }
+                excludedPaths = ".*/build/generated/.*"
             }
 
             nullaway {

--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -42,6 +42,13 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.13"
     }
+    kotlinOptions {
+        freeCompilerArgs =
+            listOf(
+                "-P",
+                "plugin:androidx.compose.compiler.plugins.kotlin:suppressKotlinVersionCompatibilityCheck=true",
+            )
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Option to avoid [these](https://github.com/open-telemetry/opentelemetry-android/pull/342#issuecomment-2100040009) kinds of issues.

This option disables compose's kotlin checks, although the config to do so is not well documented (it's mostly properly "officially" mentioned [here](https://github.com/JetBrains/compose-multiplatform/issues/2459#issuecomment-1312185906)) - Although it seems like it might change in the future. The good thing about this approach though is that it's the one that requires the least amount of changes to work.

Another option is: https://github.com/open-telemetry/opentelemetry-android/pull/355