### PR TITLE
Update semconv usages and reduce warning counts

### DIFF
--- a/android-agent/src/test/java/io/opentelemetry/android/AndroidResourceTest.java
+++ b/android-agent/src/test/java/io/opentelemetry/android/AndroidResourceTest.java
@@ -6,14 +6,14 @@
 package io.opentelemetry.android;
 
 import static io.opentelemetry.android.common.RumConstants.RUM_SDK_VERSION;
-import static io.opentelemetry.semconv.ResourceAttributes.DEVICE_MANUFACTURER;
-import static io.opentelemetry.semconv.ResourceAttributes.DEVICE_MODEL_IDENTIFIER;
-import static io.opentelemetry.semconv.ResourceAttributes.DEVICE_MODEL_NAME;
-import static io.opentelemetry.semconv.ResourceAttributes.OS_DESCRIPTION;
-import static io.opentelemetry.semconv.ResourceAttributes.OS_NAME;
-import static io.opentelemetry.semconv.ResourceAttributes.OS_TYPE;
-import static io.opentelemetry.semconv.ResourceAttributes.OS_VERSION;
-import static io.opentelemetry.semconv.ResourceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME;
+import static io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MANUFACTURER;
+import static io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MODEL_IDENTIFIER;
+import static io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MODEL_NAME;
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_DESCRIPTION;
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_NAME;
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_TYPE;
+import static io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_VERSION;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 

--- a/android-agent/src/test/java/io/opentelemetry/android/export/ModifiedSpanDataTest.java
+++ b/android-agent/src/test/java/io/opentelemetry/android/export/ModifiedSpanDataTest.java
@@ -16,7 +16,7 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceId;
 import io.opentelemetry.api.trace.TraceState;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.trace.TestSpanData;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -50,8 +50,10 @@ class ModifiedSpanDataTest {
                         .setTotalRecordedEvents(0)
                         .setTotalRecordedLinks(0)
                         .setTotalAttributeCount(12)
-                        .setInstrumentationLibraryInfo(
-                                InstrumentationLibraryInfo.create("test", "0.0.1"))
+                        .setInstrumentationScopeInfo(
+                                InstrumentationScopeInfo.builder("test")
+                                        .setVersion("0.0.1")
+                                        .build())
                         .setResource(Resource.getDefault())
                         .build();
 
@@ -73,7 +75,7 @@ class ModifiedSpanDataTest {
         assertEquals(original.getTotalRecordedLinks(), modified.getTotalRecordedLinks());
         assertEquals(1, modified.getTotalAttributeCount());
         assertEquals(
-                original.getInstrumentationLibraryInfo(), modified.getInstrumentationLibraryInfo());
+                original.getInstrumentationScopeInfo(), modified.getInstrumentationScopeInfo());
         assertEquals(original.getResource(), modified.getResource());
     }
 }

--- a/instrumentation/anr/src/test/java/io/opentelemetry/android/instrumentation/anr/StackTraceFormatterTest.java
+++ b/instrumentation/anr/src/test/java/io/opentelemetry/android/instrumentation/anr/StackTraceFormatterTest.java
@@ -6,11 +6,11 @@
 package io.opentelemetry.android.instrumentation.anr;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.context.Context;
