### PR TITLE
Relax install arg from OpenTelemetryRum to OpenTelemetry instance.

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
@@ -54,7 +54,7 @@ class SdkPreconfiguredRumBuilder
 
             // Install instrumentations
             for (instrumentation in getInstrumentations()) {
-                instrumentation.install(application, openTelemetryRum)
+                instrumentation.install(application, openTelemetryRum.openTelemetry)
             }
 
             return openTelemetryRum

--- a/core/src/main/java/io/opentelemetry/android/instrumentation/AndroidInstrumentation.kt
+++ b/core/src/main/java/io/opentelemetry/android/instrumentation/AndroidInstrumentation.kt
@@ -7,6 +7,7 @@ package io.opentelemetry.android.instrumentation
 
 import android.app.Application
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.api.OpenTelemetry
 
 /**
  * This interface defines a tool that automatically generates telemetry for a specific use-case,
@@ -30,10 +31,10 @@ interface AndroidInstrumentation {
      * to use for generating telemetry.
      *
      * @param application The Android application being instrumented.
-     * @param openTelemetryRum The [OpenTelemetryRum] instance to use for creating signals.
+     * @param openTelemetry The [OpenTelemetry] instance to use for creating signals.
      */
     fun install(
         application: Application,
-        openTelemetryRum: OpenTelemetryRum,
+        openTelemetry: OpenTelemetry,
     )
 }

--- a/core/src/test/java/io/opentelemetry/android/instrumentation/TestAndroidInstrumentation.kt
+++ b/core/src/test/java/io/opentelemetry/android/instrumentation/TestAndroidInstrumentation.kt
@@ -6,7 +6,7 @@
 package io.opentelemetry.android.instrumentation
 
 import android.app.Application
