### PR TITLE
Docker compose servers

### DIFF
--- a/demo-app/README.md
+++ b/demo-app/README.md
@@ -4,7 +4,8 @@
 This is an app built to demonstrate how to configure and use the OpenTelemetry Android agent
 to observe app and user behavior.
 
-This is very much a work in progress.
+This is very much a work in progress. See the `OtelDemoApplication.kt` for 
+a quick and dirty example of how to get the agent initialized.
 
 ## Features
 
@@ -13,4 +14,12 @@ This is very much a work in progress.
 
 ## How to use
 
-* TBD
+First, start up the collector and jaeger with docker-compose:
+
+```bash
+$ docker-compose build
+$ docker-compose up
+```
+
+Then run the demo app in the Android emulator and navigate to http://localhost:16686
+to see the Jaeger UI.

--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -64,6 +64,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.androidx.navigation.fragment.ktx)
     implementation(libs.androidx.navigation.ui.ktx)
+    implementation(libs.opentelemetry.api.incubator)
 
     coreLibraryDesugaring(libs.desugarJdkLibs)
 

--- a/demo-app/collector.yaml
+++ b/demo-app/collector.yaml
@@ -1,0 +1,21 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+extensions:
+exporters:
+  otlphttp:
+    traces_endpoint: "http://jaeger:4318/v1/traces"
+  logging:
+    verbosity: normal
+  logging/debug:
+    verbosity: detailed
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [logging/debug, otlphttp]
+    logs:
+      receivers: [otlp]
+      exporters: [logging/debug]

--- a/demo-app/compose.yaml
+++ b/demo-app/compose.yaml
@@ -1,0 +1,16 @@
+services:
+  collector:
+    image: "otel/opentelemetry-collector-contrib"
+    volumes:
+      - ./collector.yaml:/etc/demo-collector.yaml
+    entrypoint: ["/otelcol-contrib"]
+    command: ["--config", "/etc/demo-collector.yaml"]
+    ports:
+      - "4317:4317" # OTLP gRPC
+      - "4318:4318" # OTLP HTTP
+  jaeger:
+    image: "jaegertracing/all-in-one:1.57"
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    ports:
+      - "16686:16686" # UI

--- a/demo-app/gradle/libs.versions.toml
+++ b/demo-app/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 opentelemetry = "1.39.0"
+opentelemetry-alpha = "1.39.0"
 junit = "5.10.2"
 spotless = "6.25.0"
 kotlin = "2.0.0"
@@ -7,7 +8,7 @@ kotlin = "2.0.0"
 [libraries]
 androidx-appcompat = "androidx.appcompat:appcompat:1.7.0"
 opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp", version.ref = "opentelemetry" }
-opentelemetry-api-incubator = { module = "io.opentelemetry:opentelemetry-api-incubator", version.ref = "opentelemetry" }
+opentelemetry-api-incubator = { module = "io.opentelemetry:opentelemetry-api-incubator", version.ref = "opentelemetry-alpha" }
 gson = "com.google.code.gson:gson:2.11.0"
 
 #Test tools

--- a/demo-app/gradle/libs.versions.toml
+++ b/demo-app/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ kotlin = "2.0.0"
 [libraries]
 androidx-appcompat = "androidx.appcompat:appcompat:1.7.0"
 opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp", version.ref = "opentelemetry" }
-opentelemetry-api-incubator = { module = "io.opentelemetry:opentelemetry-api-incubator" }
+opentelemetry-api-incubator = { module = "io.opentelemetry:opentelemetry-api-incubator", version.ref = "opentelemetry" }
 gson = "com.google.code.gson:gson:2.11.0"
 
 #Test tools

--- a/demo-app/gradle/libs.versions.toml
+++ b/demo-app/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 opentelemetry = "1.39.0"
-opentelemetry-alpha = "1.39.0"
+opentelemetry-alpha = "1.39.0-alpha"
 junit = "5.10.2"
 spotless = "6.25.0"
 kotlin = "2.0.0"

--- a/demo-app/gradle/libs.versions.toml
+++ b/demo-app/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ kotlin = "2.0.0"
 [libraries]
 androidx-appcompat = "androidx.appcompat:appcompat:1.7.0"
 opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp", version.ref = "opentelemetry" }
