### PR TITLE
group the androidx.lifecycle dep updates for the demo app

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -49,6 +49,13 @@
         "^androidx.compose.compiler"
       ],
       "groupName": "kotlin"
+    },
+    {
+      "includePaths": ["demo-app/"],
+      "matchPackagePatterns": [
+        "^androidx.lifecycle"
+      ],
+      "groupName": "androidx.lifecycle"
     }
   ]
 }


### PR DESCRIPTION
See #491 and #492 and #493, which is what happens without this.