-import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.api.OpenTelemetry
 
 class TestAndroidInstrumentation : AndroidInstrumentation {
     var installed = false
@@ -14,7 +14,7 @@ class TestAndroidInstrumentation : AndroidInstrumentation {
 
     override fun install(
         application: Application,
-        openTelemetryRum: OpenTelemetryRum,
+        openTelemetry: OpenTelemetry,
     ) {
         installed = true
     }

--- a/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentation.kt
+++ b/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentation.kt
@@ -8,13 +8,13 @@ package io.opentelemetry.android.instrumentation.activity
 import android.app.Application
 import android.os.Build
 import com.google.auto.service.AutoService
-import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.instrumentation.activity.startup.AppStartupTimer
 import io.opentelemetry.android.instrumentation.common.Constants.INSTRUMENTATION_SCOPE
 import io.opentelemetry.android.instrumentation.common.ScreenNameExtractor
 import io.opentelemetry.android.internal.services.ServiceManager
 import io.opentelemetry.android.internal.services.visiblescreen.activities.DefaultingActivityLifecycleCallbacks
+import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.Tracer
 
 @AutoService(AndroidInstrumentation::class)
@@ -33,16 +33,16 @@ class ActivityLifecycleInstrumentation : AndroidInstrumentation {
 
     override fun install(
         application: Application,
-        openTelemetryRum: OpenTelemetryRum,
+        openTelemetry: OpenTelemetry,
     ) {
-        startupTimer.start(openTelemetryRum.openTelemetry.getTracer(INSTRUMENTATION_SCOPE))
+        startupTimer.start(openTelemetry.getTracer(INSTRUMENTATION_SCOPE))
         application.registerActivityLifecycleCallbacks(startupTimer.createLifecycleCallback())
-        application.registerActivityLifecycleCallbacks(buildActivityLifecycleTracer(openTelemetryRum))
+        application.registerActivityLifecycleCallbacks(buildActivityLifecycleTracer(openTelemetry))
     }
 
-    private fun buildActivityLifecycleTracer(openTelemetryRum: OpenTelemetryRum): DefaultingActivityLifecycleCallbacks {
+    private fun buildActivityLifecycleTracer(openTelemetry: OpenTelemetry): DefaultingActivityLifecycleCallbacks {
         val visibleScreenService = ServiceManager.get().getVisibleScreenService()
-        val delegateTracer: Tracer = openTelemetryRum.openTelemetry.getTracer(INSTRUMENTATION_SCOPE)
+        val delegateTracer: Tracer = openTelemetry.getTracer(INSTRUMENTATION_SCOPE)
         val tracers =
             ActivityTracerCache(
                 tracerCustomizer.invoke(delegateTracer),

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityInstrumentationTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityInstrumentationTest.kt
@@ -33,8 +33,6 @@ class ActivityInstrumentationTest {
     fun setUp() {
         application = RuntimeEnvironment.getApplication()
         openTelemetry = mockk()
-        openTelemetryRum = mockk()
-        every { openTelemetryRum.openTelemetry }.returns(openTelemetry)
         activityLifecycleInstrumentation = ActivityLifecycleInstrumentation()
 
         Companion.initialize(application)
@@ -54,7 +52,7 @@ class ActivityInstrumentationTest {
         )
         every { startupSpanBuilder.startSpan() }.returns(startupSpan)
 
-        activityLifecycleInstrumentation.install(application, openTelemetryRum)
+        activityLifecycleInstrumentation.install(application, openTelemetry)
 
         verify {
             tracer.spanBuilder("AppStart")

--- a/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrInstrumentation.java
+++ b/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrInstrumentation.java
@@ -9,9 +9,9 @@ import android.app.Application;
 import android.os.Looper;
 import androidx.annotation.NonNull;
 import com.google.auto.service.AutoService;
-import io.opentelemetry.android.OpenTelemetryRum;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
 import io.opentelemetry.android.internal.services.ServiceManager;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.util.ArrayList;
 import java.util.List;
@@ -47,15 +47,14 @@ public final class AnrInstrumentation implements AndroidInstrumentation {
     }
 
     @Override
-    public void install(
-            @NonNull Application application, @NonNull OpenTelemetryRum openTelemetryRum) {
+    public void install(@NonNull Application application, @NonNull OpenTelemetry openTelemetry) {
         AnrDetector anrDetector =
                 new AnrDetector(
                         additionalExtractors,
                         mainLooper,
                         scheduler,
                         ServiceManager.get().getAppLifecycleService(),
-                        openTelemetryRum.getOpenTelemetry());
+                        openTelemetry);
         anrDetector.start();
     }
 }

--- a/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporterInstrumentation.java
+++ b/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporterInstrumentation.java
@@ -8,9 +8,9 @@ package io.opentelemetry.android.instrumentation.crash;
 import android.app.Application;
 import androidx.annotation.NonNull;
 import com.google.auto.service.AutoService;
-import io.opentelemetry.android.OpenTelemetryRum;
 import io.opentelemetry.android.RuntimeDetailsExtractor;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import java.util.ArrayList;
@@ -28,10 +28,9 @@ public final class CrashReporterInstrumentation implements AndroidInstrumentatio
     }
 
     @Override
-    public void install(
-            @NonNull Application application, @NonNull OpenTelemetryRum openTelemetryRum) {
+    public void install(@NonNull Application application, @NonNull OpenTelemetry openTelemetry) {
         addAttributesExtractor(RuntimeDetailsExtractor.create(application));
         CrashReporter crashReporter = new CrashReporter(additionalExtractors);
-        crashReporter.install((OpenTelemetrySdk) openTelemetryRum.getOpenTelemetry());
+        crashReporter.install((OpenTelemetrySdk) openTelemetry);
     }
 }

--- a/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReporterTest.java
+++ b/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReporterTest.java
@@ -8,11 +8,8 @@ package io.opentelemetry.android.instrumentation.crash;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor.constant;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
-import io.opentelemetry.android.OpenTelemetryRum;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.logs.SdkLoggerProvider;
@@ -58,12 +55,9 @@ public class CrashReporterTest {
 
     @Test
     public void integrationTest() throws InterruptedException {
-        OpenTelemetryRum openTelemetryRum = mock();
-        when(openTelemetryRum.getOpenTelemetry()).thenReturn(openTelemetrySdk);
-
         CrashReporterInstrumentation instrumentation = new CrashReporterInstrumentation();
         instrumentation.addAttributesExtractor(constant(stringKey("test.key"), "abc"));
-        instrumentation.install(RuntimeEnvironment.getApplication(), openTelemetryRum);
+        instrumentation.install(RuntimeEnvironment.getApplication(), openTelemetrySdk);
 
         String exceptionMessage = "boooom!";
         RuntimeException crash = new RuntimeException(exceptionMessage);

--- a/instrumentation/fragment/src/main/java/io/opentelemetry/android/instrumentation/fragment/FragmentLifecycleInstrumentation.kt
+++ b/instrumentation/fragment/src/main/java/io/opentelemetry/android/instrumentation/fragment/FragmentLifecycleInstrumentation.kt
@@ -9,12 +9,12 @@ import android.app.Application
 import android.app.Application.ActivityLifecycleCallbacks
 import android.os.Build
 import com.google.auto.service.AutoService
-import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.instrumentation.common.Constants.INSTRUMENTATION_SCOPE
 import io.opentelemetry.android.instrumentation.common.ScreenNameExtractor
 import io.opentelemetry.android.internal.services.ServiceManager
 import io.opentelemetry.android.internal.services.visiblescreen.fragments.RumFragmentActivityRegisterer
+import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.Tracer
 
 @AutoService(AndroidInstrumentation::class)
@@ -32,14 +32,14 @@ class FragmentLifecycleInstrumentation : AndroidInstrumentation {
 
     override fun install(
         application: Application,
-        openTelemetryRum: OpenTelemetryRum,
+        openTelemetry: OpenTelemetry,
     ) {
-        application.registerActivityLifecycleCallbacks(buildFragmentRegisterer(openTelemetryRum))
+        application.registerActivityLifecycleCallbacks(buildFragmentRegisterer(openTelemetry))
     }
 
-    private fun buildFragmentRegisterer(openTelemetryRum: OpenTelemetryRum): ActivityLifecycleCallbacks {
+    private fun buildFragmentRegisterer(openTelemetry: OpenTelemetry): ActivityLifecycleCallbacks {
         val visibleScreenService = ServiceManager.get().getVisibleScreenService()
-        val delegateTracer: Tracer = openTelemetryRum.openTelemetry.getTracer(INSTRUMENTATION_SCOPE)
+        val delegateTracer: Tracer = openTelemetry.getTracer(INSTRUMENTATION_SCOPE)
         val fragmentLifecycle =
             RumFragmentLifecycleCallbacks(
                 tracerCustomizer.invoke(delegateTracer),

--- a/instrumentation/httpurlconnection/library/src/main/java/io/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlInstrumentation.java
+++ b/instrumentation/httpurlconnection/library/src/main/java/io/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlInstrumentation.java
@@ -7,8 +7,8 @@ package io.opentelemetry.instrumentation.library.httpurlconnection;
 
 import android.app.Application;
 import com.google.auto.service.AutoService;
-import io.opentelemetry.android.OpenTelemetryRum;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.net.PeerServiceResolver;
 import io.opentelemetry.instrumentation.api.internal.HttpConstants;
 import io.opentelemetry.instrumentation.library.httpurlconnection.internal.HttpUrlConnectionSingletons;
@@ -123,9 +123,8 @@ public class HttpUrlInstrumentation implements AndroidInstrumentation {
     }
 
     @Override
-    public void install(
-            @NotNull Application application, @NotNull OpenTelemetryRum openTelemetryRum) {
-        HttpUrlConnectionSingletons.configure(this, openTelemetryRum.getOpenTelemetry());
+    public void install(@NotNull Application application, @NotNull OpenTelemetry openTelemetry) {
+        HttpUrlConnectionSingletons.configure(this, openTelemetry);
     }
 
     /**

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentation.java
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentation.java
@@ -8,10 +8,10 @@ package io.opentelemetry.android.instrumentation.network;
 import android.app.Application;
 import androidx.annotation.NonNull;
 import com.google.auto.service.AutoService;
-import io.opentelemetry.android.OpenTelemetryRum;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
 import io.opentelemetry.android.internal.services.ServiceManager;
 import io.opentelemetry.android.internal.services.network.data.CurrentNetwork;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,11 +31,10 @@ public final class NetworkChangeInstrumentation implements AndroidInstrumentatio
     }
 
     @Override
-    public void install(
-            @NonNull Application application, @NonNull OpenTelemetryRum openTelemetryRum) {
+    public void install(@NonNull Application application, @NonNull OpenTelemetry openTelemetry) {
         NetworkChangeMonitor networkChangeMonitor =
                 new NetworkChangeMonitor(
-                        openTelemetryRum.getOpenTelemetry(),
+                        openTelemetry,
                         ServiceManager.get().getAppLifecycleService(),
                         ServiceManager.get().getCurrentNetworkProvider(),
                         Collections.unmodifiableList(additionalExtractors));

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/OkHttpInstrumentation.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/OkHttpInstrumentation.java
@@ -7,8 +7,8 @@ package io.opentelemetry.instrumentation.library.okhttp.v3_0;
 
 import android.app.Application;
 import com.google.auto.service.AutoService;
-import io.opentelemetry.android.OpenTelemetryRum;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.net.PeerServiceResolver;
 import io.opentelemetry.instrumentation.api.internal.HttpConstants;
 import io.opentelemetry.instrumentation.library.okhttp.v3_0.internal.OkHttp3Singletons;
@@ -123,8 +123,7 @@ public class OkHttpInstrumentation implements AndroidInstrumentation {
     }
 
     @Override
-    public void install(
-            @NotNull Application application, @NotNull OpenTelemetryRum openTelemetryRum) {
-        OkHttp3Singletons.configure(this, openTelemetryRum.getOpenTelemetry());
+    public void install(@NotNull Application application, @NotNull OpenTelemetry openTelemetry) {
+        OkHttp3Singletons.configure(this, openTelemetry);
     }
 }

--- a/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentation.java
+++ b/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentation.java
@@ -11,9 +11,9 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import com.google.auto.service.AutoService;
-import io.opentelemetry.android.OpenTelemetryRum;
 import io.opentelemetry.android.common.RumConstants;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
+import io.opentelemetry.api.OpenTelemetry;
 import java.time.Duration;
 
 /** Entrypoint for installing the slow rendering detection instrumentation. */
@@ -43,8 +43,7 @@ public final class SlowRenderingInstrumentation implements AndroidInstrumentatio
 
     @RequiresApi(Build.VERSION_CODES.N)
     @Override
-    public void install(
-            @NonNull Application application, @NonNull OpenTelemetryRum openTelemetryRum) {
+    public void install(@NonNull Application application, @NonNull OpenTelemetry openTelemetry) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             Log.w(
                     RumConstants.OTEL_RUM_LOG_TAG,
@@ -54,9 +53,7 @@ public final class SlowRenderingInstrumentation implements AndroidInstrumentatio
 
         SlowRenderListener detector =
                 new SlowRenderListener(
-                        openTelemetryRum
-                                .getOpenTelemetry()
-                                .getTracer("io.opentelemetry.slow-rendering"),
+                        openTelemetry.getTracer("io.opentelemetry.slow-rendering"),
                         slowRenderingDetectionPollInterval);
 
         application.registerActivityLifecycleCallbacks(detector);

--- a/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentationTest.kt
+++ b/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentationTest.kt
@@ -14,7 +14,6 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -27,15 +26,12 @@ import java.time.Duration
 class SlowRenderingInstrumentationTest {
     private lateinit var slowRenderingInstrumentation: SlowRenderingInstrumentation
     private lateinit var application: Application
-    private lateinit var openTelemetryRum: OpenTelemetryRum
     private lateinit var openTelemetry: OpenTelemetrySdk
 
     @Before
     fun setUp() {
         application = mockk()
         openTelemetry = mockk()
-        openTelemetryRum = mockk()
-        every { openTelemetryRum.openTelemetry }.returns(openTelemetry)
         slowRenderingInstrumentation = SlowRenderingInstrumentation()
     }
 
@@ -67,13 +63,13 @@ class SlowRenderingInstrumentationTest {
     @Config(sdk = [23])
     @Test
     fun `Not installing instrumentation on devices with API level lower than 24`() {
-        slowRenderingInstrumentation.install(application, openTelemetryRum)
+        slowRenderingInstrumentation.install(application, openTelemetry)
 
         verify {
             application wasNot Called
         }
         verify {
-            openTelemetryRum wasNot Called
+            openTelemetry wasNot Called
         }
     }
 
@@ -84,7 +80,7 @@ class SlowRenderingInstrumentationTest {
         every { openTelemetry.getTracer(any()) }.returns(mockk())
         every { application.registerActivityLifecycleCallbacks(any()) } just Runs
 
-        slowRenderingInstrumentation.install(application, openTelemetryRum)
+        slowRenderingInstrumentation.install(application, openTelemetry)
 
         verify { openTelemetry.getTracer("io.opentelemetry.slow-rendering") }
         verify { application.registerActivityLifecycleCallbacks(capture(capturedListener)) }

--- a/instrumentation/startup/src/main/java/io/opentelemetry/android/instrumentation/startup/StartupInstrumentation.kt
+++ b/instrumentation/startup/src/main/java/io/opentelemetry/android/instrumentation/startup/StartupInstrumentation.kt
@@ -7,19 +7,19 @@ package io.opentelemetry.android.instrumentation.startup
 
 import android.app.Application
 import com.google.auto.service.AutoService
-import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.internal.initialization.InitializationEvents
+import io.opentelemetry.api.OpenTelemetry
 
 @AutoService(AndroidInstrumentation::class)
 class StartupInstrumentation : AndroidInstrumentation {
     override fun install(
         application: Application,
-        openTelemetryRum: OpenTelemetryRum,
+        openTelemetry: OpenTelemetry,
     ) {
         val events = InitializationEvents.get()
         if (events is SdkInitializationEvents) {
-            events.finish(openTelemetryRum.openTelemetry)
+            events.finish(openTelemetry)
         }
     }
 }

--- a/instrumentation/startup/src/test/java/io/opentelemetry/android/instrumentation/startup/StartupInstrumentationTest.kt
+++ b/instrumentation/startup/src/test/java/io/opentelemetry/android/instrumentation/startup/StartupInstrumentationTest.kt
@@ -38,12 +38,10 @@ class StartupInstrumentationTest {
     @Test
     fun `Call finish on SdkInitializationEvents`() {
         val sdkInitializationEvents = mockk<SdkInitializationEvents>()
-        val openTelemetryRum = mockk<OpenTelemetryRum>()
-        every { openTelemetryRum.openTelemetry }.returns(otelTesting.openTelemetry)
         every { sdkInitializationEvents.finish(any()) } just Runs
         InitializationEvents.set(sdkInitializationEvents)
 
-        instrumentation.install(mockk(), openTelemetryRum)
+        instrumentation.install(mockk(), otelTesting.openTelemetry)
 
         verify {
             sdkInitializationEvents.finish(otelTesting.openTelemetry)
@@ -56,7 +54,7 @@ class StartupInstrumentationTest {
         val openTelemetryRum = mockk<OpenTelemetryRum>()
         InitializationEvents.set(initializationEvents)
 
-        instrumentation.install(mockk(), openTelemetryRum)
+        instrumentation.install(mockk(), otelTesting.openTelemetry)
 
         verify { initializationEvents wasNot Called }
     }

--- a/instrumentation/volley/README.md
+++ b/instrumentation/volley/README.md
@@ -22,10 +22,15 @@ dependencies {
 
 ## How to use VolleyTracing
 
-To use `VolleyTracing`, you must have already initialized `OpenTelemetryRum`.
+To use `VolleyTracing`, you must have already initialized an `OpenTelemetry` instance.
 To build an instrumented client HTTP call, you will first create an instance of
-`VolleyTracing` by passing in the `OpenTelemetry` instance from the `OpenTelemtryRum`
-instance to the builder:
+`VolleyTracing` by passing in the `OpenTelemetry` instance to the builder:
+
+```java
+VolleyTracing volleyTracing = VolleyTracing.builder(openTelemetry).build();
+```
+
+If you're using `OpenTelemetryRum`, you can get the `OpenTelemetry` instance from it:
 
 ```java
 VolleyTracing volleyTracing = VolleyTracing.builder(otelRum.getOpenTelemtry()).build();


### PR DESCRIPTION
As @surbhiia described in #658, there is an unnecessary tight coupling from the `AndroidInstrumentation` implementations back to the core module.  Literally every one of the instrumentations was taking the rum instance only so that it could get access to the otel instance. 

So let's simplify this and have fewer law-of-demeter violations! This changes the `install()` API to take the OpenTelemetry instance directly.