### PR TITLE
Demo app: Order confirmation

### DIFF
--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/AstronomyShopActivity.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/AstronomyShopActivity.kt
@@ -32,6 +32,7 @@ import io.opentelemetry.android.demo.shop.ui.products.ProductList
 import io.opentelemetry.android.demo.shop.ui.cart.CartViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.opentelemetry.android.demo.shop.ui.cart.CheckoutConfirmationScreen
+import io.opentelemetry.android.demo.shop.ui.cart.CheckoutInfoViewModel
 import io.opentelemetry.android.demo.shop.ui.cart.InfoScreen
 
 class AstronomyShopActivity : AppCompatActivity() {
@@ -50,6 +51,8 @@ fun AstronomyShopScreen() {
     val context = LocalContext.current
     val astronomyShopNavController = rememberAstronomyShopNavController()
     val cartViewModel: CartViewModel = viewModel()
+    val checkoutInfoViewModel: CheckoutInfoViewModel = viewModel()
+
     DemoAppTheme {
         Surface(
             modifier = Modifier.fillMaxSize(),
@@ -105,10 +108,15 @@ fun AstronomyShopScreen() {
                     composable(MainDestinations.CHECKOUT_INFO_ROUTE) {
                         InfoScreen(
                             onPlaceOrderClick = {astronomyShopNavController.navigateToCheckoutConfirmation()},
-                            upPress = {astronomyShopNavController.upPress()})
+                            upPress = {astronomyShopNavController.upPress()},
+                            checkoutInfoViewModel = checkoutInfoViewModel
+                        )
                     }
                     composable(MainDestinations.CHECKOUT_CONFIRMATION_ROUTE){
-                        CheckoutConfirmationScreen(cartViewModel = cartViewModel)
+                        CheckoutConfirmationScreen(
+                            cartViewModel = cartViewModel,
+                            checkoutInfoViewModel = checkoutInfoViewModel
+                        )
                     }
                 }
             }

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/AstronomyShopActivity.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/AstronomyShopActivity.kt
@@ -31,6 +31,7 @@ import io.opentelemetry.android.demo.shop.ui.products.ProductDetails
 import io.opentelemetry.android.demo.shop.ui.products.ProductList
 import io.opentelemetry.android.demo.shop.ui.cart.CartViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
+import io.opentelemetry.android.demo.shop.ui.cart.CheckoutConfirmationScreen
 import io.opentelemetry.android.demo.shop.ui.cart.InfoScreen
 
 class AstronomyShopActivity : AppCompatActivity() {
@@ -102,7 +103,12 @@ fun AstronomyShopScreen() {
                         }
                     }
                     composable(MainDestinations.CHECKOUT_INFO_ROUTE) {
-                        InfoScreen(upPress = {astronomyShopNavController.upPress()})
+                        InfoScreen(
+                            onPlaceOrderClick = {astronomyShopNavController.navigateToCheckoutConfirmation()},
+                            upPress = {astronomyShopNavController.upPress()})
+                    }
+                    composable(MainDestinations.CHECKOUT_CONFIRMATION_ROUTE){
+                        CheckoutConfirmationScreen(cartViewModel = cartViewModel)
                     }
                 }
             }

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/Navigation.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/Navigation.kt
@@ -26,6 +26,7 @@ object MainDestinations {
     const val PRODUCT_DETAIL_ROUTE = "product"
     const val PRODUCT_ID_KEY = "productId"
     const val CHECKOUT_INFO_ROUTE = "checkout-info"
+    const val CHECKOUT_CONFIRMATION_ROUTE = "checkout-confirmation"
 }
 
 @Composable
@@ -52,6 +53,10 @@ class AstronomyShopNavController(
 
     fun navigateToCheckoutInfo(){
         navController.navigate(MainDestinations.CHECKOUT_INFO_ROUTE)
+    }
+
+    fun navigateToCheckoutConfirmation(){
+        navController.navigate(MainDestinations.CHECKOUT_CONFIRMATION_ROUTE)
     }
 }
 
@@ -80,6 +85,14 @@ class InstrumentedAstronomyShopNavController(
         delegate.navigateToCheckoutInfo()
         generateNavigationEvent(
             eventName = "navigate.to.checkout.info",
+            payload = emptyMap()
+        )
+    }
+
+    fun navigateToCheckoutConfirmation() {
+        delegate.navigateToCheckoutConfirmation()
+        generateNavigationEvent(
+            eventName = "navigate.to.checkout.confirmation",
             payload = emptyMap()
         )
     }

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutConfirmation.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutConfirmation.kt
@@ -35,6 +35,7 @@ fun CheckoutConfirmationScreen(
             lifecycleOwner.lifecycle.removeObserver(observer)
         }
     }
