### PR TITLE
remove proguard config for InstrumenationUtil

### DIFF
--- a/instrumentation/okhttp/okhttp-3.0/library/consumer-rules.pro
+++ b/instrumentation/okhttp/okhttp-3.0/library/consumer-rules.pro
@@ -1,1 +1,0 @@
--keep class io.opentelemetry.exporter.internal.InstrumentationUtil { *; }


### PR DESCRIPTION
With SDK 1.41.0 `io.opentelemetry.exporter.internal.InstrumentationUtil` is now deprecated and replaced with `io.opentelemetry.api.internal.InstrumentationUtil` directly in the API.

Update to the 1.41.0 SDK has been done in https://github.com/open-telemetry/opentelemetry-android/pull/521 and is now merged.

As a consequence, the proguard configuration is no more needed for this class.

@LikeTheSalad can you tell me if there is anything related to `InstrumentationUtil` usage that needs to be updated here ?