### PR TITLE
fix: add otlp protocols endpoints in demo-app collector config

### DIFF
--- a/demo-app/collector.yaml
+++ b/demo-app/collector.yaml
@@ -2,7 +2,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:4318
 extensions:
 exporters:
   otlphttp:


### PR DESCRIPTION
Added otlp protocols endpoints in demo-app collector config