### PR TITLE
add-disk-buffering-debug-mode

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfiguration.java
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfiguration.java
@@ -22,6 +22,7 @@ public final class DiskBufferingConfiguration {
     private final long maxFileAgeForWriteMillis;
     private final long minFileAgeForReadMillis;
     private final long maxFileAgeForReadMillis;
+    private final boolean enableDebugMode;
 
     private DiskBufferingConfiguration(Builder builder) {
         enabled = builder.enabled;
@@ -30,7 +31,7 @@ public final class DiskBufferingConfiguration {
         maxFileAgeForWriteMillis = builder.maxFileAgeForWriteMillis;
         minFileAgeForReadMillis = builder.minFileAgeForReadMillis;
         maxFileAgeForReadMillis = builder.maxFileAgeForReadMillis;
-        this.enableDebugMode = builder.enableDebugMode;
+        enableDebugMode = builder.enableDebugMode;
     }
 
     public static Builder builder() {

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfiguration.java
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfiguration.java
@@ -30,7 +30,7 @@ public final class DiskBufferingConfiguration {
         maxFileAgeForWriteMillis = builder.maxFileAgeForWriteMillis;
         minFileAgeForReadMillis = builder.minFileAgeForReadMillis;
         maxFileAgeForReadMillis = builder.maxFileAgeForReadMillis;
-        this.enableDebugMode = builder.enableDebugMode; 
+        this.enableDebugMode = builder.enableDebugMode;
     }
 
     public static Builder builder() {
@@ -78,9 +78,12 @@ public final class DiskBufferingConfiguration {
         // Sets the debug mode for disk buffering, enabling additional logging.
         public Builder setDebugMode(boolean enableDebugMode) {
             this.enableDebugMode = enableDebugMode;
-            Logger.getLogger(DiskBufferingConfiguration.class.getName()).log(Level.INFO, 
-                "Disk buffering has been " + (enabled ? "enabled." : "disabled.") + 
-                    (enableDebugMode ? " Debug mode is active." : ""));
+            Logger.getLogger(DiskBufferingConfiguration.class.getName())
+                    .log(
+                            Level.INFO,
+                            "Disk buffering has been "
+                                    + (enabled ? "enabled." : "disabled.")
+                                    + (enableDebugMode ? " Debug mode is active." : ""));
             return this;
         }
 
@@ -88,9 +91,10 @@ public final class DiskBufferingConfiguration {
         public Builder setEnabled(boolean enabled) {
             this.enabled = enabled;
             if (enableDebugMode) {
-                Logger.getLogger(DiskBufferingConfiguration.class.getName()).log(Level.INFO, "Debug log message here");
+                Logger.getLogger(DiskBufferingConfiguration.class.getName())
+                        .log(Level.INFO, "Debug log message here");
             }
-            
+
             return this;
         }
 

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfiguration.java
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfiguration.java
@@ -30,6 +30,7 @@ public final class DiskBufferingConfiguration {
         maxFileAgeForWriteMillis = builder.maxFileAgeForWriteMillis;
         minFileAgeForReadMillis = builder.minFileAgeForReadMillis;
         maxFileAgeForReadMillis = builder.maxFileAgeForReadMillis;
+        this.enableDebugMode = builder.enableDebugMode; 
     }
 
     public static Builder builder() {
@@ -70,12 +71,26 @@ public final class DiskBufferingConfiguration {
         private long maxFileAgeForWriteMillis = TimeUnit.SECONDS.toMillis(30);
         private long minFileAgeForReadMillis = TimeUnit.SECONDS.toMillis(33);
         private long maxFileAgeForReadMillis = TimeUnit.HOURS.toMillis(18);
+        private boolean enableDebugMode = false;
 
         private ExportScheduleHandler exportScheduleHandler = DefaultExportScheduleHandler.create();
+
+        // Sets the debug mode for disk buffering, enabling additional logging.
+        public Builder setDebugMode(boolean enableDebugMode) {
+            this.enableDebugMode = enableDebugMode;
+            Logger.getLogger(DiskBufferingConfiguration.class.getName()).log(Level.INFO, 
+                "Disk buffering has been " + (enabled ? "enabled." : "disabled.") + 
+                    (enableDebugMode ? " Debug mode is active." : ""));
+            return this;
+        }
 
         /** Enables or disables disk buffering. */
         public Builder setEnabled(boolean enabled) {
             this.enabled = enabled;
+            if (enableDebugMode) {
+                Logger.getLogger(DiskBufferingConfiguration.class.getName()).log(Level.INFO, "Debug log message here");
+            }
+            
             return this;
         }
 

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfiguration.java
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfiguration.java
@@ -76,7 +76,7 @@ public final class DiskBufferingConfiguration {
 
         private ExportScheduleHandler exportScheduleHandler = DefaultExportScheduleHandler.create();
 
-        // Sets the debug mode for disk buffering, enabling additional logging.
+        /** Sets the debug mode for disk buffering, enabling additional logging. */
         public Builder setDebugMode(boolean enableDebugMode) {
             this.enableDebugMode = enableDebugMode;
             Logger.getLogger(DiskBufferingConfiguration.class.getName())


### PR DESCRIPTION
**Description**

Fixes #597  Add setting to enable disk buffering debug mode 

This PR introduces a configurable debug mode in the `DiskBufferingConfiguration` class within OpenTelemetry Android, allowing users to enable verbose logging for troubleshooting disk buffering behavior.
**Changes Made**

1. Added `setDebugMode` Method:

A new method, `setDebugMode`, has been added to the `DiskBufferingConfiguration.Builder `class. This method accepts a boolean parameter to enable or disable debug mode.
When enabled, a log message indicates that debug mode for disk buffering is active, providing enhanced logging details for easier troubleshooting.

2. Enhanced `setEnabled `Method:

The `setEnabled` method now includes a check for `enableDebugMode`. If debug mode is active, an additional log message provides further information on the state of disk buffering.
This conditional logging gives users more visibility into the disk buffering configuration when debug mode is enabled.