### PR TITLE
Update HttpUrlConnection androidTests to make them compatible for parallel running

### DIFF
--- a/instrumentation/httpurlconnection/testing/build.gradle.kts
+++ b/instrumentation/httpurlconnection/testing/build.gradle.kts
@@ -7,4 +7,5 @@ dependencies {
     byteBuddy(project(":instrumentation:httpurlconnection:agent"))
     implementation(project(":instrumentation:httpurlconnection:library"))
     implementation(project(":test-common"))
+    androidTestImplementation(libs.assertj.core)
 }

--- a/instrumentation/okhttp/okhttp-3.0/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/InstrumentationTest.java
+++ b/instrumentation/okhttp/okhttp-3.0/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/InstrumentationTest.java
@@ -30,6 +30,8 @@ import org.junit.Test;
 public class InstrumentationTest {
     private MockWebServer server;
     private static final InMemorySpanExporter inMemorySpanExporter = InMemorySpanExporter.create();
+    private static final OpenTelemetryTestUtils openTelemetryTestUtils =
+            new OpenTelemetryTestUtils();
 
     @Before
     public void setUp() throws IOException {
@@ -45,10 +47,10 @@ public class InstrumentationTest {
 
     @Test
     public void okhttpTraces() throws IOException {
-        OpenTelemetryTestUtils.setUpSpanExporter(inMemorySpanExporter);
+        openTelemetryTestUtils.setUpSpanExporter(inMemorySpanExporter);
         server.enqueue(new MockResponse().setResponseCode(200));
 
-        Span span = OpenTelemetryTestUtils.getSpan();
+        Span span = openTelemetryTestUtils.getSpan();
 
         try (Scope ignored = span.makeCurrent()) {
             OkHttpClient client =
@@ -72,9 +74,9 @@ public class InstrumentationTest {
 
     @Test
     public void okhttpTraces_with_callback() throws InterruptedException {
-        OpenTelemetryTestUtils.setUpSpanExporter(inMemorySpanExporter);
+        openTelemetryTestUtils.setUpSpanExporter(inMemorySpanExporter);
         CountDownLatch lock = new CountDownLatch(1);
-        Span span = OpenTelemetryTestUtils.getSpan();
+        Span span = openTelemetryTestUtils.getSpan();
 
         try (Scope ignored = span.makeCurrent()) {
             server.enqueue(new MockResponse().setResponseCode(200));
@@ -121,13 +123,13 @@ public class InstrumentationTest {
         // so it should be run isolated to actually get it to fail when it's expected to fail.
         OtlpHttpSpanExporter exporter =
                 OtlpHttpSpanExporter.builder().setEndpoint(server.url("").toString()).build();
-        OpenTelemetryTestUtils.setUpSpanExporter(exporter);
+        openTelemetryTestUtils.setUpSpanExporter(exporter);
 
         server.enqueue(new MockResponse().setResponseCode(200));
 
         // This span should trigger 1 export okhttp call, which is the only okhttp call expected
         // for this test case.
-        OpenTelemetryTestUtils.getSpan().end();
+        openTelemetryTestUtils.getSpan().end();
 
         // Wait for unwanted extra okhttp requests.
         int loop = 0;

--- a/test-common/src/main/kotlin/io/opentelemetry/android/test/common/OpenTelemetryTestUtils.kt
+++ b/test-common/src/main/kotlin/io/opentelemetry/android/test/common/OpenTelemetryTestUtils.kt
@@ -13,15 +13,13 @@ import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
 import io.opentelemetry.sdk.trace.export.SpanExporter
 
-object OpenTelemetryTestUtils {
+class OpenTelemetryTestUtils {
     lateinit var openTelemetry: OpenTelemetry
 
-    @JvmStatic
     fun getSpan(): Span {
         return openTelemetry.getTracer("TestTracer").spanBuilder("A Span").startSpan()
     }
 
-    @JvmStatic
     fun setUpSpanExporter(spanExporter: SpanExporter): OpenTelemetry {
         openTelemetry =
             OpenTelemetrySdk.builder()


### PR DESCRIPTION
Improving androidTests to make them compatible for running in parallel: 

- Tested by running them parallel in android studio:
<img width="1351" alt="Screenshot parallel run" src="https://github.com/user-attachments/assets/b572f067-02ff-4824-b72b-f955ac8d84ce">

- Tested synchronous run:
<img width="679" alt="Screenshot sync run" src="https://github.com/user-attachments/assets/88e67651-768e-4302-8e1a-88d7416c0b57">

- Also tested the actual instrumentation (non test scenario) works as expected. 

- No change for the Okhttp3 androidTests. They run correctly synchronously:
<img width="866" alt="Screenshot okhttp3 sync" src="https://github.com/user-attachments/assets/a4ca330b-c294-46ba-8fbd-b1695f08bac1">
