### PR TITLE
Remove unused constant that exists in semconv

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/common/RumConstants.java
+++ b/core/src/main/java/io/opentelemetry/android/common/RumConstants.java
@@ -27,9 +27,6 @@ public class RumConstants {
     public static final AttributeKey<Long> HEAP_FREE_KEY = longKey("heap.free");
     public static final AttributeKey<Double> BATTERY_PERCENT_KEY = doubleKey("battery.percent");
 
-    public static final AttributeKey<String> PREVIOUS_SESSION_ID_KEY =
-            stringKey("session.previous_id");
-
     public static final String APP_START_SPAN_NAME = "AppStart";
 
     public static final class Events {


### PR DESCRIPTION
`session.previous_id` exists in `SessionIncubatingAttributes.SESSION_PREVIOUS_ID` so we don't need it here.