### PR TITLE
Tell the markdown link checker to ignore this localhost url

### DIFF
--- a/.github/scripts/markdown-link-check-config.json
+++ b/.github/scripts/markdown-link-check-config.json
@@ -4,5 +4,9 @@
     200,
     403
   ],
-  "ignorePatterns": []
+  "ignorePatterns": [
+    {
+      "pattern": "^http://localhost:16686$"
+    }
+  ]
 }


### PR DESCRIPTION
The demo app references this URL for the local jaeger service, but it fails the markdown link checker. This excludes it.