### PR TITLE
Release docs update

### DIFF
--- a/.github/workflows/draft-change-log-entries.yaml
+++ b/.github/workflows/draft-change-log-entries.yaml
@@ -1,0 +1,12 @@
+name: Draft CHANGELOG entries for a release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  create_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run changelog draft script
+        run: sh .github/scripts/draft-change-log-entries.sh

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,8 @@ We first need to prepare the release. This creates a versioned release branch, T
 - Make sure that the `gradle.properties` version property is set to the value you want to release.
   This must be different than the most recent release number (typically one minor version increase).
 - Merge a pull request to `main` branch that updates the `CHANGELOG.md`.
-  - The heading for the unreleased entries must be `## Unreleased`.
+    - The heading for the unreleased entries must be `## Unreleased`.
+    - Use [this action](https://github.com/open-telemetry/opentelemetry-android/actions/workflows/draft-change-log-entries.yaml) as a starting point for writing the change log. It will print a draft in the console that you can copy to create your PR for updating the `CHANGELOG.md` file.
 - Go to the
   [prepare-release-branch action](https://github.com/open-telemetry/opentelemetry-android/actions/workflows/prepare-release-branch.yml)
   in Github and click on "Run workflow".

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -12,7 +12,7 @@ We first need to prepare the release. This creates a versioned release branch, T
   This must be different than the most recent release number (typically one minor version increase).
 - Merge a pull request to `main` branch that updates the `CHANGELOG.md`.
     - The heading for the unreleased entries must be `## Unreleased`.
-    - Use [this action](https://github.com/open-telemetry/opentelemetry-android/actions/workflows/draft-change-log-entries.yaml) as a starting point for writing the change log. It will print a draft in the console that you can copy to create your PR for updating the `CHANGELOG.md` file.
+    - Use [this action](https://github.com/open-telemetry/opentelemetry-android/actions/workflows/draft-change-log-entries.yaml) as a starting point for writing the change log entries. It will print a draft in the console that you can copy to create your PR.
 - Go to the
   [prepare-release-branch action](https://github.com/open-telemetry/opentelemetry-android/actions/workflows/prepare-release-branch.yml)
   in Github and click on "Run workflow".


### PR DESCRIPTION
This is to provide a GH action to run the changelog draft script as well as updating the release instructions to mention it.