### PR TITLE
:bug: fix for timer getting reset on retrival of session id

### DIFF
--- a/android-agent/src/main/java/io/opentelemetry/android/SessionId.java
+++ b/android-agent/src/main/java/io/opentelemetry/android/SessionId.java
@@ -62,9 +62,9 @@ class SessionId {
             }
             // value will never be null
             currentValue = requireNonNull(value.get());
+            timeoutHandler.bump();
         }
 
-        timeoutHandler.bump();
         // sessionId change listener needs to be called after bumping the timer because it may
         // create a new span
         SessionIdChangeListener sessionIdChangeListener = this.sessionIdChangeListener;


### PR DESCRIPTION
Whenever we are getting session id, timer for sessionid idle gets updated. Ideally the timer should be updated only when the session is expired or reached maxed timeout. 

Due to current behaviour, when accessing session id when app background the timer gets updated.