### PR TITLE
fix: update references to logging exporter

### DIFF
--- a/demo-app/collector.yaml
+++ b/demo-app/collector.yaml
@@ -9,15 +9,15 @@ extensions:
 exporters:
   otlphttp:
     traces_endpoint: "http://jaeger:4318/v1/traces"
-  logging:
+  debug:
     verbosity: normal
-  logging/debug:
+  debug/detailed:
     verbosity: detailed
 service:
   pipelines:
     traces:
       receivers: [otlp]
-      exporters: [logging/debug, otlphttp]
+      exporters: [debug/detailed, otlphttp]
     logs:
       receivers: [otlp]
-      exporters: [logging/debug]
+      exporters: [debug/detailed]


### PR DESCRIPTION
This exporter has been replaced by the debug exporter and will be removed soon. Related to https://github.com/open-telemetry/opentelemetry-collector/pull/11037