### PR TITLE
Ensure the demo app collector is listening on all interfaces

### DIFF
--- a/demo-app/README.md
+++ b/demo-app/README.md
@@ -17,8 +17,8 @@ a quick and dirty example of how to get the agent initialized.
 First, start up the collector and jaeger with docker-compose:
 
 ```bash
-$ docker-compose build
-$ docker-compose up
+$ docker compose build
+$ docker compose up
 ```
 
 Then run the demo app in the Android emulator and navigate to http://localhost:16686

--- a/demo-app/compose.yaml
+++ b/demo-app/compose.yaml
@@ -12,5 +12,6 @@ services:
     image: "jaegertracing/all-in-one:1.59"
     environment:
       - COLLECTOR_OTLP_ENABLED=true
+      - COLLECTOR_OTLP_HTTP_HOST_PORT=0.0.0.0:4318
     ports:
       - "16686:16686" # UI


### PR DESCRIPTION
This workaround is required for containerization to work in the latest jaeger ([1.59](https://github.com/jaegertracing/jaeger/releases/tag/v1.59.0)).

Resovles #506 .