### PR TITLE
Demo App crash

### DIFF
--- a/demo-app/README.md
+++ b/demo-app/README.md
@@ -34,6 +34,11 @@ The OpenTelemetry Android Demo App currently supports the following features:
   - Provides detailed insights into each lifecycle phase.
   - Can be observed in the "About OpenTelemetry Android" activity, entered via "Learn more" on the main screen.
 
+* Crash Reporting  
+  - App crashes are automatically reported.
+  - In order to crash the demo app, try to add to cart exactly 10 National Park Foundation Explorascopes (first product on the list after clicking "Go shopping") and click "Yes, I'm sure." on the alert pop-up. This will cause a multi-threaded crash of the app.
+  - Note: The crash is reported as an event and isn't visible in the Jaeger UI, only in the collector output.
+
 * ANR Detection
   - Automatically detects and reports ANRs in the app.
   - ANR events are captured as spans with detailed stack traces, providing insights into the exact operations that caused the ANR.
@@ -52,9 +57,6 @@ The OpenTelemetry Android Demo App currently supports the following features:
 
 ### Known Gaps
 As of now, there are a few areas where the instrumentation might not be comprehensive:
-
-* Crash Reporting  
-App crashes are automatically reported, but the app currently does not include any features that intentionally trigger crashes.
 
 * HTTP Client Instrumentation  
 OpenTelemetry Android supports automatic instrumentation for HTTP client libraries. This feature captures spans for HTTP requests with details. However, the demo app does not currently demonstrate this feature as it doesn't make any network requests.

--- a/demo-app/README.md
+++ b/demo-app/README.md
@@ -35,7 +35,7 @@ The OpenTelemetry Android Demo App currently supports the following features:
   - Can be observed in the "About OpenTelemetry Android" activity, entered via "Learn more" on the main screen.
 
 * Crash Reporting  
-  - App crashes are automatically reported.
+  - Automatically detects and reports a crash of the application.
   - In order to crash the demo app, try to add to cart exactly 10 National Park Foundation Explorascopes (first product on the list after clicking "Go shopping") and click "Yes, I'm sure." on the alert pop-up. This will cause a multi-threaded crash of the app.
   - Note: The crash is reported as an event and isn't visible in the Jaeger UI, only in the collector output.
 

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/components/ConfirmCrashPopUp.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/components/ConfirmCrashPopUp.kt
@@ -17,7 +17,7 @@ fun ConfirmCrashPopup(
             Text(text = "Are you sure?")
         },
         text = {
-            Text(text = "This may crash the app.")
+            Text(text = "This will crash the app.")
         },
         confirmButton = {
             TextButton(onClick = { onConfirm() }) {

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/components/ConfirmCrashPopUp.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/components/ConfirmCrashPopUp.kt
@@ -5,9 +5,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 
-import androidx.compose.ui.tooling.preview.Preview
-
-
 @Composable
 fun ConfirmCrashPopup(
     onConfirm: () -> Unit,

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/components/ConfirmCrashPopUp.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/components/ConfirmCrashPopUp.kt
@@ -1,0 +1,36 @@
+package io.opentelemetry.android.demo.shop.ui.components
+
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+
+import androidx.compose.ui.tooling.preview.Preview
+
+
+@Composable
+fun ConfirmCrashPopup(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+
+    AlertDialog(
+        onDismissRequest = { onDismiss() },
+        title = {
+            Text(text = "Are you sure?")
+        },
+        text = {
+            Text(text = "This may crash the app.")
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm() }) {
+                Text(text = "Yes, I'm sure")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = { onDismiss() }) {
+                Text(text = "No, go back")
+            }
+        }
+    )
+}


### PR DESCRIPTION
May resolve #347.
Added a way to crash the demo app through unhandled exceptions and documented it. To invoke it, try adding to cart exactly 10 of the first product on the list. The way in which `multiThreadCrashing` function works is copied from the [splunk-otel-android sample app](https://github.com/signalfx/splunk-otel-android/tree/main/sample-app) function of the same name.