### PR TITLE
Upgrading Kotlin to 2.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
 }
 
 extra["java_version"] = JavaVersion.VERSION_1_8
-extra["kotlin_min_supported_version"] = KotlinVersion.KOTLIN_1_6
+extra["kotlin_min_supported_version"] = KotlinVersion.KOTLIN_1_7
 
 allprojects {
     repositories {

--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -4,6 +4,7 @@ import java.util.Properties
 plugins {
     alias(rootLibs.plugins.androidApp)
     alias(libs.plugins.kotlinAndroid)
+    alias(libs.plugins.compose.compiler)
 }
 
 val localProperties = Properties()
@@ -40,11 +41,7 @@ android {
         }
     }
     buildFeatures {
-        compose = true
         viewBinding = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.14"
     }
     val javaVersion = JavaVersion.VERSION_11
     compileOptions {

--- a/demo-app/gradle/libs.versions.toml
+++ b/demo-app/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 opentelemetry = "1.38.0"
 junit = "5.10.2"
 spotless = "6.25.0"
-kotlin = "1.9.24"
+kotlin = "2.0.0"
 
 [libraries]
 androidx-appcompat = "androidx.appcompat:appcompat:1.6.1"
@@ -41,3 +41,4 @@ junit = ["junit-jupiter-api", "junit-jupiter-engine", "junit-vintage-engine"]
 [plugins]
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ junit = "5.10.2"
 byteBuddy = "1.14.16"
 okhttp = "4.12.0"
 spotless = "6.25.0"
-kotlin = "1.9.24"
+kotlin = "2.0.0"
 androidPlugin = "8.4.1"
 
 [libraries]


### PR DESCRIPTION
Supersedes #380 

Using the new compose compiler plugin to fix compose version compatibilities with Kotlin 2.0.0. Also, the `1.6` min kotlin `languageVersion`/`apiVersion` has been marked as deprecated, so I've bumped it to the next minimum `1.7`.