### PR TITLE
release.yml - Remove commented grep

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,6 @@ jobs:
             prior_version="$major.$minor.$((patch - 1))"
           fi
           # otel instrumentation version comes in through alpha bom
-#          inst_version=$(grep ^opentelemetry-alpha gradle/libs.versions.toml | sed -E "s/^.*\"(.*)\"/\1/")
           inst_version=$(./gradlew --console=plain android-agent:dependencies | \
                         grep 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom ' | \
                         sed -e "s/.* -> //" | sed -e "s/ .*//" | \


### PR DESCRIPTION
Looks like #665 did not do the trick, [still broken](https://github.com/open-telemetry/opentelemetry-android/actions/runs/11559453062)....so I used a yaml validator and it caught an issue related to a comment:

<img width="819" alt="image" src="https://github.com/user-attachments/assets/ad60d9b2-1871-4ad0-b482-031492fae188">

So let's just remove that commented line and hope that does the trick. 