### PR TITLE
Explicitly enumerate core packages

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,12 +18,17 @@
       "allowedVersions": "!/\\-SNAPSHOT$/"
     },
     {
-      // Group updates from otel java core repo, so that x.y.z and x.y.z-alpha
-      // are updated together.
+      // Group updates from otel java core repo
       "matchPackageNames": [
-        "io.opentelemetry:opentelemetry-*",
+        "io.opentelemetry:opentelemetry-api",
+        "io.opentelemetry:opentelemetry-api-incubator",
+        "io.opentelemetry:opentelemetry-context",
+        "io.opentelemetry:opentelemetry-exporter-logging",
+        "io.opentelemetry:opentelemetry-exporter-otlp",
+        "io.opentelemetry:opentelemetry-sdk",
+        "io.opentelemetry:opentelemetry-sdk-testing",
+        "io.opentelemetry:opentelemetry-sdk-extension-incubator"
       ],
-      "extractVersion": "^(?<version>\\d+\\.\\d+\\.\\d+)(-alpha)?",
       "groupName": "otel-core"
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -29,6 +29,7 @@
         "io.opentelemetry:opentelemetry-sdk-testing",
         "io.opentelemetry:opentelemetry-sdk-extension-incubator"
       ],
+      "ignoreUnstable": false,
       "groupName": "otel-core"
     },
     {

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -6,6 +6,7 @@
   "packageRules": [
     {
       "matchPackageNames": [
+        "io.opentelemetry.contrib:opentelemetry-disk-buffering",
         "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha",
         "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator",
         "io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0"


### PR DESCRIPTION
The attempt in #582 did not work as expected, resulting in horrible renovate ideas like #585. 

So now we just explicitly list out all of the core packages, group them together, and tell renovate to not ignore unstable, which I think means to keep the alphas (and don't favor non-alphas).