### PR TITLE
Actually call listeners

### DIFF
--- a/android-agent/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/android-agent/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -337,6 +337,8 @@ public final class OpenTelemetryRumBuilder {
                         .setPropagators(buildFinalPropagators())
                         .build();
 
+        otelSdkReadyListeners.forEach(listener -> listener.accept(sdk));
+
         scheduleDiskTelemetryReader(signalFromDiskExporter, diskBufferingConfiguration);
 
         SdkPreconfiguredRumBuilder delegate =

--- a/android-agent/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/android-agent/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -43,6 +43,7 @@ import io.opentelemetry.context.Scope;
 import io.opentelemetry.context.propagation.TextMapGetter;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.contrib.disk.buffering.SpanToDiskExporter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
 import io.opentelemetry.sdk.resources.Resource;
@@ -56,6 +57,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -254,6 +256,16 @@ class OpenTelemetryRumBuilderTest {
         verify(scheduleHandler).disable();
         assertThat(exporterCaptor.getValue()).isNotInstanceOf(SpanToDiskExporter.class);
         assertThat(SignalFromDiskExporter.get()).isNull();
+    }
+
+    @Test
+    void sdkReadyListeners(){
+        OtelRumConfig config = buildConfig();
+        AtomicReference<OpenTelemetrySdk> seen = new AtomicReference<>();
+        OpenTelemetryRum.builder(application, config)
+                .addOtelSdkReadyListener(seen::set)
+                .build(mock(ServiceManager.class));
+        assertThat(seen.get()).isNotNull();
     }
 
     @Test

--- a/android-agent/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/android-agent/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -259,7 +259,7 @@ class OpenTelemetryRumBuilderTest {
     }
 
     @Test
-    void sdkReadyListeners(){
+    void sdkReadyListeners() {
         OtelRumConfig config = buildConfig();
         AtomicReference<OpenTelemetrySdk> seen = new AtomicReference<>();
         OpenTelemetryRum.builder(application, config)

--- a/android-agent/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/android-agent/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -151,10 +151,6 @@ class OpenTelemetryRumBuilderTest {
         verify(listener).onApplicationBackgrounded();
     }
 
-    private OtelRumConfig buildConfig() {
-        return new OtelRumConfig().disableNetworkAttributes();
-    }
-
     @Test
     void canAddPropagator() {
         Context context = Context.root();
@@ -347,5 +343,9 @@ class OpenTelemetryRumBuilderTest {
     @NonNull
     private OpenTelemetryRumBuilder makeBuilder() {
         return OpenTelemetryRum.builder(application, buildConfig());
+    }
+
+    private OtelRumConfig buildConfig() {
+        return new OtelRumConfig().disableNetworkAttributes().disableSdkInitializationEvents();
     }
 }


### PR DESCRIPTION
As part of #397, we introduced listeners who can get notified immediately after the otel sdk is created. This is used when creating the initialization events, but users also have the ability to add. Unfortunately, we forgot to actually call the listeners!