+opentelemetry-api-incubator = { module = "io.opentelemetry:opentelemetry-api-incubator" }
 gson = "com.google.code.gson:gson:2.11.0"
 
 #Test tools

--- a/demo-app/src/main/AndroidManifest.xml
+++ b/demo-app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-        android:name=".OtelSampleApplication"
+        android:name=".OtelDemoApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/DemoViewModel.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/DemoViewModel.kt
@@ -13,7 +13,7 @@ import kotlinx.coroutines.launch
 
 class DemoViewModel : ViewModel() {
     val sessionIdState = MutableStateFlow("? unknown ?")
-    private val tracer = OtelSampleApplication.tracer("otel.demo")!!
+    private val tracer = OtelDemoApplication.tracer("otel.demo")!!
 
     init {
         viewModelScope.launch {

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/MainActivity.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/MainActivity.kt
@@ -11,7 +11,6 @@ import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -81,6 +80,6 @@ class MainActivity : ComponentActivity() {
                 Log.d(TAG, "Main Activity started ")
             }
         }
-        viewModel.sessionIdState.value = OtelSampleApplication.rum?.rumSessionId!!
+        viewModel.sessionIdState.value = OtelDemoApplication.rum?.rumSessionId!!
     }
 }

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/MainOtelButton.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/MainOtelButton.kt
@@ -42,12 +42,6 @@ fun MainOtelButton(icon: Painter) {
 }
 
 fun generateClickEvent() {
-    // TODO: Make an actual otel event
-    val tracer = OtelSampleApplication.tracer("otel.demo")
-    val span =
-        tracer
-            ?.spanBuilder("logo.clicked")
-            ?.setSpanKind(SpanKind.INTERNAL)
-            ?.startSpan()
-    span?.end()
+    OtelDemoApplication.eventBuilder("otel.demo.app", "logo.clicked")
+        .emit()
 }

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/MainOtelButton.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/MainOtelButton.kt
@@ -42,6 +42,15 @@ fun MainOtelButton(icon: Painter) {
 }
 
 fun generateClickEvent() {
-    OtelDemoApplication.eventBuilder("otel.demo.app", "logo.clicked")
+    val scope = "otel.demo.app"
+    OtelDemoApplication.eventBuilder(scope, "logo.clicked")
         .emit()
+    // For now, we also emit a span, so that we can see something in a UI
+    val tracer = OtelDemoApplication.tracer(scope)
+    val span =
+        tracer
+            ?.spanBuilder("logo.clicked")
+            ?.setSpanKind(SpanKind.INTERNAL)
+            ?.startSpan()
+    span?.end()
 }

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/OtelDemoApplication.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/OtelDemoApplication.kt
@@ -14,14 +14,16 @@ import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfiguration
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.incubator.events.EventBuilder
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
+import io.opentelemetry.sdk.logs.internal.SdkEventLoggerProvider
 import kotlin.math.log
 
 const val TAG = "otel.demo"
 
-class OtelSampleApplication : Application() {
+class OtelDemoApplication : Application() {
     @SuppressLint("RestrictedApi")
     override fun onCreate() {
         super.onCreate()
@@ -65,6 +67,13 @@ class OtelSampleApplication : Application() {
 
         fun tracer(name: String): Tracer? {
             return rum?.openTelemetry?.tracerProvider?.get(name)
+        }
+
+        fun eventBuilder(scopeName: String, eventName: String): EventBuilder {
+            val loggerProvider = rum?.openTelemetry?.logsBridge
+            val eventLogger =
+                SdkEventLoggerProvider.create(loggerProvider).get(scopeName)
+            return eventLogger.builder(eventName)
         }
     }
 }


### PR DESCRIPTION
Resolves #345. This will rebase after #424.

It does a few more things with the demo app:

* Rename from `OtelSampleApplication` to `OtelDemoApplication` for consistency with project name (and otel demo)
* Wire up logs exporter
* Generate an event in addition to span for logo click on main page
* Add docker compose and collector configs
* Updates the README with instructions on how to start up the service(s).