### PR TITLE
Wire up logs export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Logs are now exported to stdout by default.
+* New method to customize log exporter: addLogRecordExporterCustomizer()
+
 ## Version 0.6.0 (2024-05-22)
 
 This version of OpenTelemetry Android is built on:

--- a/android-agent/build.gradle.kts
+++ b/android-agent/build.gradle.kts
@@ -79,6 +79,7 @@ dependencies {
     implementation(libs.opentelemetry.instrumentation.api)
     implementation(libs.opentelemetry.semconv.incubating)
     implementation(libs.opentelemetry.diskBuffering)
+    testImplementation(libs.opentelemetry.api.incubator)
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.awaitility)
     testImplementation(libs.robolectric)

--- a/demo-app/proguard-rules.pro
+++ b/demo-app/proguard-rules.pro
@@ -1,5 +1,6 @@
 -dontwarn com.fasterxml.jackson.core.JsonFactory
 -dontwarn com.fasterxml.jackson.core.JsonGenerator
--dontwarn com.google.auto.value.AutoValue$Builder
 -dontwarn com.google.auto.value.AutoValue
+-dontwarn com.google.auto.value.AutoValue$Builder
+-dontwarn com.google.auto.value.AutoValue$CopyAnnotations
 -dontwarn com.google.auto.value.extension.memoized.Memoized

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/OtelSampleApplication.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/OtelSampleApplication.kt
@@ -15,7 +15,9 @@ import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfiguratio
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
+import kotlin.math.log
 
 const val TAG = "otel.demo"
 
@@ -36,12 +38,18 @@ class OtelSampleApplication : Application() {
                 .setDiskBufferingConfiguration(diskBufferingConfig)
 
         // 10.0.2.2 is apparently a special binding to the host running the emulator
-        val ingestUrl = "http://10.0.2.2:4318/v1/traces"
+        val spansIngestUrl = "http://10.0.2.2:4318/v1/traces"
+        val logsIngestUrl = "http://10.0.2.2:4318/v1/logs"
         val otelRumBuilder: OpenTelemetryRumBuilder =
             OpenTelemetryRum.builder(this, config)
                 .addSpanExporterCustomizer {
                     OtlpHttpSpanExporter.builder()
-                        .setEndpoint(ingestUrl)
+                        .setEndpoint(spansIngestUrl)
+                        .build()
+                }
+                .addLogRecordExporterCustomizer {
+                    OtlpHttpLogRecordExporter.builder()
+                        .setEndpoint(logsIngestUrl)
                         .build()
                 }
         try {


### PR DESCRIPTION
This will rebase after #421 is merged. 

So far, logs export has been completely absent. In order for logs and events to make it out of the agent, we need logs to be wired up in some form. For now, just like spans, the basic default exporter just logs to the console (visible in logcat). This also adds a method that allows customization, which the demo app now uses to export to the emulator host.

I was able to use this to see events exported as logs in a locally running collector!

And just to be extra clear, this isn't really what #142 is asking for, because it doesn't bridge the android logger...it's just otel logs.