### PR TITLE
Expose additional disk buffering configuration

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -333,12 +333,16 @@ public final class OpenTelemetryRumBuilder {
             throws IOException {
         Preferences preferences = serviceManager.getPreferences();
         CacheStorage storage = serviceManager.getCacheStorage();
+        DiskBufferingConfiguration config = this.config.getDiskBufferingConfiguration();
         DiskManager diskManager =
-                new DiskManager(storage, preferences, config.getDiskBufferingConfiguration());
+                new DiskManager(storage, preferences, config);
         return StorageConfiguration.builder()
+                .setRootDir(diskManager.getSignalsBufferDir())
                 .setMaxFileSize(diskManager.getMaxCacheFileSize())
                 .setMaxFolderSize(diskManager.getMaxFolderSize())
-                .setRootDir(diskManager.getSignalsBufferDir())
+                .setMaxFileAgeForWriteMillis(config.getMaxFileAgeForWriteMillis())
+                .setMaxFileAgeForReadMillis(config.getMaxFileAgeForReadMillis())
+                .setMinFileAgeForReadMillis(config.getMinFileAgeForReadMillis())
                 .setTemporaryFileProvider(
                         new SimpleTemporaryFileProvider(diskManager.getTemporaryDir()))
                 .build();

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -334,8 +334,7 @@ public final class OpenTelemetryRumBuilder {
         Preferences preferences = serviceManager.getPreferences();
         CacheStorage storage = serviceManager.getCacheStorage();
         DiskBufferingConfiguration config = this.config.getDiskBufferingConfiguration();
-        DiskManager diskManager =
-                new DiskManager(storage, preferences, config);
+        DiskManager diskManager = new DiskManager(storage, preferences, config);
         return StorageConfiguration.builder()
                 .setRootDir(diskManager.getSignalsBufferDir())
                 .setMaxFileSize(diskManager.getMaxCacheFileSize())

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfiguration.java
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfiguration.java
@@ -5,21 +5,32 @@
 
 package io.opentelemetry.android.features.diskbuffering;
 
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import io.opentelemetry.android.features.diskbuffering.scheduler.DefaultExportScheduleHandler;
 import io.opentelemetry.android.features.diskbuffering.scheduler.ExportScheduleHandler;
 
 /** Configuration for disk buffering. */
 public final class DiskBufferingConfiguration {
-    private final boolean enabled;
-    private final int maxCacheSize;
-    private final ExportScheduleHandler exportScheduleHandler;
     private static final int DEFAULT_MAX_CACHE_SIZE = 60 * 1024 * 1024;
     private static final int MAX_FILE_SIZE = 1024 * 1024;
 
+    private final boolean enabled;
+    private final int maxCacheSize;
+    private final ExportScheduleHandler exportScheduleHandler;
+    private final long maxFileAgeForWriteMillis;
+    private final long minFileAgeForReadMillis;
+    private final long maxFileAgeForReadMillis;
+
     private DiskBufferingConfiguration(Builder builder) {
-        this.enabled = builder.enabled;
-        this.maxCacheSize = builder.maxCacheSize;
-        this.exportScheduleHandler = builder.exportScheduleHandler;
+        enabled = builder.enabled;
+        maxCacheSize = builder.maxCacheSize;
+        exportScheduleHandler = builder.exportScheduleHandler;
+        maxFileAgeForWriteMillis = builder.maxFileAgeForWriteMillis;
+        minFileAgeForReadMillis = builder.minFileAgeForReadMillis;
+        maxFileAgeForReadMillis = builder.maxFileAgeForReadMillis;
     }
 
     public static Builder builder() {
@@ -42,14 +53,57 @@ public final class DiskBufferingConfiguration {
         return exportScheduleHandler;
     }
 
+    public long getMaxFileAgeForWriteMillis() {
+        return maxFileAgeForWriteMillis;
+    }
+
+    public long getMaxFileAgeForReadMillis() {
+        return maxFileAgeForReadMillis;
+    }
+
+    public long getMinFileAgeForReadMillis() {
+        return minFileAgeForReadMillis;
+    }
+
     public static final class Builder {
         private boolean enabled = false;
         private int maxCacheSize = DEFAULT_MAX_CACHE_SIZE;
+        private long maxFileAgeForWriteMillis = TimeUnit.SECONDS.toMillis(30);
+        private long minFileAgeForReadMillis = TimeUnit.SECONDS.toMillis(33);
+        private long maxFileAgeForReadMillis = TimeUnit.HOURS.toMillis(18);
+
         private ExportScheduleHandler exportScheduleHandler = DefaultExportScheduleHandler.create();
 
         /** Enables or disables disk buffering. */
         public Builder setEnabled(boolean enabled) {
             this.enabled = enabled;
+            return this;
+        }
+
+        /**
+         * Sets the max amount of time a file can receive new data. Default is 30 seconds.
+         */
+        public Builder setMaxFileAgeForWriteMillis(long maxFileAgeForWriteMillis) {
+            this.maxFileAgeForWriteMillis = maxFileAgeForWriteMillis;
+            return this;
+        }
+
+        /**
+         * Sets the min amount of time that must pass before a file is read. This value
+         * must be greater than maxFileAgeForWriteMillis.
+         */
+        public Builder setMinFileAgeForReadMillis(long minFileAgeForReadMillis) {
+            this.minFileAgeForReadMillis = minFileAgeForReadMillis;
+            return this;
+        }
+
+
+        /**
+         * Sets the max age in ms for which a file is considered not-stale. Files
+         * older than this will be dropped.
+         */
+        public Builder setMaxFileAgeForReadMillis(long maxFileAgeForReadMillis) {
+            this.maxFileAgeForReadMillis = maxFileAgeForReadMillis;
             return this;
         }
 
@@ -73,6 +127,13 @@ public final class DiskBufferingConfiguration {
         }
 
         public DiskBufferingConfiguration build() {
+            // See note in StorageConfiguration.getMinFileAgeForReadMillis()
+            if(minFileAgeForReadMillis <= maxFileAgeForWriteMillis){
+                Logger logger = Logger.getLogger(DiskBufferingConfiguration.class.getName());
+                logger.log(Level.WARNING, "minFileAgeForReadMillis must be greater than maxFileAgeForWriteMillis");
+                logger.log(Level.WARNING, "overriding minFileAgeForReadMillis from " + minFileAgeForReadMillis + " to " + minFileAgeForReadMillis + 5);
+                minFileAgeForReadMillis = maxFileAgeForWriteMillis + 5;
+            }
             return new DiskBufferingConfiguration(this);
         }
     }

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfiguration.java
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfiguration.java
@@ -5,12 +5,11 @@
 
 package io.opentelemetry.android.features.diskbuffering;
 
+import io.opentelemetry.android.features.diskbuffering.scheduler.DefaultExportScheduleHandler;
+import io.opentelemetry.android.features.diskbuffering.scheduler.ExportScheduleHandler;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import io.opentelemetry.android.features.diskbuffering.scheduler.DefaultExportScheduleHandler;
-import io.opentelemetry.android.features.diskbuffering.scheduler.ExportScheduleHandler;
 
 /** Configuration for disk buffering. */
 public final class DiskBufferingConfiguration {
@@ -80,27 +79,24 @@ public final class DiskBufferingConfiguration {
             return this;
         }
 
-        /**
-         * Sets the max amount of time a file can receive new data. Default is 30 seconds.
-         */
+        /** Sets the max amount of time a file can receive new data. Default is 30 seconds. */
         public Builder setMaxFileAgeForWriteMillis(long maxFileAgeForWriteMillis) {
             this.maxFileAgeForWriteMillis = maxFileAgeForWriteMillis;
             return this;
         }
 
         /**
-         * Sets the min amount of time that must pass before a file is read. This value
-         * must be greater than maxFileAgeForWriteMillis.
+         * Sets the min amount of time that must pass before a file is read. This value must be
+         * greater than maxFileAgeForWriteMillis.
          */
         public Builder setMinFileAgeForReadMillis(long minFileAgeForReadMillis) {
             this.minFileAgeForReadMillis = minFileAgeForReadMillis;
             return this;
         }
 
-
         /**
-         * Sets the max age in ms for which a file is considered not-stale. Files
-         * older than this will be dropped.
+         * Sets the max age in ms for which a file is considered not-stale. Files older than this
+         * will be dropped.
          */
         public Builder setMaxFileAgeForReadMillis(long maxFileAgeForReadMillis) {
             this.maxFileAgeForReadMillis = maxFileAgeForReadMillis;
@@ -128,10 +124,18 @@ public final class DiskBufferingConfiguration {
 
         public DiskBufferingConfiguration build() {
             // See note in StorageConfiguration.getMinFileAgeForReadMillis()
-            if(minFileAgeForReadMillis <= maxFileAgeForWriteMillis){
+            if (minFileAgeForReadMillis <= maxFileAgeForWriteMillis) {
                 Logger logger = Logger.getLogger(DiskBufferingConfiguration.class.getName());
-                logger.log(Level.WARNING, "minFileAgeForReadMillis must be greater than maxFileAgeForWriteMillis");
-                logger.log(Level.WARNING, "overriding minFileAgeForReadMillis from " + minFileAgeForReadMillis + " to " + minFileAgeForReadMillis + 5);
+                logger.log(
+                        Level.WARNING,
+                        "minFileAgeForReadMillis must be greater than maxFileAgeForWriteMillis");
+                logger.log(
+                        Level.WARNING,
+                        "overriding minFileAgeForReadMillis from "
+                                + minFileAgeForReadMillis
+                                + " to "
+                                + minFileAgeForReadMillis
+                                + 5);
                 minFileAgeForReadMillis = maxFileAgeForWriteMillis + 5;
             }
             return new DiskBufferingConfiguration(this);


### PR DESCRIPTION
Because one size can't necessarily fit all, we need to expose additional settings for the disk buffering feature.

* maxFileAgeForWriteMillis
* minFileAgeForReadMillis
* maxFileAgeForReadMillis

These map over directly to the same configurations in the contrib module, and use the same sane defaults as well.