### PR TITLE
Group java core dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,6 +18,15 @@
       "allowedVersions": "!/\\-SNAPSHOT$/"
     },
     {
+      // Group updates from otel java core repo, so that x.y.z and x.y.z-alpha
+      // are updated together.
+      "matchPackageNames": [
+        "io.opentelemetry:opentelemetry-*",
+      ],
+      "extractVersion": "^(?<version>\\d+\\.\\d+\\.\\d+)(-alpha)?",
+      "groupName": "otel-core"
+    },
+    {
       // navigation-fragment 2.7.0 and above require android api 34+, which we are not ready for
       // yet due to android gradle plugin only supporting min 33.
       "matchPackagePrefixes": ["androidx.navigation"],


### PR DESCRIPTION
We currently have a state where renovate can push version updates for some of the core repos separately from the same `-alpha` artifacts. This can (and has) introduced breakage, so I think we should look at grouping the core versions with their alpha counterparts.