+
     val shippingInfo = checkoutInfoViewModel.shippingInfo
 
     Column(
@@ -53,7 +54,7 @@ fun CheckoutConfirmationScreen(
         )
 
         Text(
-            text = "We've sent you a confirmation email.",
+            text = "We've sent a confirmation email to ${shippingInfo.email}.",
             fontSize = 18.sp,
             textAlign = TextAlign.Center,
             modifier = Modifier

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutConfirmation.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutConfirmation.kt
@@ -7,17 +7,34 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import io.opentelemetry.android.demo.shop.ui.products.ProductCard
+import java.util.Locale
 
 @Composable
 fun CheckoutConfirmationScreen(
     cartViewModel: CartViewModel,
     checkoutInfoViewModel: CheckoutInfoViewModel
 ) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_PAUSE || event == Lifecycle.Event.ON_STOP) {
+                cartViewModel.clearCart()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
     val shippingInfo = checkoutInfoViewModel.shippingInfo
 
     Column(
@@ -28,7 +45,7 @@ fun CheckoutConfirmationScreen(
     ) {
         Text(
             text = "Your order is complete!",
-            style = MaterialTheme.typography.titleLarge.copy(fontSize = 24.sp),
+            fontSize = 24.sp,
             textAlign = TextAlign.Center,
             modifier = Modifier
                 .fillMaxWidth()
@@ -37,7 +54,7 @@ fun CheckoutConfirmationScreen(
 
         Text(
             text = "We've sent you a confirmation email.",
-            style = MaterialTheme.typography.bodyMedium,
+            fontSize = 18.sp,
             textAlign = TextAlign.Center,
             modifier = Modifier
                 .fillMaxWidth()
@@ -46,36 +63,43 @@ fun CheckoutConfirmationScreen(
 
         val cartItems = cartViewModel.cartItems.collectAsState().value
         cartItems.forEach { cartItem ->
-            ProductCard(
-                product = cartItem.product,
-                onProductClick = {},
-                isNarrow = true,
+            Row(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 8.dp)
-            )
+                    .fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                ProductCard(
+                    product = cartItem.product,
+                    onProductClick = {},
+                    modifier = Modifier
+                        .width(300.dp)
+                        .height(170.dp),
+                    isNarrow = true
+                )
+                Column(
+                    modifier = Modifier
+                        .fillMaxHeight(),
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(
+                        text = "Quantity: ${cartItem.quantity}",
+                        fontSize = 12.sp,
+                        modifier = Modifier
+                            .padding(horizontal = 8.dp)
+                    )
 
-            Text(
-                text = "Quantity: ${cartItem.quantity}",
-                style = MaterialTheme.typography.bodyMedium,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 8.dp)
-            )
-
-            Text(
-                text = "Total: $${String.format("%.2f", cartItem.totalPrice())}",
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(8.dp),
-                textAlign = TextAlign.End
-            )
+                    Text(
+                        text = "Total: \$${String.format(Locale.US, "%.2f", cartItem.totalPrice())}",
+                        fontSize = 14.sp,
+                        modifier = Modifier
+                            .padding(8.dp),
+                    )
+                }
+            }
         }
 
         Text(
-            text = "Grand Total: $${cartViewModel.getTotalPrice()}",
-            style = MaterialTheme.typography.titleMedium,
+            text = "Total Price: \$${String.format(Locale.US, "%.2f", cartViewModel.getTotalPrice())}",
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(top = 16.dp, bottom = 16.dp),
@@ -86,7 +110,6 @@ fun CheckoutConfirmationScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(vertical = 16.dp),
-            colors = CardDefaults.cardColors(containerColor = Color.LightGray)
         ) {
             Column(
                 modifier = Modifier.padding(16.dp),
@@ -94,45 +117,24 @@ fun CheckoutConfirmationScreen(
             ) {
                 Text(
                     text = "Shipping Data",
-                    style = MaterialTheme.typography.bodyLarge,
-                    color = Color.Black
+                    fontWeight = FontWeight.Bold
                 )
                 Text(
                     text = "Street: ${shippingInfo.streetAddress}",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = Color.Black
                 )
                 Text(
                     text = "City: ${shippingInfo.city}",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = Color.Black
                 )
                 Text(
                     text = "State: ${shippingInfo.state}",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = Color.Black
                 )
                 Text(
                     text = "Zip Code: ${shippingInfo.zipCode}",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = Color.Black
                 )
                 Text(
                     text = "Country: ${shippingInfo.country}",
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = Color.Black
                 )
             }
-        }
-
-        Button(
-            onClick = { /* TODO Handle continue shopping action */ },
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(50.dp)
-                .align(Alignment.CenterHorizontally)
-        ) {
-            Text(text = "Continue Shopping")
         }
     }
 }

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutConfirmation.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutConfirmation.kt
@@ -1,0 +1,120 @@
+package io.opentelemetry.android.demo.shop.ui.cart
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.sp
+import io.opentelemetry.android.demo.shop.ui.products.ProductCard
+
+@Composable
+fun CheckoutConfirmationScreen(
+    cartViewModel: CartViewModel,
+//    shippingInfo: ShippingInfo
+) {
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+            .verticalScroll(rememberScrollState())
+    ) {
+
+        Text(
+            text = "Your order is complete!",
+            style = MaterialTheme.typography.titleLarge.copy(fontSize = 24.sp),
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp)
+        )
+
+        Text(
+            text = "We've sent you a confirmation email.",
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 32.dp)
+        )
+
+        cartViewModel.cartItems.collectAsState().value.firstOrNull()?.let { cartItem ->
+            ProductCard(
+                product = cartItem.product,
+                onProductClick = {},
+                isNarrow = true,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp)
+            )
+
+            Text(
+                text = "Total: $${cartViewModel.getTotalPrice()}",
+                style = MaterialTheme.typography.bodyLarge,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp),
+                textAlign = TextAlign.End
+            )
+        }
+
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 16.dp),
+            colors = CardDefaults.cardColors(containerColor = Color.LightGray)
+        ) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = "Shipping Data",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = Color.Black
+                )
+//                Text(
+//                    text = "Street: ${shippingInfo.streetAddress}",
+//                    style = MaterialTheme.typography.bodyMedium,
+//                    color = Color.Black
+//                )
+//                Text(
+//                    text = "City: ${shippingInfo.city}",
+//                    style = MaterialTheme.typography.bodyMedium,
+//                    color = Color.Black
+//                )
+//                Text(
+//                    text = "State: ${shippingInfo.state}",
+//                    style = MaterialTheme.typography.bodyMedium,
+//                    color = Color.Black
+//                )
+//                Text(
+//                    text = "Zip Code: ${shippingInfo.zipCode}",
+//                    style = MaterialTheme.typography.bodyMedium,
+//                    color = Color.Black
+//                )
+//                Text(
+//                    text = "Country: ${shippingInfo.country}",
+//                    style = MaterialTheme.typography.bodyMedium,
+//                    color = Color.Black
+//                )
+            }
+        }
+
+        Button(
+            onClick = { /* TODO Handle continue shopping action */ },
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(50.dp)
+                .align(Alignment.CenterHorizontally)
+        ) {
+            Text(text = "Continue Shopping")
+        }
+    }
+}

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutConfirmation.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutConfirmation.kt
@@ -16,8 +16,9 @@ import io.opentelemetry.android.demo.shop.ui.products.ProductCard
 @Composable
 fun CheckoutConfirmationScreen(
     cartViewModel: CartViewModel,
-//    shippingInfo: ShippingInfo
+    checkoutInfoViewModel: CheckoutInfoViewModel
 ) {
+    val shippingInfo = checkoutInfoViewModel.shippingInfo
 
     Column(
         modifier = Modifier
@@ -79,31 +80,31 @@ fun CheckoutConfirmationScreen(
                     style = MaterialTheme.typography.bodyLarge,
                     color = Color.Black
                 )
-//                Text(
-//                    text = "Street: ${shippingInfo.streetAddress}",
-//                    style = MaterialTheme.typography.bodyMedium,
-//                    color = Color.Black
-//                )
-//                Text(
-//                    text = "City: ${shippingInfo.city}",
-//                    style = MaterialTheme.typography.bodyMedium,
-//                    color = Color.Black
-//                )
-//                Text(
-//                    text = "State: ${shippingInfo.state}",
-//                    style = MaterialTheme.typography.bodyMedium,
-//                    color = Color.Black
-//                )
-//                Text(
-//                    text = "Zip Code: ${shippingInfo.zipCode}",
-//                    style = MaterialTheme.typography.bodyMedium,
-//                    color = Color.Black
-//                )
-//                Text(
-//                    text = "Country: ${shippingInfo.country}",
-//                    style = MaterialTheme.typography.bodyMedium,
-//                    color = Color.Black
-//                )
+                Text(
+                    text = "Street: ${shippingInfo.streetAddress}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.Black
+                )
+                Text(
+                    text = "City: ${shippingInfo.city}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.Black
+                )
+                Text(
+                    text = "State: ${shippingInfo.state}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.Black
+                )
+                Text(
+                    text = "Zip Code: ${shippingInfo.zipCode}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.Black
+                )
+                Text(
+                    text = "Country: ${shippingInfo.country}",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = Color.Black
+                )
             }
         }
 

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutConfirmation.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutConfirmation.kt
@@ -5,11 +5,11 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.opentelemetry.android.demo.shop.ui.products.ProductCard
 
