### PR TITLE
Removing sh when running the script

### DIFF
--- a/.github/workflows/draft-change-log-entries.yaml
+++ b/.github/workflows/draft-change-log-entries.yaml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run changelog draft script
-        run: sh .github/scripts/draft-change-log-entries.sh
+        run: ./.github/scripts/draft-change-log-entries.sh


### PR DESCRIPTION
I gave it a [try](https://github.com/open-telemetry/opentelemetry-android/actions/runs/9315211335/job/25640903132) and it failed when evaluating the regex... I read that using `sh` might cause the script to not run with `bash` so, let's see.. (any feedback is appreciated, I'm not a bash expert).