-import io.opentelemetry.semconv.SemanticAttributes;
 import org.junit.jupiter.api.Test;
 
 class StackTraceFormatterTest {
@@ -30,7 +30,7 @@ class StackTraceFormatterTest {
         assertThat(startAttributes.build())
                 .hasSize(1)
                 .containsEntry(
-                        SemanticAttributes.EXCEPTION_STACKTRACE,
+                        EXCEPTION_STACKTRACE,
                         "a.b.Class.foo(/src/a/b/Class.java:42)\n"
                                 + "a.b.AnotherClass.bar(/src/a/b/AnotherClass.java:123)\n");
 

--- a/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReporterTest.java
+++ b/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReporterTest.java
@@ -17,7 +17,8 @@ import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions;
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension;
-import io.opentelemetry.semconv.SemanticAttributes;
+import io.opentelemetry.semconv.ExceptionAttributes;
+import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes;
 import java.util.List;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -70,13 +71,13 @@ class CrashReporterTest {
 
         Attributes crashAttributes = logRecords.get(0).getAttributes();
         OpenTelemetryAssertions.assertThat(crashAttributes)
-                .containsEntry(SemanticAttributes.EXCEPTION_ESCAPED, true)
-                .containsEntry(SemanticAttributes.EXCEPTION_MESSAGE, exceptionMessage)
-                .containsEntry(SemanticAttributes.EXCEPTION_TYPE, "java.lang.RuntimeException")
-                .containsEntry(SemanticAttributes.THREAD_ID, crashingThread.getId())
-                .containsEntry(SemanticAttributes.THREAD_NAME, crashingThread.getName())
+                .containsEntry(ExceptionAttributes.EXCEPTION_ESCAPED, true)
+                .containsEntry(ExceptionAttributes.EXCEPTION_MESSAGE, exceptionMessage)
+                .containsEntry(ExceptionAttributes.EXCEPTION_TYPE, "java.lang.RuntimeException")
+                .containsEntry(ThreadIncubatingAttributes.THREAD_ID, crashingThread.getId())
+                .containsEntry(ThreadIncubatingAttributes.THREAD_NAME, crashingThread.getName())
                 .containsEntry(stringKey("test.key"), "abc");
-        assertThat(crashAttributes.get(SemanticAttributes.EXCEPTION_STACKTRACE))
+        assertThat(crashAttributes.get(ExceptionAttributes.EXCEPTION_STACKTRACE))
                 .startsWith("java.lang.RuntimeException: boooom!");
     }
 }

--- a/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/CurrentNetworkAttributesExtractorTest.java
+++ b/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/CurrentNetworkAttributesExtractorTest.java
@@ -5,11 +5,16 @@
 
 package io.opentelemetry.android.instrumentation.network;
 
+import static io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes.NETWORK_CARRIER_ICC;
+import static io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes.NETWORK_CARRIER_MCC;
+import static io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes.NETWORK_CARRIER_MNC;
+import static io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes.NETWORK_CARRIER_NAME;
+import static io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes.NETWORK_CONNECTION_SUBTYPE;
+import static io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes.NETWORK_CONNECTION_TYPE;
 import static org.assertj.core.api.Assertions.entry;
 
 import android.os.Build;
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions;
-import io.opentelemetry.semconv.SemanticAttributes;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -38,12 +43,12 @@ public class CurrentNetworkAttributesExtractorTest {
 
         OpenTelemetryAssertions.assertThat(underTest.extract(currentNetwork))
                 .containsOnly(
-                        entry(SemanticAttributes.NETWORK_CONNECTION_TYPE, "cell"),
-                        entry(SemanticAttributes.NETWORK_CONNECTION_SUBTYPE, "aaa"),
-                        entry(SemanticAttributes.NETWORK_CARRIER_NAME, "ShadyTel"),
-                        entry(SemanticAttributes.NETWORK_CARRIER_ICC, "US"),
-                        entry(SemanticAttributes.NETWORK_CARRIER_MCC, "usa"),
-                        entry(SemanticAttributes.NETWORK_CARRIER_MNC, "omg"));
+                        entry(NETWORK_CONNECTION_TYPE, "cell"),
+                        entry(NETWORK_CONNECTION_SUBTYPE, "aaa"),
+                        entry(NETWORK_CARRIER_NAME, "ShadyTel"),
+                        entry(NETWORK_CARRIER_ICC, "US"),
+                        entry(NETWORK_CARRIER_MCC, "usa"),
+                        entry(NETWORK_CARRIER_MNC, "omg"));
     }
 
     @Config(sdk = Build.VERSION_CODES.O)
@@ -57,7 +62,7 @@ public class CurrentNetworkAttributesExtractorTest {
 
         OpenTelemetryAssertions.assertThat(underTest.extract(currentNetwork))
                 .containsOnly(
-                        entry(SemanticAttributes.NETWORK_CONNECTION_TYPE, "cell"),
-                        entry(SemanticAttributes.NETWORK_CONNECTION_SUBTYPE, "aaa"));
+                        entry(NETWORK_CONNECTION_TYPE, "cell"),
+                        entry(NETWORK_CONNECTION_SUBTYPE, "aaa"));
     }
 }

--- a/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkAttributesSpanAppenderTest.java
+++ b/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkAttributesSpanAppenderTest.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.android.instrumentation.network;
 
