### PR TITLE
Cleanup httpurlconnection androidTests

### DIFF
--- a/instrumentation/httpurlconnection/library/src/main/java/io/opentelemetry/instrumentation/library/httpurlconnection/internal/HttpUrlConnectionSingletons.java
+++ b/instrumentation/httpurlconnection/library/src/main/java/io/opentelemetry/instrumentation/library/httpurlconnection/internal/HttpUrlConnectionSingletons.java
@@ -29,8 +29,7 @@ public final class HttpUrlConnectionSingletons {
     private static final Object lock = new Object();
     private static OpenTelemetry openTelemetryInstance;
 
-    public static Instrumenter<URLConnection, Integer> createInstrumenter(
-            OpenTelemetry opentelemetry) {
+    public static Instrumenter<URLConnection, Integer> createInstrumenter() {
 
         HttpUrlHttpAttributesGetter httpAttributesGetter = new HttpUrlHttpAttributesGetter();
 
@@ -53,7 +52,7 @@ public final class HttpUrlConnectionSingletons {
                                 httpAttributesGetter,
                                 HttpUrlInstrumentationConfig.newPeerServiceResolver());
 
-        openTelemetryInstance = (opentelemetry == null) ? GlobalOpenTelemetry.get() : opentelemetry;
+        openTelemetryInstance = GlobalOpenTelemetry.get();
 
         InstrumenterBuilder<URLConnection, Integer> builder =
                 Instrumenter.<URLConnection, Integer>builder(
@@ -79,7 +78,7 @@ public final class HttpUrlConnectionSingletons {
         if (instrumenter == null) {
             synchronized (lock) {
                 if (instrumenter == null) {
-                    instrumenter = createInstrumenter(null);
+                    instrumenter = createInstrumenter();
                 }
             }
         }
@@ -88,11 +87,6 @@ public final class HttpUrlConnectionSingletons {
 
     public static OpenTelemetry openTelemetryInstance() {
         return openTelemetryInstance;
-    }
-
-    // Used for setting the instrumenter for testing purposes only.
-    public static void setInstrumenterForTesting(OpenTelemetry opentelemetry) {
-        instrumenter = createInstrumenter(opentelemetry);
     }
 
     private HttpUrlConnectionSingletons() {}

--- a/instrumentation/httpurlconnection/testing/build.gradle.kts
+++ b/instrumentation/httpurlconnection/testing/build.gradle.kts
@@ -7,4 +7,5 @@ dependencies {
     byteBuddy(project(":instrumentation:httpurlconnection:agent"))
     implementation(project(":instrumentation:httpurlconnection:library"))
     implementation(project(":test-common"))
+    androidTestImplementation(libs.assertj.core)
 }

--- a/instrumentation/httpurlconnection/testing/src/androidTest/kotlin/io/opentelemetry/instrumentation/library/httpurlconnection/InstrumentationTest.kt
+++ b/instrumentation/httpurlconnection/testing/src/androidTest/kotlin/io/opentelemetry/instrumentation/library/httpurlconnection/InstrumentationTest.kt
@@ -8,54 +8,57 @@ package io.opentelemetry.instrumentation.library.httpurlconnection
 import io.opentelemetry.android.test.common.OpenTelemetryTestUtils
 import io.opentelemetry.instrumentation.library.httpurlconnection.HttpUrlConnectionTestUtil.executeGet
 import io.opentelemetry.instrumentation.library.httpurlconnection.HttpUrlConnectionTestUtil.post
-import io.opentelemetry.instrumentation.library.httpurlconnection.internal.HttpUrlConnectionSingletons
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
-import org.junit.Assert
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.fail
+import org.junit.After
+import org.junit.BeforeClass
 import org.junit.Test
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 class InstrumentationTest {
+    companion object {
+        private val inMemorySpanExporter: InMemorySpanExporter = InMemorySpanExporter.create()
+
+        @JvmStatic
+        @BeforeClass
+        fun setUpClass() {
+            OpenTelemetryTestUtils.setUpSpanExporter(inMemorySpanExporter)
+        }
+    }
+
+    @After
+    fun tearDown() {
+        inMemorySpanExporter.reset()
+    }
+
     @Test
     fun testHttpUrlConnectionGetRequest_ShouldBeTraced() {
-        val inMemorySpanExporter = InMemorySpanExporter.create()
-        HttpUrlConnectionSingletons.setInstrumenterForTesting(OpenTelemetryTestUtils.setUpSpanExporter(inMemorySpanExporter))
         executeGet("http://httpbin.org/get")
-        Assert.assertEquals(1, inMemorySpanExporter.finishedSpanItems.size)
-        inMemorySpanExporter.shutdown()
+        assertThat(inMemorySpanExporter.finishedSpanItems.size).isEqualTo(1)
     }
 
     @Test
     fun testHttpUrlConnectionPostRequest_ShouldBeTraced() {
-        val inMemorySpanExporter = InMemorySpanExporter.create()
-        HttpUrlConnectionSingletons.setInstrumenterForTesting(OpenTelemetryTestUtils.setUpSpanExporter(inMemorySpanExporter))
         post("http://httpbin.org/post")
-        Assert.assertEquals(1, inMemorySpanExporter.finishedSpanItems.size)
-        inMemorySpanExporter.shutdown()
+        assertThat(inMemorySpanExporter.finishedSpanItems.size).isEqualTo(1)
     }
 
     @Test
     fun testHttpUrlConnectionGetRequest_WhenNoStreamFetchedAndNoDisconnectCalled_ShouldNotBeTraced() {
-        val inMemorySpanExporter = InMemorySpanExporter.create()
-        HttpUrlConnectionSingletons.setInstrumenterForTesting(OpenTelemetryTestUtils.setUpSpanExporter(inMemorySpanExporter))
         executeGet("http://httpbin.org/get", false, false)
-        Assert.assertEquals(0, inMemorySpanExporter.finishedSpanItems.size)
-        inMemorySpanExporter.shutdown()
+        assertThat(inMemorySpanExporter.finishedSpanItems.size).isEqualTo(0)
     }
 
     @Test
     fun testHttpUrlConnectionGetRequest_WhenNoStreamFetchedButDisconnectCalled_ShouldBeTraced() {
-        val inMemorySpanExporter = InMemorySpanExporter.create()
-        HttpUrlConnectionSingletons.setInstrumenterForTesting(OpenTelemetryTestUtils.setUpSpanExporter(inMemorySpanExporter))
         executeGet("http://httpbin.org/get", false)
-        Assert.assertEquals(1, inMemorySpanExporter.finishedSpanItems.size)
-        inMemorySpanExporter.shutdown()
+        assertThat(inMemorySpanExporter.finishedSpanItems.size).isEqualTo(1)
     }
 
     @Test
     fun testHttpUrlConnectionGetRequest_WhenFourConcurrentRequestsAreMade_AllShouldBeTraced() {
-        val inMemorySpanExporter = InMemorySpanExporter.create()
-        HttpUrlConnectionSingletons.setInstrumenterForTesting(OpenTelemetryTestUtils.setUpSpanExporter(inMemorySpanExporter))
         val executor = Executors.newFixedThreadPool(4)
         try {
             executor.submit { executeGet("http://httpbin.org/get") }
@@ -67,10 +70,10 @@ class InstrumentationTest {
             // Wait for all tasks to finish execution or timeout
             if (executor.awaitTermination(2, TimeUnit.SECONDS)) {
                 // if all tasks finish before timeout
-                Assert.assertEquals(4, inMemorySpanExporter.finishedSpanItems.size)
+                assertThat(inMemorySpanExporter.finishedSpanItems.size).isEqualTo(4)
             } else {
                 // if all tasks don't finish before timeout
-                Assert.fail(
+                fail(
                     "Test could not be completed as tasks did not complete within the 2s timeout period.",
                 )
             }
@@ -78,19 +81,16 @@ class InstrumentationTest {
             // print stack trace to decipher lines that threw InterruptedException as it can be
             // possibly thrown by multiple calls above.
             e.printStackTrace()
-            Assert.fail("Test could not be completed due to an interrupted exception.")
+            fail("Test could not be completed due to an interrupted exception.")
         } finally {
             if (!executor.isShutdown) {
                 executor.shutdownNow()
             }
-            inMemorySpanExporter.shutdown()
         }
     }
 
     @Test
     fun testHttpUrlConnectionRequest_ContextPropagationHappensAsExpected() {
-        val inMemorySpanExporter = InMemorySpanExporter.create()
-        HttpUrlConnectionSingletons.setInstrumenterForTesting(OpenTelemetryTestUtils.setUpSpanExporter(inMemorySpanExporter))
         val parentSpan = OpenTelemetryTestUtils.getSpan()
 
         parentSpan.makeCurrent().use {
@@ -98,15 +98,11 @@ class InstrumentationTest {
             val spanDataList = inMemorySpanExporter.finishedSpanItems
             if (spanDataList.isNotEmpty()) {
                 val currentSpanData = spanDataList[0]
-                Assert.assertEquals(
-                    parentSpan.spanContext.traceId,
-                    currentSpanData.traceId,
-                )
+                assertThat(currentSpanData.traceId).isEqualTo(parentSpan.spanContext.traceId)
             }
         }
         parentSpan.end()
 
-        Assert.assertEquals(2, inMemorySpanExporter.finishedSpanItems.size)
-        inMemorySpanExporter.shutdown()
+        assertThat(inMemorySpanExporter.finishedSpanItems.size).isEqualTo(2)
     }
 }

--- a/test-common/src/main/kotlin/io/opentelemetry/android/test/common/OpenTelemetryTestUtils.kt
+++ b/test-common/src/main/kotlin/io/opentelemetry/android/test/common/OpenTelemetryTestUtils.kt
@@ -22,17 +22,14 @@ object OpenTelemetryTestUtils {
     }
 
     @JvmStatic
-    fun setUpSpanExporter(spanExporter: SpanExporter): OpenTelemetry {
+    fun setUpSpanExporter(spanExporter: SpanExporter) {
         openTelemetry =
             OpenTelemetrySdk.builder()
                 .setTracerProvider(getSimpleTracerProvider(spanExporter))
                 .build()
 
-        // TODO: Remove the bottom two lines after making okhttp3 androidTests parallel too.
         GlobalOpenTelemetry.resetForTest()
         GlobalOpenTelemetry.set(openTelemetry)
-
-        return openTelemetry
     }
 
     private fun getSimpleTracerProvider(spanExporter: SpanExporter): SdkTracerProvider {


### PR DESCRIPTION
 This PR cleans up httpurlconnection androidTests based on learnings and discussions from PR #452 and PR #500:

- Keep tests synchronous. 
- Address any open comments. 