### PR TITLE
Leverage boms for transient core deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,12 @@ jobs:
           else
             prior_version="$major.$minor.$((patch - 1))"
           fi
-          inst_version=$(grep ^opentelemetry-alpha gradle/libs.versions.toml | sed -E "s/^.*\"(.*)\"/\1/")
+          # otel instrumentation version comes in through alpha bom
+#          inst_version=$(grep ^opentelemetry-alpha gradle/libs.versions.toml | sed -E "s/^.*\"(.*)\"/\1/")
+          inst_version=$(./gradlew --console=plain android-agent:dependencies | \
+                        grep 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom ' | \
+                        sed -e "s/.* -> //" | sed -e "s/ .*//" | \
+                        sort | head -1)
           # otel-java core libs are transient deps thru instrumentation boms
           sdk_version=$(./gradlew --console=plain android-agent:dependencies | \
                         grep 'io.opentelemetry:opentelemetry-api ' | \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,11 @@ jobs:
             prior_version="$major.$minor.$((patch - 1))"
           fi
           inst_version=$(grep ^opentelemetry-alpha gradle/libs.versions.toml | sed -E "s/^.*\"(.*)\"/\1/")
-          sdk_version=$(cat gradle/libs.versions.toml  | grep "^opentelemetry =" | sed -E "s/^.*\"(.*)\"/\1/")
+          # otel-java core libs are transient deps thru instrumentation boms
+          sdk_version=$(./gradlew --console=plain android-agent:dependencies | \
+                        grep 'io.opentelemetry:opentelemetry-api ' | \
+                        sed -e "s/.* -> //" | sed -e "s/ .*//" | \
+                        sort | head -1)
           
           echo "VERSION=$version" >> $GITHUB_ENV
           echo "PRIOR_VERSION=$prior_version" >> $GITHUB_ENV

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -66,7 +66,7 @@ dependencies {
     implementation(libs.androidx.navigation.fragment)
     implementation(libs.androidx.lifecycle.process)
 
-    api(platform(libs.opentelemetry.platform))
+    api(platform(libs.opentelemetry.platform.alpha))
     api(libs.opentelemetry.api)
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.api.incubator)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,4 @@
 [versions]
-opentelemetry = "1.43.0"
-opentelemetry-alpha = "1.43.0-alpha"
 opentelemetry-instrumentation = "2.9.0"
 opentelemetry-instrumentation-alpha = "2.9.0-alpha"
 opentelemetry-semconv = "1.25.0-alpha"
@@ -17,6 +15,7 @@ autoService = "1.1.1"
 
 [libraries]
 opentelemetry-platform = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom", version.ref = "opentelemetry-instrumentation" }
+opentelemetry-platform-alpha = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetry-instrumentation-alpha" }
 androidx-navigation-fragment = "androidx.navigation:navigation-fragment:2.7.7"
 androidx-core = "androidx.core:core:1.13.1"
 androidx-lifecycle-process = "androidx.lifecycle:lifecycle-process:2.8.6"
@@ -30,18 +29,18 @@ opentelemetry-semconv = { module = "io.opentelemetry.semconv:opentelemetry-semco
 opentelemetry-semconv-incubating = { module = "io.opentelemetry.semconv:opentelemetry-semconv-incubating", version.ref = "opentelemetry-semconv" }
 opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api" }
 opentelemetry-api-incubator = { module = "io.opentelemetry:opentelemetry-api-incubator" }
-opentelemetry-sdk-extension-incubator = { module = "io.opentelemetry:opentelemetry-sdk-extension-incubator", version.ref = "opentelemetry-alpha" }
+opentelemetry-sdk-extension-incubator = { module = "io.opentelemetry:opentelemetry-sdk-extension-incubator" }
 opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk" }
-opentelemetry-context = { module = "io.opentelemetry:opentelemetry-context", version.ref = "opentelemetry" }
+opentelemetry-context = { module = "io.opentelemetry:opentelemetry-context" }
 opentelemetry-exporter-logging = { module = "io.opentelemetry:opentelemetry-exporter-logging" }
 opentelemetry-diskBuffering = { module = "io.opentelemetry.contrib:opentelemetry-disk-buffering", version.ref = "opentelemetry-contrib" }
-opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp", version.ref = "opentelemetry" }
+opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp" }
 volley = "com.android.volley:volley:1.2.1"
 auto-service-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "autoService" }
 auto-service-processor = { module = "com.google.auto.service:auto-service", version.ref = "autoService" }
 
 #Test tools
-opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing", version.ref = "opentelemetry" }
+opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing" }
 androidx-test-core = "androidx.test:core:1.6.1"
 androidx-test-rules = "androidx.test:rules:1.6.1"
 androidx-test-runner = "androidx.test:runner:1.6.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-opentelemetry-instrumentation = "2.9.0"
 opentelemetry-instrumentation-alpha = "2.9.0-alpha"
+#opentelemetry-instrumentation = "2.9.0" // alpha bom includes non-alpha bom
 opentelemetry-semconv = "1.25.0-alpha"
 opentelemetry-contrib = "1.40.0-alpha"
 mockito = "5.14.2"
@@ -14,8 +14,8 @@ junitKtx = "1.2.1"
 autoService = "1.1.1"
 
 [libraries]
-opentelemetry-platform = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom", version.ref = "opentelemetry-instrumentation" }
 opentelemetry-platform-alpha = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetry-instrumentation-alpha" }
+opentelemetry-platform = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom" }
 androidx-navigation-fragment = "androidx.navigation:navigation-fragment:2.7.7"
 androidx-core = "androidx.core:core:1.13.1"
 androidx-lifecycle-process = "androidx.lifecycle:lifecycle-process:2.8.6"

--- a/instrumentation/activity/build.gradle.kts
+++ b/instrumentation/activity/build.gradle.kts
@@ -14,7 +14,7 @@ android {
 }
 
 dependencies {
-    api(platform(libs.opentelemetry.platform))
+    api(platform(libs.opentelemetry.platform.alpha))
     api(libs.opentelemetry.api)
     api(project(":instrumentation:common-api"))
     api(project(":core"))

--- a/instrumentation/anr/build.gradle.kts
+++ b/instrumentation/anr/build.gradle.kts
@@ -18,7 +18,7 @@ android {
 }
 
 dependencies {
-    api(platform(libs.opentelemetry.platform))
+    api(platform(libs.opentelemetry.platform.alpha))
     api(libs.opentelemetry.api)
     api(project(":core"))
     implementation(libs.androidx.core)

--- a/instrumentation/common-api/build.gradle.kts
+++ b/instrumentation/common-api/build.gradle.kts
@@ -15,7 +15,7 @@ android {
 
 dependencies {
     api(project(":core"))
-    api(platform(libs.opentelemetry.platform))
+    api(platform(libs.opentelemetry.platform.alpha))
     api(libs.opentelemetry.api)
     implementation(libs.androidx.navigation.fragment)
     implementation(libs.opentelemetry.sdk)

--- a/instrumentation/crash/build.gradle.kts
+++ b/instrumentation/crash/build.gradle.kts
@@ -14,7 +14,7 @@ android {
 }
 
 dependencies {
-    api(platform(libs.opentelemetry.platform))
+    api(platform(libs.opentelemetry.platform.alpha))
     api(libs.opentelemetry.api)
     api(project(":core"))
     implementation(libs.androidx.core)

--- a/instrumentation/fragment/build.gradle.kts
+++ b/instrumentation/fragment/build.gradle.kts
@@ -14,7 +14,7 @@ android {
 }
 
 dependencies {
-    api(platform(libs.opentelemetry.platform))
+    api(platform(libs.opentelemetry.platform.alpha))
     api(libs.opentelemetry.api)
     api(project(":instrumentation:common-api"))
     api(project(":core"))

--- a/instrumentation/httpurlconnection/library/build.gradle.kts
+++ b/instrumentation/httpurlconnection/library/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 }
 
 dependencies {
-    api(platform(libs.opentelemetry.platform))
+    api(platform(libs.opentelemetry.platform.alpha))
     api(libs.opentelemetry.api)
     api(libs.opentelemetry.context)
     api(project(":core"))

--- a/instrumentation/network/build.gradle.kts
+++ b/instrumentation/network/build.gradle.kts
@@ -19,7 +19,7 @@ android {
 }
 
 dependencies {
-    api(platform(libs.opentelemetry.platform))
+    api(platform(libs.opentelemetry.platform.alpha))
     api(libs.opentelemetry.api)
     api(project(":core"))
     api(project(":instrumentation:common-api"))

--- a/instrumentation/slowrendering/build.gradle.kts
+++ b/instrumentation/slowrendering/build.gradle.kts
@@ -14,7 +14,7 @@ android {
 }
 
 dependencies {
-    api(platform(libs.opentelemetry.platform))
+    api(platform(libs.opentelemetry.platform.alpha))
     api(libs.opentelemetry.api)
     api(project(":core"))
     api(project(":instrumentation:common-api"))

--- a/instrumentation/startup/build.gradle.kts
+++ b/instrumentation/startup/build.gradle.kts
@@ -14,7 +14,6 @@ android {
 }
 
 dependencies {
-    api(platform(libs.opentelemetry.platform))
     api(platform(libs.opentelemetry.platform.alpha))
     api(libs.opentelemetry.api)
     api(project(":core"))

--- a/instrumentation/startup/build.gradle.kts
+++ b/instrumentation/startup/build.gradle.kts
@@ -15,6 +15,7 @@ android {
 
 dependencies {
     api(platform(libs.opentelemetry.platform))
+    api(platform(libs.opentelemetry.platform.alpha))
     api(libs.opentelemetry.api)
     api(project(":core"))
     implementation(libs.androidx.core)

--- a/instrumentation/volley/library/build.gradle.kts
+++ b/instrumentation/volley/library/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     implementation(libs.opentelemetry.semconv.incubating)
     compileOnly(libs.volley)
 
-    api(platform(libs.opentelemetry.platform))
+    api(platform(libs.opentelemetry.platform.alpha))
     api(libs.opentelemetry.api)
 
     testImplementation(libs.volley)

--- a/test-common/build.gradle.kts
+++ b/test-common/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 
 dependencies {
     api(project(":core"))
-    api(platform(libs.opentelemetry.platform))
+    api(platform(libs.opentelemetry.platform.alpha))
     api(libs.opentelemetry.sdk)
     api(libs.opentelemetry.api)
     api(libs.opentelemetry.sdk.testing)


### PR DESCRIPTION
See this as an example of renovate updating the core lib versions before the instrumentation versions are updated: https://github.com/open-telemetry/opentelemetry-android/pull/630#issuecomment-2420416384

This opens a window during which our instrumentation dep could be misaligned with our core dep. This change now forces the use of boms at the instrumentation level in order to determine which versions of the core libs to use.

Because we no longer explicitly declare which version of the core libs (api/sdk) we use in the `libs.versions.toml` file, we have to grep for it at release time via `./gradlew android-agent:dependencies`.