### PR TITLE
release.yml - Remove empty whitespace

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ jobs:
             exit 1
           fi
       - uses: actions/checkout@v4
-
       - name: Set environment variables
         run: |
           version=$(.github/scripts/get-version.sh)


### PR DESCRIPTION
Maybe this is new because the file was modified in #652, but we're seeing some weird build failures the claim that `release.yml` is malformed:

https://github.com/open-telemetry/opentelemetry-android/actions/runs/11557577328

The whitespace had been in there for at least 6 months, not sure why it's a new problem. Let's remove it and see if that goes away.