### PR TITLE
start AppStart span when installing activity lifecycle instrumentation

### DIFF
--- a/instrumentation/activity/build.gradle.kts
+++ b/instrumentation/activity/build.gradle.kts
@@ -22,4 +22,5 @@ dependencies {
     implementation(libs.androidx.core)
     implementation(libs.androidx.navigation.fragment)
     implementation(libs.opentelemetry.instrumentation.api)
+    testImplementation(libs.robolectric)
 }

--- a/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentation.kt
+++ b/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentation.kt
@@ -35,6 +35,7 @@ class ActivityLifecycleInstrumentation : AndroidInstrumentation {
         application: Application,
         openTelemetryRum: OpenTelemetryRum,
     ) {
+        startupTimer.start(openTelemetryRum.openTelemetry.getTracer(INSTRUMENTATION_SCOPE))
         application.registerActivityLifecycleCallbacks(startupTimer.createLifecycleCallback())
         application.registerActivityLifecycleCallbacks(buildActivityLifecycleTracer(openTelemetryRum))
     }

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityInstrumentationTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityInstrumentationTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.activity
+
+import android.app.Application
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.common.RumConstants
+import io.opentelemetry.android.internal.services.ServiceManager.Companion
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanBuilder
+import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RuntimeEnvironment
+
+@RunWith(AndroidJUnit4::class)
+class ActivityInstrumentationTest {
+    private lateinit var activityLifecycleInstrumentation: ActivityLifecycleInstrumentation
+    private lateinit var application: Application
+    private lateinit var openTelemetryRum: OpenTelemetryRum
+    private lateinit var openTelemetry: OpenTelemetrySdk
+
+    @Before
+    fun setUp() {
+        application = RuntimeEnvironment.getApplication()
+        openTelemetry = mockk()
+        openTelemetryRum = mockk()
+        every { openTelemetryRum.openTelemetry }.returns(openTelemetry)
+        activityLifecycleInstrumentation = ActivityLifecycleInstrumentation()
+
+        Companion.initialize(application)
+    }
+
+    @Test
+    fun `Installing instrumentation starts AppStartupTimer`() {
+        val tracer: Tracer = mockk()
+        val startupSpanBuilder: SpanBuilder = mockk()
+        val startupSpan: Span = mockk()
+
+        every { openTelemetry.getTracer("io.opentelemetry.lifecycle") }.returns(tracer)
+        every { tracer.spanBuilder("AppStart") }.returns(startupSpanBuilder)
+        every { startupSpanBuilder.setStartTimestamp(any(), any()) }.returns(startupSpanBuilder)
+        every { startupSpanBuilder.setAttribute(RumConstants.START_TYPE_KEY, "cold") }.returns(
+            startupSpanBuilder,
+        )
+        every { startupSpanBuilder.startSpan() }.returns(startupSpan)
+
+        activityLifecycleInstrumentation.install(application, openTelemetryRum)
+
+        verify {
+            tracer.spanBuilder("AppStart")
+        }
+        verify {
+            startupSpanBuilder.setAttribute(RumConstants.START_TYPE_KEY, "cold")
+        }
+        verify {
+            startupSpanBuilder.startSpan()
+        }
+    }
+}


### PR DESCRIPTION
This fixes issue #560 by calling `AppStartupTimer#start` in `ActivityLifecycleInstrumentation#install`.

Since `start` is idempotent, this will still work if a way to pass in a pre-started timer to the instrumentation is added later.

Added tests based on `SlowRenderingInstrumentationTest`. To verify the changes:

`./gradlew :instrumentation:activity:testDebugUnitTest`
`./gradlew check`
