### PR TITLE
Configure OTLP receiver to listen on 0.0.0.0

### DIFF
--- a/demo-app/collector.yaml
+++ b/demo-app/collector.yaml
@@ -2,7 +2,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:4318
 extensions:
 exporters:
   otlphttp:


### PR DESCRIPTION
This change configures the OTLP receiver in the demo application to listen on 0.0.0.0. Previously, this was part of the default config but changed since v0.104.0.

Related to #506.