### PR TITLE
Keep sdk incubator same as core

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 opentelemetry = "1.41.0"
-opentelemetry-alpha = "1.38.0-alpha"
+opentelemetry-alpha = "1.41.0-alpha"
 opentelemetry-instrumentation = "2.7.0"
 opentelemetry-instrumentation-alpha = "2.7.0-alpha"
 opentelemetry-semconv = "1.25.0-alpha"


### PR DESCRIPTION
We need to keep the alpha dependencies from core at the same version as core.