@@ -26,7 +26,6 @@ fun CheckoutConfirmationScreen(
             .padding(16.dp)
             .verticalScroll(rememberScrollState())
     ) {
-
         Text(
             text = "Your order is complete!",
             style = MaterialTheme.typography.titleLarge.copy(fontSize = 24.sp),
@@ -45,18 +44,27 @@ fun CheckoutConfirmationScreen(
                 .padding(bottom = 32.dp)
         )
 
-        cartViewModel.cartItems.collectAsState().value.firstOrNull()?.let { cartItem ->
+        val cartItems = cartViewModel.cartItems.collectAsState().value
+        cartItems.forEach { cartItem ->
             ProductCard(
                 product = cartItem.product,
                 onProductClick = {},
                 isNarrow = true,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(bottom = 16.dp)
+                    .padding(vertical = 8.dp)
             )
 
             Text(
-                text = "Total: $${cartViewModel.getTotalPrice()}",
+                text = "Quantity: ${cartItem.quantity}",
+                style = MaterialTheme.typography.bodyMedium,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp)
+            )
+
+            Text(
+                text = "Total: $${String.format("%.2f", cartItem.totalPrice())}",
                 style = MaterialTheme.typography.bodyLarge,
                 modifier = Modifier
                     .fillMaxWidth()
@@ -64,6 +72,15 @@ fun CheckoutConfirmationScreen(
                 textAlign = TextAlign.End
             )
         }
+
+        Text(
+            text = "Grand Total: $${cartViewModel.getTotalPrice()}",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 16.dp, bottom = 16.dp),
+            textAlign = TextAlign.End
+        )
 
         Card(
             modifier = Modifier

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutInfo.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutInfo.kt
@@ -77,8 +77,8 @@ fun InfoScreen(
     upPress: () -> Unit,
     checkoutInfoViewModel: CheckoutInfoViewModel
 ) {
-    val shippingInfo by remember { mutableStateOf(checkoutInfoViewModel.shippingInfo) }
-    val paymentInfo by remember { mutableStateOf(checkoutInfoViewModel.paymentInfo) }
+    val shippingInfo = checkoutInfoViewModel.shippingInfo
+    val paymentInfo = checkoutInfoViewModel.paymentInfo
 
     val focusManager = LocalFocusManager.current
     val canProceed = checkoutInfoViewModel.canProceedToCheckout()

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutInfo.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutInfo.kt
@@ -19,32 +19,6 @@ import io.opentelemetry.android.demo.shop.ui.components.UpPressButton
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.text.style.TextAlign
 
-data class ShippingInfo(
-    var email: String = "",
-    var streetAddress: String = "",
-    var zipCode: String = "",
-    var city: String = "",
-    var state: String = "",
-    var country: String = ""
-) {
-    fun isComplete(): Boolean {
-        return arrayOf(email, streetAddress, zipCode, city, state, country)
-            .all { it.isNotBlank() }
-    }
-}
-
-data class PaymentInfo(
-    var creditCardNumber: String = "",
-    var expiryMonth: String = "",
-    var expiryYear: String = "",
-    var cvv: String = ""
-) {
-    fun isComplete(): Boolean {
-        return arrayOf(creditCardNumber, expiryMonth, expiryYear, cvv)
-            .all { it.isNotBlank() }
-    }
-}
-
 @Composable
 fun InfoField(
     value: String,
@@ -99,6 +73,7 @@ fun InfoFieldsSection(
 
 @Composable
 fun InfoScreen(
+    onPlaceOrderClick: () -> Unit,
     upPress: () -> Unit
 ) {
     var shippingInfo by remember { mutableStateOf(ShippingInfo()) }
@@ -112,7 +87,7 @@ fun InfoScreen(
             .fillMaxSize()
             .background(Color.White)
     ) {
-        // Content inside a Column
+
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -149,11 +124,11 @@ fun InfoScreen(
             Spacer(modifier = Modifier.height(16.dp))
 
             Button(
-                onClick = { /*TODO Handle*/ },
+                onClick = onPlaceOrderClick,
                 modifier = Modifier.fillMaxWidth(),
                 enabled = canProceed
             ) {
-                Text("Proceed")
+                Text("Place Order")
             }
         }
 

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutInfo.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutInfo.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.unit.dp
 import io.opentelemetry.android.demo.shop.ui.components.UpPressButton
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.text.style.TextAlign
-import androidx.lifecycle.viewmodel.compose.viewModel
 
 @Composable
 fun InfoField(
@@ -126,7 +125,6 @@ fun InfoScreen(
 
             Button(
                 onClick = {
-                    // Proceed to the next screen when clicked
                     onPlaceOrderClick()
                 },
                 modifier = Modifier.fillMaxWidth(),

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutInfo.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutInfo.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import io.opentelemetry.android.demo.shop.ui.components.UpPressButton
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.text.style.TextAlign
+import androidx.lifecycle.viewmodel.compose.viewModel
 
 @Composable
 fun InfoField(
@@ -74,20 +75,20 @@ fun InfoFieldsSection(
 @Composable
 fun InfoScreen(
     onPlaceOrderClick: () -> Unit,
-    upPress: () -> Unit
+    upPress: () -> Unit,
+    checkoutInfoViewModel: CheckoutInfoViewModel = viewModel()
 ) {
-    var shippingInfo by remember { mutableStateOf(ShippingInfo()) }
-    var paymentInfo by remember { mutableStateOf(PaymentInfo()) }
+    val shippingInfo by remember { mutableStateOf(checkoutInfoViewModel.shippingInfo) }
+    val paymentInfo by remember { mutableStateOf(checkoutInfoViewModel.paymentInfo) }
 
     val focusManager = LocalFocusManager.current
-    val canProceed = shippingInfo.isComplete() && paymentInfo.isComplete()
+    val canProceed = checkoutInfoViewModel.canProceedToCheckout()
 
     Box(
         modifier = Modifier
             .fillMaxSize()
             .background(Color.White)
     ) {
-
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -99,12 +100,12 @@ fun InfoScreen(
 
             InfoFieldsSection(
                 fields = listOf(
-                    Triple("E-mail Address", shippingInfo.email) { shippingInfo = shippingInfo.copy(email = it) },
-                    Triple("Street Address", shippingInfo.streetAddress) { shippingInfo = shippingInfo.copy(streetAddress = it) },
-                    Triple("Zip Code", shippingInfo.zipCode) { shippingInfo = shippingInfo.copy(zipCode = it) },
-                    Triple("City", shippingInfo.city) { shippingInfo = shippingInfo.copy(city = it) },
-                    Triple("State", shippingInfo.state) { shippingInfo = shippingInfo.copy(state = it) },
-                    Triple("Country", shippingInfo.country) { shippingInfo = shippingInfo.copy(country = it) }
+                    Triple("E-mail Address", shippingInfo.email) { checkoutInfoViewModel.updateShippingInfo(shippingInfo.copy(email = it)) },
+                    Triple("Street Address", shippingInfo.streetAddress) { checkoutInfoViewModel.updateShippingInfo(shippingInfo.copy(streetAddress = it)) },
+                    Triple("Zip Code", shippingInfo.zipCode) { checkoutInfoViewModel.updateShippingInfo(shippingInfo.copy(zipCode = it)) },
+                    Triple("City", shippingInfo.city) { checkoutInfoViewModel.updateShippingInfo(shippingInfo.copy(city = it)) },
+                    Triple("State", shippingInfo.state) { checkoutInfoViewModel.updateShippingInfo(shippingInfo.copy(state = it)) },
+                    Triple("Country", shippingInfo.country) { checkoutInfoViewModel.updateShippingInfo(shippingInfo.copy(country = it)) }
                 )
             )
 
@@ -114,17 +115,20 @@ fun InfoScreen(
 
             InfoFieldsSection(
                 fields = listOf(
-                    Triple("Credit Card Number", paymentInfo.creditCardNumber) { paymentInfo = paymentInfo.copy(creditCardNumber = it) },
-                    Triple("Month", paymentInfo.expiryMonth) { paymentInfo = paymentInfo.copy(expiryMonth = it) },
-                    Triple("Year", paymentInfo.expiryYear) { paymentInfo = paymentInfo.copy(expiryYear = it) },
-                    Triple("CVV", paymentInfo.cvv) { paymentInfo = paymentInfo.copy(cvv = it) }
+                    Triple("Credit Card Number", paymentInfo.creditCardNumber) { checkoutInfoViewModel.updatePaymentInfo(paymentInfo.copy(creditCardNumber = it)) },
+                    Triple("Month", paymentInfo.expiryMonth) { checkoutInfoViewModel.updatePaymentInfo(paymentInfo.copy(expiryMonth = it)) },
+                    Triple("Year", paymentInfo.expiryYear) { checkoutInfoViewModel.updatePaymentInfo(paymentInfo.copy(expiryYear = it)) },
+                    Triple("CVV", paymentInfo.cvv) { checkoutInfoViewModel.updatePaymentInfo(paymentInfo.copy(cvv = it)) }
                 )
             )
 
             Spacer(modifier = Modifier.height(16.dp))
 
             Button(
-                onClick = onPlaceOrderClick,
+                onClick = {
+                    // Proceed to the next screen when clicked
+                    onPlaceOrderClick()
+                },
                 modifier = Modifier.fillMaxWidth(),
                 enabled = canProceed
             ) {

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutInfo.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutInfo.kt
@@ -76,7 +76,7 @@ fun InfoFieldsSection(
 fun InfoScreen(
     onPlaceOrderClick: () -> Unit,
     upPress: () -> Unit,
-    checkoutInfoViewModel: CheckoutInfoViewModel = viewModel()
+    checkoutInfoViewModel: CheckoutInfoViewModel
 ) {
     val shippingInfo by remember { mutableStateOf(checkoutInfoViewModel.shippingInfo) }
     val paymentInfo by remember { mutableStateOf(checkoutInfoViewModel.paymentInfo) }

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutInfoViewModel.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/cart/CheckoutInfoViewModel.kt
@@ -1,0 +1,53 @@
+package io.opentelemetry.android.demo.shop.ui.cart
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+
+data class ShippingInfo(
+    var email: String = "someone@example.com",
+    var streetAddress: String = "1600 Amphitheatre Parkway",
+    var zipCode: String = "94043",
+    var city: String = "Mountain View",
+    var state: String = "CA",
+    var country: String = "United States"
+) {
+    fun isComplete(): Boolean {
+        return arrayOf(email, streetAddress, zipCode, city, state, country)
+            .all { it.isNotBlank() }
+    }
+}
+
+data class PaymentInfo(
+    var creditCardNumber: String = "4432-8015-6152-0454",
+    var expiryMonth: String = "01",
+    var expiryYear: String = "2030",
+    var cvv: String = "137"
+) {
+    fun isComplete(): Boolean {
+        return arrayOf(creditCardNumber, expiryMonth, expiryYear, cvv)
+            .all { it.isNotBlank() }
+    }
+}
+
+class CheckoutInfoViewModel : ViewModel() {
+
+    var shippingInfo by mutableStateOf(ShippingInfo())
+        private set
+
+    var paymentInfo by mutableStateOf(PaymentInfo())
+        private set
+
+    fun updateShippingInfo(newShippingInfo: ShippingInfo) {
+        shippingInfo = newShippingInfo
+    }
+
+    fun updatePaymentInfo(newPaymentInfo: PaymentInfo) {
+        paymentInfo = newPaymentInfo
+    }
+
+    fun canProceedToCheckout(): Boolean {
+        return shippingInfo.isComplete() && paymentInfo.isComplete()
+    }
+}


### PR DESCRIPTION
Created `CheckoutConfirmation.kt` with an order confirmation screen, basing it off the web demo. User sees this screen after clicking "Place Order" on the CheckoutInfo screen. The cart is also cleared in the process.
<img width="299" alt="image" src="https://github.com/user-attachments/assets/82a0ce5a-a369-4c83-8d33-a77f91875ed2">
Additionally, I made the form for shipping and payment information pre-filled, to be able to go to that screen without filling them in every time.
