### PR TITLE
Demo app: don't start the main activity again, just finish the current one

### DIFF
--- a/demo-app/src/main/java/io/opentelemetry/android/demo/about/AboutActivity.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/about/AboutActivity.kt
@@ -1,10 +1,8 @@
 package io.opentelemetry.android.demo.about
 
-import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.bottomnavigation.BottomNavigationView
-import io.opentelemetry.android.demo.MainActivity
 import io.opentelemetry.android.demo.R
 
 class AboutActivity : AppCompatActivity() {

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/about/AboutActivity.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/about/AboutActivity.kt
@@ -25,9 +25,6 @@ class AboutActivity : AppCompatActivity() {
         bottomNavigationView.setOnItemSelectedListener { item ->
             when (item.itemId) {
                 R.id.navigation_exit -> {
-                    val intent = Intent(this, MainActivity::class.java)
-                    intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
-                    startActivity(intent)
                     finish()
                     true
                 }

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/AstronomyShopActivity.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/AstronomyShopActivity.kt
@@ -66,8 +66,6 @@ fun AstronomyShopScreen() {
                             }
                         },
                         onExitClicked = {
-                            val intent = Intent(context, MainActivity::class.java)
-                            context.startActivity(intent)
                             (context as? Activity)?.finish()
                         }
                     )

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/AstronomyShopActivity.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/AstronomyShopActivity.kt
@@ -6,7 +6,6 @@
 package io.opentelemetry.android.demo.shop.ui
 
 import android.app.Activity
-import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
@@ -23,7 +22,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
-import io.opentelemetry.android.demo.MainActivity
 import io.opentelemetry.android.demo.shop.clients.ProductCatalogClient
 import io.opentelemetry.android.demo.theme.DemoAppTheme
 import io.opentelemetry.android.demo.shop.ui.cart.CartScreen


### PR DESCRIPTION
Basically the title. I don't think we should be starting the main activity again, when clicking the `Exit` button on another activity. Just finishing the current activity seems to work fine. The motivation to look into this were multiple `App start` spans emitted by the app. After those changes it doesn't happen, there are `Restarted` spans for the main activity instead. The behaviour after the change is identical to the one using the phone's build-in "go back" button while on the first screen of a non-main activity.