+import static io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes.NETWORK_CONNECTION_SUBTYPE;
+import static io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes.NETWORK_CONNECTION_TYPE;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
@@ -13,7 +15,6 @@ import static org.mockito.Mockito.when;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.sdk.trace.ReadWriteSpan;
-import io.opentelemetry.semconv.SemanticAttributes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -42,8 +43,8 @@ class NetworkAttributesSpanAppenderTest {
         verify(span)
                 .setAllAttributes(
                         Attributes.of(
-                                SemanticAttributes.NETWORK_CONNECTION_TYPE, "cell",
-                                SemanticAttributes.NETWORK_CONNECTION_SUBTYPE, "LTE"));
+                                NETWORK_CONNECTION_TYPE, "cell",
+                                NETWORK_CONNECTION_SUBTYPE, "LTE"));
 
         assertFalse(underTest.isEndRequired());
     }

--- a/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeMonitorTest.java
+++ b/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeMonitorTest.java
@@ -7,6 +7,12 @@ package io.opentelemetry.android.instrumentation.network;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes.NETWORK_CARRIER_ICC;
+import static io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes.NETWORK_CARRIER_MCC;
+import static io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes.NETWORK_CARRIER_MNC;
+import static io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes.NETWORK_CARRIER_NAME;
+import static io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes.NETWORK_CONNECTION_SUBTYPE;
+import static io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes.NETWORK_CONNECTION_TYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
@@ -18,7 +24,6 @@ import io.opentelemetry.android.instrumentation.common.InstrumentedApplication;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.SemanticAttributes;
 import java.util.List;
 import org.junit.After;
 import org.junit.Before;
@@ -74,7 +79,7 @@ public class NetworkChangeMonitorTest {
                 .hasName("network.change")
                 .hasAttributesSatisfyingExactly(
                         equalTo(NetworkApplicationListener.NETWORK_STATUS_KEY, "available"),
-                        equalTo(SemanticAttributes.NETWORK_CONNECTION_TYPE, "wifi"));
+                        equalTo(NETWORK_CONNECTION_TYPE, "wifi"));
     }
 
     @Test
@@ -106,12 +111,12 @@ public class NetworkChangeMonitorTest {
                 .hasName("network.change")
                 .hasAttributesSatisfyingExactly(
                         equalTo(NetworkApplicationListener.NETWORK_STATUS_KEY, "available"),
-                        equalTo(SemanticAttributes.NETWORK_CONNECTION_TYPE, "cell"),
-                        equalTo(SemanticAttributes.NETWORK_CONNECTION_SUBTYPE, "LTE"),
-                        equalTo(SemanticAttributes.NETWORK_CARRIER_NAME, "ShadyTel"),
-                        equalTo(SemanticAttributes.NETWORK_CARRIER_ICC, "US"),
-                        equalTo(SemanticAttributes.NETWORK_CARRIER_MCC, "usa"),
-                        equalTo(SemanticAttributes.NETWORK_CARRIER_MNC, "omg"));
+                        equalTo(NETWORK_CONNECTION_TYPE, "cell"),
+                        equalTo(NETWORK_CONNECTION_SUBTYPE, "LTE"),
+                        equalTo(NETWORK_CARRIER_NAME, "ShadyTel"),
+                        equalTo(NETWORK_CARRIER_ICC, "US"),
+                        equalTo(NETWORK_CARRIER_MCC, "usa"),
+                        equalTo(NETWORK_CARRIER_MNC, "omg"));
     }
 
     @Test
@@ -130,7 +135,7 @@ public class NetworkChangeMonitorTest {
                 .hasName("network.change")
                 .hasAttributesSatisfyingExactly(
                         equalTo(NetworkApplicationListener.NETWORK_STATUS_KEY, "lost"),
-                        equalTo(SemanticAttributes.NETWORK_CONNECTION_TYPE, "unavailable"));
+                        equalTo(NETWORK_CONNECTION_TYPE, "unavailable"));
     }
 
     @Test

