### PR TITLE
Remove targetSdk declaration

### DIFF
--- a/buildSrc/src/main/kotlin/otel.android-app-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.android-app-conventions.gradle.kts
@@ -14,7 +14,6 @@ android {
 
     defaultConfig {
         minSdk = (property("android.minSdk") as String).toInt()
-        targetSdk = (property("android.targetSdk") as String).toInt()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,6 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 
 android.minSdk=21
-android.targetSdk=23
 android.compileSdk=34
-
 version=0.6.0
 group=io.opentelemetry.android


### PR DESCRIPTION
Setting the `targetSdkVersion` is the domain of apps, not libraries. Given the project's `minSdkVersion` is 21, apps that target 21 should be able use it, so adding this is probably too restrictive as the manifest merging process will use the highest one, which would be 23, if we left this in, which would override what the app's setting stipuates.