### PR TITLE
Don't add artifacts to the GH release page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,12 +93,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          cp android-agent/build/outputs/aar/opentelemetry-android-release.aar opentelemetry-android.aar
           gh release create --target $GITHUB_REF_NAME \
                             --title "Version $VERSION" \
                             --notes-file /tmp/release-notes.txt \
-                            v$VERSION \
-                            opentelemetry-android.aar
+                            v$VERSION
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
We don't need them, and since we're so modular now it doesn't make as much since to just publish the agent/sdk thing alone.