--- a/instrumentation/volley/library/src/test/java/io/opentelemetry/android/instrumentation/volley/TracingHurlStackExceptionTest.java
+++ b/instrumentation/volley/library/src/test/java/io/opentelemetry/android/instrumentation/volley/TracingHurlStackExceptionTest.java
@@ -6,6 +6,8 @@
 package io.opentelemetry.android.instrumentation.volley;
 
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
+import static io.opentelemetry.semconv.ExceptionAttributes.*;
+import static io.opentelemetry.semconv.SemanticAttributes.EXCEPTION_EVENT_NAME;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.android.volley.Request;
@@ -14,7 +16,6 @@ import com.android.volley.toolbox.RequestFuture;
 import com.android.volley.toolbox.StringRequest;
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.SemanticAttributes;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.junit.After;
@@ -64,21 +65,18 @@ public class TracingHurlStackExceptionTest {
         assertThat(span)
                 .hasEventsSatisfyingExactly(
                         e ->
-                                e.hasName(SemanticAttributes.EXCEPTION_EVENT_NAME)
+                                e.hasName(EXCEPTION_EVENT_NAME)
                                         .hasAttributesSatisfying(
                                                 a ->
                                                         assertThat(a)
                                                                 .containsEntry(
-                                                                        SemanticAttributes
-                                                                                .EXCEPTION_TYPE,
+                                                                        EXCEPTION_TYPE,
                                                                         "java.lang.RuntimeException")
                                                                 .containsEntry(
-                                                                        SemanticAttributes
-                                                                                .EXCEPTION_MESSAGE,
+                                                                        EXCEPTION_MESSAGE,
                                                                         "Something went wrong")
                                                                 .containsKey(
-                                                                        SemanticAttributes
-                                                                                .EXCEPTION_STACKTRACE)));
+                                                                        EXCEPTION_STACKTRACE)));
     }
 
     static class FailingURLRewriter implements HurlStack.UrlRewriter {

--- a/instrumentation/volley/library/src/test/java/io/opentelemetry/android/instrumentation/volley/TracingHurlStackTest.java
+++ b/instrumentation/volley/library/src/test/java/io/opentelemetry/android/instrumentation/volley/TracingHurlStackTest.java
@@ -23,7 +23,11 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.data.StatusData;
+import io.opentelemetry.semconv.HttpAttributes;
 import io.opentelemetry.semconv.SemanticAttributes;
+import io.opentelemetry.semconv.ServerAttributes;
+import io.opentelemetry.semconv.UrlAttributes;
+import io.opentelemetry.semconv.incubating.HttpIncubatingAttributes;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.URL;
@@ -248,15 +252,14 @@ public class TracingHurlStackTest {
         assertThat(span.getKind()).isEqualTo(SpanKind.CLIENT);
 
         Attributes spanAttributes = span.getAttributes();
-        assertThat(spanAttributes.get(SemanticAttributes.HTTP_REQUEST_METHOD)).isEqualTo("GET");
-        assertThat(spanAttributes.get(SemanticAttributes.HTTP_RESPONSE_STATUS_CODE))
-                .isEqualTo(status);
-        assertThat(spanAttributes.get(SemanticAttributes.URL_FULL)).isEqualTo(url.toString());
-        assertThat(spanAttributes.get(SemanticAttributes.SERVER_PORT)).isEqualTo(url.getPort());
-        assertThat(spanAttributes.get(SemanticAttributes.SERVER_ADDRESS)).isEqualTo(url.getHost());
+        assertThat(spanAttributes.get(HttpAttributes.HTTP_REQUEST_METHOD)).isEqualTo("GET");
+        assertThat(spanAttributes.get(HttpAttributes.HTTP_RESPONSE_STATUS_CODE)).isEqualTo(status);
+        assertThat(spanAttributes.get(UrlAttributes.URL_FULL)).isEqualTo(url.toString());
+        assertThat(spanAttributes.get(ServerAttributes.SERVER_PORT)).isEqualTo(url.getPort());
+        assertThat(spanAttributes.get(ServerAttributes.SERVER_ADDRESS)).isEqualTo(url.getHost());
 
         if (responseBody != null) {
-            assertThat(span.getAttributes().get(SemanticAttributes.HTTP_RESPONSE_BODY_SIZE))
+            assertThat(span.getAttributes().get(HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE))
                     .isEqualTo(responseBody.length());
         }
     }

--- a/instrumentation/volley/library/src/test/java/io/opentelemetry/android/instrumentation/volley/VolleyResponseAttributesExtractorTest.java
+++ b/instrumentation/volley/library/src/test/java/io/opentelemetry/android/instrumentation/volley/VolleyResponseAttributesExtractorTest.java
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.android.instrumentation.volley;
 
-import static io.opentelemetry.semconv.SemanticAttributes.HTTP_RESPONSE_BODY_SIZE;
+import static io.opentelemetry.semconv.incubating.HttpIncubatingAttributes.HTTP_RESPONSE_BODY_SIZE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 


### PR DESCRIPTION
Quite a few deprecated usages updated here. Switching to the active/contemporary versions to avoid future breakage.