### PR TITLE
Enable desugaring in debug for demo app

### DIFF
--- a/demo-app/gradle.properties
+++ b/demo-app/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
+android.useFullClasspathForDexingTransform=true


### PR DESCRIPTION
Make building the demo app in debug work by enabling the Gradle setting that makes desugaring work when minSdkVersion is set to < 24