### PR TITLE
Relax the ServiceManager singleton nature

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRum.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRum.java
@@ -61,14 +61,16 @@ public interface OpenTelemetryRum {
      * @param openTelemetrySdk The {@link OpenTelemetrySdk} that the user has already created.
      * @param discoverInstrumentations TRUE to look for instrumentations in the classpath and
      *     applying them automatically.
+     * @param serviceManager The ServiceManager instance
      */
     static SdkPreconfiguredRumBuilder builder(
             Application application,
             OpenTelemetrySdk openTelemetrySdk,
-            boolean discoverInstrumentations) {
+            boolean discoverInstrumentations,
+            ServiceManager serviceManager) {
         ServiceManager.initialize(application);
         return new SdkPreconfiguredRumBuilder(
-                application, openTelemetrySdk, discoverInstrumentations, ServiceManager.get());
+                application, openTelemetrySdk, discoverInstrumentations, serviceManager);
     }
 
     /** Returns a no-op implementation of {@link OpenTelemetryRum}. */

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRum.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRum.java
@@ -68,7 +68,7 @@ public interface OpenTelemetryRum {
             OpenTelemetrySdk openTelemetrySdk,
             boolean discoverInstrumentations,
             ServiceManager serviceManager) {
-        ServiceManager.initialize(application);
+
         return new SdkPreconfiguredRumBuilder(
                 application, openTelemetrySdk, discoverInstrumentations, serviceManager);
     }

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -9,9 +9,7 @@ import static java.util.Objects.requireNonNull;
 
 import android.app.Application;
 import android.util.Log;
-
 import androidx.annotation.NonNull;
-
 import io.opentelemetry.android.common.RumConstants;
 import io.opentelemetry.android.config.OtelRumConfig;
 import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfiguration;
@@ -89,8 +87,7 @@ public final class OpenTelemetryRumBuilder {
 
     private Resource resource;
 
-    @Nullable
-    private ServiceManager serviceManager;
+    @Nullable private ServiceManager serviceManager;
 
     private static TextMapPropagator buildDefaultPropagator() {
         return TextMapPropagator.composite(
@@ -281,8 +278,7 @@ public final class OpenTelemetryRumBuilder {
         SignalFromDiskExporter signalFromDiskExporter = null;
         if (diskBufferingConfiguration.isEnabled()) {
             try {
-                StorageConfiguration storageConfiguration =
-                        createStorageConfiguration();
+                StorageConfiguration storageConfiguration = createStorageConfiguration();
                 final SpanExporter originalSpanExporter = spanExporter;
                 spanExporter =
                         SpanToDiskExporter.create(originalSpanExporter, storageConfiguration);
@@ -332,7 +328,7 @@ public final class OpenTelemetryRumBuilder {
 
     @NonNull
     private ServiceManager getServiceManager() {
-        if(serviceManager == null){
+        if (serviceManager == null) {
             ServiceManager.initialize(application);
             serviceManager = ServiceManager.get();
         }
@@ -344,8 +340,7 @@ public final class OpenTelemetryRumBuilder {
         return this;
     }
 
-    private StorageConfiguration createStorageConfiguration()
-            throws IOException {
+    private StorageConfiguration createStorageConfiguration() throws IOException {
         Preferences preferences = getServiceManager().getPreferences();
         CacheStorage storage = getServiceManager().getCacheStorage();
         DiskBufferingConfiguration config = this.config.getDiskBufferingConfiguration();

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -26,6 +26,7 @@ import io.opentelemetry.android.internal.processors.GlobalAttributesLogRecordApp
 import io.opentelemetry.android.internal.services.CacheStorage;
 import io.opentelemetry.android.internal.services.Preferences;
 import io.opentelemetry.android.internal.services.ServiceManager;
+import io.opentelemetry.android.internal.services.ServiceManagerImpl;
 import io.opentelemetry.android.internal.services.periodicwork.PeriodicWorkService;
 import io.opentelemetry.android.session.SessionManager;
 import io.opentelemetry.android.session.SessionProvider;
@@ -334,8 +335,7 @@ public final class OpenTelemetryRumBuilder {
     @NonNull
     private ServiceManager getServiceManager() {
         if (serviceManager == null) {
-            ServiceManager.initialize(application);
-            serviceManager = ServiceManager.get();
+            serviceManager = ServiceManagerImpl.Companion.create(application);
         }
         return serviceManager;
     }

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -346,8 +346,8 @@ public final class OpenTelemetryRumBuilder {
     }
 
     /**
-     * Sets a scheduler that will take care of periodically read data stored in disk and export
-     * it. If not specified, the default schedule exporter will be used.
+     * Sets a scheduler that will take care of periodically read data stored in disk and export it.
+     * If not specified, the default schedule exporter will be used.
      */
     public OpenTelemetryRumBuilder setExportScheduleHandler(
             ExportScheduleHandler exportScheduleHandler) {
@@ -374,7 +374,7 @@ public final class OpenTelemetryRumBuilder {
 
     private void scheduleDiskTelemetryReader(@Nullable SignalFromDiskExporter signalExporter) {
 
-        if(exportScheduleHandler == null){
+        if (exportScheduleHandler == null) {
             ServiceManager serviceManager = getServiceManager();
             // TODO: Is it safe to get the work service yet here? If so, we can
             // avoid all this lazy supplier stuff....

--- a/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
@@ -8,6 +8,7 @@ package io.opentelemetry.android
 import android.app.Application
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.instrumentation.AndroidInstrumentationLoader
+import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.internal.services.ServiceManager
 import io.opentelemetry.android.session.SessionManager
 import io.opentelemetry.sdk.OpenTelemetrySdk
@@ -53,8 +54,9 @@ class SdkPreconfiguredRumBuilder
             val openTelemetryRum = OpenTelemetryRumImpl(sdk, sessionManager)
 
             // Install instrumentations
+            val ctx = InstallationContext(application, openTelemetryRum.openTelemetry, serviceManager)
             for (instrumentation in getInstrumentations()) {
-                instrumentation.install(application, openTelemetryRum.openTelemetry)
+                instrumentation.install(ctx)
             }
 
             return openTelemetryRum

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfiguration.java
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfiguration.java
@@ -6,10 +6,14 @@
 package io.opentelemetry.android.features.diskbuffering;
 
 import io.opentelemetry.android.features.diskbuffering.scheduler.DefaultExportScheduleHandler;
+import io.opentelemetry.android.features.diskbuffering.scheduler.DefaultExportScheduler;
 import io.opentelemetry.android.features.diskbuffering.scheduler.ExportScheduleHandler;
+import io.opentelemetry.android.internal.services.ServiceManager;
+import io.opentelemetry.android.internal.services.periodicwork.PeriodicWorkService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import kotlin.jvm.functions.Function0;
 
 /** Configuration for disk buffering. */
 public final class DiskBufferingConfiguration {
@@ -71,7 +75,11 @@ public final class DiskBufferingConfiguration {
         private long minFileAgeForReadMillis = TimeUnit.SECONDS.toMillis(33);
         private long maxFileAgeForReadMillis = TimeUnit.HOURS.toMillis(18);
 
-        private ExportScheduleHandler exportScheduleHandler = DefaultExportScheduleHandler.create();
+        private final Function0<PeriodicWorkService> getWorkService =
+                () -> ServiceManager.get().getPeriodicWorkService();
+        private ExportScheduleHandler exportScheduleHandler =
+                new DefaultExportScheduleHandler(
+                        new DefaultExportScheduler(getWorkService), getWorkService);
 
         /** Enables or disables disk buffering. */
         public Builder setEnabled(boolean enabled) {

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfiguration.java
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfiguration.java
@@ -5,15 +5,9 @@
 
 package io.opentelemetry.android.features.diskbuffering;
 
-import io.opentelemetry.android.features.diskbuffering.scheduler.DefaultExportScheduleHandler;
-import io.opentelemetry.android.features.diskbuffering.scheduler.DefaultExportScheduler;
-import io.opentelemetry.android.features.diskbuffering.scheduler.ExportScheduleHandler;
-import io.opentelemetry.android.internal.services.ServiceManager;
-import io.opentelemetry.android.internal.services.periodicwork.PeriodicWorkService;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import kotlin.jvm.functions.Function0;
 
 /** Configuration for disk buffering. */
 public final class DiskBufferingConfiguration {
@@ -22,7 +16,6 @@ public final class DiskBufferingConfiguration {
 
     private final boolean enabled;
     private final int maxCacheSize;
-    private final ExportScheduleHandler exportScheduleHandler;
     private final long maxFileAgeForWriteMillis;
     private final long minFileAgeForReadMillis;
     private final long maxFileAgeForReadMillis;
@@ -30,7 +23,6 @@ public final class DiskBufferingConfiguration {
     private DiskBufferingConfiguration(Builder builder) {
         enabled = builder.enabled;
         maxCacheSize = builder.maxCacheSize;
-        exportScheduleHandler = builder.exportScheduleHandler;
         maxFileAgeForWriteMillis = builder.maxFileAgeForWriteMillis;
         minFileAgeForReadMillis = builder.minFileAgeForReadMillis;
         maxFileAgeForReadMillis = builder.maxFileAgeForReadMillis;
@@ -52,10 +44,6 @@ public final class DiskBufferingConfiguration {
         return MAX_FILE_SIZE;
     }
 
-    public ExportScheduleHandler getExportScheduleHandler() {
-        return exportScheduleHandler;
-    }
-
     public long getMaxFileAgeForWriteMillis() {
         return maxFileAgeForWriteMillis;
     }
@@ -74,12 +62,6 @@ public final class DiskBufferingConfiguration {
         private long maxFileAgeForWriteMillis = TimeUnit.SECONDS.toMillis(30);
         private long minFileAgeForReadMillis = TimeUnit.SECONDS.toMillis(33);
         private long maxFileAgeForReadMillis = TimeUnit.HOURS.toMillis(18);
-
-        private final Function0<PeriodicWorkService> getWorkService =
-                () -> ServiceManager.get().getPeriodicWorkService();
-        private ExportScheduleHandler exportScheduleHandler =
-                new DefaultExportScheduleHandler(
-                        new DefaultExportScheduler(getWorkService), getWorkService);
 
         /** Enables or disables disk buffering. */
         public Builder setEnabled(boolean enabled) {
@@ -118,15 +100,6 @@ public final class DiskBufferingConfiguration {
          */
         public Builder setMaxCacheSize(int maxCacheSize) {
             this.maxCacheSize = maxCacheSize;
-            return this;
-        }
-
-        /**
-         * Sets a scheduler that will take care of periodically read data stored in disk and export
-         * it.
-         */
-        public Builder setExportScheduleHandler(ExportScheduleHandler exportScheduleHandler) {
-            this.exportScheduleHandler = exportScheduleHandler;
             return this;
         }
 

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduleHandler.kt
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduleHandler.kt
@@ -28,7 +28,9 @@ class DefaultExportScheduleHandler(
         fun create(): DefaultExportScheduleHandler {
             val serviceManager = ServiceManager.get()
             return DefaultExportScheduleHandler(
-                DefaultExportScheduler.create(serviceManager),
+                DefaultExportScheduler {
+                    serviceManager.getPeriodicWorkService()
+                }
             ) {
                 serviceManager.getPeriodicWorkService()
             }

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduleHandler.kt
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduleHandler.kt
@@ -26,10 +26,11 @@ class DefaultExportScheduleHandler(
     companion object {
         @JvmStatic
         fun create(): DefaultExportScheduleHandler {
+            val serviceManager = ServiceManager.get()
             return DefaultExportScheduleHandler(
-                DefaultExportScheduler.create(),
+                DefaultExportScheduler.create(serviceManager),
             ) {
-                ServiceManager.get().getPeriodicWorkService()
+                serviceManager.getPeriodicWorkService()
             }
         }
     }

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduleHandler.kt
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduleHandler.kt
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.android.features.diskbuffering.scheduler
 
-import io.opentelemetry.android.internal.services.ServiceManager
 import io.opentelemetry.android.internal.services.periodicwork.PeriodicWorkService
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -20,20 +19,6 @@ class DefaultExportScheduleHandler(
     override fun enable() {
         if (!enabled.getAndSet(true)) {
             periodicWorkService.enqueue(exportScheduler)
-        }
-    }
-
-    companion object {
-        @JvmStatic
-        fun create(): DefaultExportScheduleHandler {
-            val serviceManager = ServiceManager.get()
-            return DefaultExportScheduleHandler(
-                DefaultExportScheduler {
-                    serviceManager.getPeriodicWorkService()
-                }
-            ) {
-                serviceManager.getPeriodicWorkService()
-            }
         }
     }
 }

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduler.kt
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduler.kt
@@ -18,12 +18,6 @@ class DefaultExportScheduler(periodicWorkServiceProvider: () -> PeriodicWorkServ
     PeriodicRunnable(periodicWorkServiceProvider) {
     companion object {
         private val DELAY_BEFORE_NEXT_EXPORT_IN_MILLIS = TimeUnit.SECONDS.toMillis(10)
-
-        fun create(serviceManager: ServiceManager): DefaultExportScheduler {
-            return DefaultExportScheduler {
-                serviceManager.getPeriodicWorkService()
-            }
-        }
     }
 
     override fun onRun() {

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduler.kt
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduler.kt
@@ -8,7 +8,6 @@ package io.opentelemetry.android.features.diskbuffering.scheduler
 import android.util.Log
 import io.opentelemetry.android.common.RumConstants.OTEL_RUM_LOG_TAG
 import io.opentelemetry.android.features.diskbuffering.SignalFromDiskExporter
-import io.opentelemetry.android.internal.services.ServiceManager
 import io.opentelemetry.android.internal.services.periodicwork.PeriodicRunnable
 import io.opentelemetry.android.internal.services.periodicwork.PeriodicWorkService
 import java.io.IOException

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduler.kt
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduler.kt
@@ -19,9 +19,9 @@ class DefaultExportScheduler(periodicWorkServiceProvider: () -> PeriodicWorkServ
     companion object {
         private val DELAY_BEFORE_NEXT_EXPORT_IN_MILLIS = TimeUnit.SECONDS.toMillis(10)
 
-        fun create(): DefaultExportScheduler {
+        fun create(serviceManager: ServiceManager): DefaultExportScheduler {
             return DefaultExportScheduler {
-                ServiceManager.get().getPeriodicWorkService()
+                serviceManager.getPeriodicWorkService()
             }
         }
     }

--- a/core/src/main/java/io/opentelemetry/android/instrumentation/AndroidInstrumentation.kt
+++ b/core/src/main/java/io/opentelemetry/android/instrumentation/AndroidInstrumentation.kt
@@ -5,9 +5,7 @@
 
 package io.opentelemetry.android.instrumentation
 
-import android.app.Application
 import io.opentelemetry.android.OpenTelemetryRum
-import io.opentelemetry.api.OpenTelemetry
 
 /**
  * This interface defines a tool that automatically generates telemetry for a specific use-case,
@@ -30,11 +28,7 @@ interface AndroidInstrumentation {
      * only be called from [OpenTelemetryRum]'s builder once the [OpenTelemetryRum] instance is initialized and ready
      * to use for generating telemetry.
      *
-     * @param application The Android application being instrumented.
-     * @param openTelemetry The [OpenTelemetry] instance to use for creating signals.
+     * @param ctx The InstallationContext under which the instrumentation is being installed
      */
-    fun install(
-        application: Application,
-        openTelemetry: OpenTelemetry,
-    )
+    fun install(ctx: InstallationContext)
 }

--- a/core/src/main/java/io/opentelemetry/android/instrumentation/AndroidInstrumentation.kt
+++ b/core/src/main/java/io/opentelemetry/android/instrumentation/AndroidInstrumentation.kt
@@ -28,7 +28,7 @@ interface AndroidInstrumentation {
      * only be called from [OpenTelemetryRum]'s builder once the [OpenTelemetryRum] instance is initialized and ready
      * to use for generating telemetry.
      *
-     * @param ctx The InstallationContext under which the instrumentation is being installed
+     * @param ctx The InstallationContext under which the instrumentation is being installed.
      */
     fun install(ctx: InstallationContext)
 }

--- a/core/src/main/java/io/opentelemetry/android/instrumentation/InstallationContext.kt
+++ b/core/src/main/java/io/opentelemetry/android/instrumentation/InstallationContext.kt
@@ -1,0 +1,11 @@
+package io.opentelemetry.android.instrumentation
+
+import android.app.Application
+import io.opentelemetry.android.internal.services.ServiceManager
+import io.opentelemetry.api.OpenTelemetry
+
+data class InstallationContext(
+    val application: Application,
+    val openTelemetry: OpenTelemetry,
+    val serviceManager: ServiceManager
+)

--- a/core/src/main/java/io/opentelemetry/android/instrumentation/InstallationContext.kt
+++ b/core/src/main/java/io/opentelemetry/android/instrumentation/InstallationContext.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.android.instrumentation
 
 import android.app.Application
@@ -7,5 +12,5 @@ import io.opentelemetry.api.OpenTelemetry
 data class InstallationContext(
     val application: Application,
     val openTelemetry: OpenTelemetry,
-    val serviceManager: ServiceManager
+    val serviceManager: ServiceManager,
 )

--- a/core/src/main/java/io/opentelemetry/android/internal/services/ServiceManager.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/services/ServiceManager.kt
@@ -35,19 +35,7 @@ interface ServiceManager : Startable {
             if (instance != null) {
                 return
             }
-            instance =
-                ServiceManagerImpl(
-                    listOf(
-                        Preferences.create(application),
-                        CacheStorage(
-                            application,
-                        ),
-                        PeriodicWorkService(),
-                        CurrentNetworkProvider.create(application),
-                        AppLifecycleService.create(),
-                        VisibleScreenService.create(application),
-                    ),
-                )
+            instance = ServiceManagerImpl.create(application)
         }
 
         @JvmStatic

--- a/core/src/main/java/io/opentelemetry/android/internal/services/ServiceManager.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/services/ServiceManager.kt
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.android.internal.services
 
-import android.app.Application
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycleService
 import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
 import io.opentelemetry.android.internal.services.periodicwork.PeriodicWorkService
@@ -26,27 +25,4 @@ interface ServiceManager : Startable {
     fun getAppLifecycleService(): AppLifecycleService
 
     fun getVisibleScreenService(): VisibleScreenService
-
-    companion object {
-        private var instance: ServiceManager? = null
-
-        @JvmStatic
-        fun initialize(application: Application) {
-            if (instance != null) {
-                return
-            }
-            instance = ServiceManagerImpl.create(application)
-        }
-
-        @JvmStatic
-        fun get(): ServiceManager {
-            checkNotNull(instance) { "Services haven't been initialized" }
-            return instance!!
-        }
-
-        @JvmStatic
-        fun resetForTest() {
-            instance = null
-        }
-    }
 }

--- a/core/src/main/java/io/opentelemetry/android/internal/services/ServiceManagerImpl.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/services/ServiceManagerImpl.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.android.internal.services
 
+import android.app.Application
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycleService
 import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
 import io.opentelemetry.android.internal.services.periodicwork.PeriodicWorkService
@@ -20,6 +21,24 @@ internal class ServiceManagerImpl(services: List<Any>) : ServiceManager {
             map[service.javaClass] = service
         }
         this.services = Collections.unmodifiableMap(map)
+    }
+
+    companion object {
+        @JvmStatic
+        fun create(application: Application): ServiceManager {
+            return ServiceManagerImpl(
+                listOf(
+                    Preferences.create(application),
+                    CacheStorage(
+                        application,
+                    ),
+                    PeriodicWorkService(),
+                    CurrentNetworkProvider.create(application),
+                    AppLifecycleService.create(),
+                    VisibleScreenService.create(application),
+                ),
+            )
+        }
     }
 
     override fun getPreferences(): Preferences {

--- a/core/src/main/java/io/opentelemetry/android/internal/services/ServiceManagerImpl.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/services/ServiceManagerImpl.kt
@@ -29,9 +29,7 @@ internal class ServiceManagerImpl(services: List<Any>) : ServiceManager {
             return ServiceManagerImpl(
                 listOf(
                     Preferences.create(application),
-                    CacheStorage(
-                        application,
-                    ),
+                    CacheStorage(application),
                     PeriodicWorkService(),
                     CurrentNetworkProvider.create(application),
                     AppLifecycleService.create(),

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -457,7 +457,8 @@ public class OpenTelemetryRumBuilderTest {
         when(openTelemetrySdk.getLogsBridge()).thenReturn(logsBridge);
         when(logsBridge.loggerBuilder(any())).thenReturn(loggerBuilder);
 
-        OpenTelemetryRum.builder(application, openTelemetrySdk, true).build();
+        OpenTelemetryRum.builder(application, openTelemetrySdk, true, createServiceManager())
+                .build();
 
         assertThat(ServiceManager.get()).isNotNull();
     }

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -327,13 +327,13 @@ public class OpenTelemetryRumBuilderTest {
         OtelRumConfig config = buildConfig();
         ExportScheduleHandler scheduleHandler = mock();
         config.setDiskBufferingConfiguration(
-                DiskBufferingConfiguration.builder()
-                        .setEnabled(true)
-                        .setExportScheduleHandler(scheduleHandler)
-                        .build());
+                DiskBufferingConfiguration.builder().setEnabled(true).build());
         ArgumentCaptor<SpanExporter> exporterCaptor = ArgumentCaptor.forClass(SpanExporter.class);
 
-        OpenTelemetryRum.builder(application, config).setServiceManager(serviceManager).build();
+        OpenTelemetryRum.builder(application, config)
+                .setExportScheduleHandler(scheduleHandler)
+                .setServiceManager(serviceManager)
+                .build();
 
         assertThat(SignalFromDiskExporter.get()).isNotNull();
         verify(scheduleHandler).enable();
@@ -357,12 +357,12 @@ public class OpenTelemetryRumBuilderTest {
         ArgumentCaptor<SpanExporter> exporterCaptor = ArgumentCaptor.forClass(SpanExporter.class);
         OtelRumConfig config = buildConfig();
         config.setDiskBufferingConfiguration(
-                DiskBufferingConfiguration.builder()
-                        .setEnabled(true)
-                        .setExportScheduleHandler(scheduleHandler)
-                        .build());
+                DiskBufferingConfiguration.builder().setEnabled(true).build());
 
-        OpenTelemetryRum.builder(application, config).setServiceManager(serviceManager).build();
+        OpenTelemetryRum.builder(application, config)
+                .setServiceManager(serviceManager)
+                .setExportScheduleHandler(scheduleHandler)
+                .build();
 
         verify(initializationEvents).spanExporterInitialized(exporterCaptor.capture());
         verify(scheduleHandler, never()).enable();
@@ -389,12 +389,11 @@ public class OpenTelemetryRumBuilderTest {
 
         OtelRumConfig config = buildConfig();
         config.setDiskBufferingConfiguration(
-                DiskBufferingConfiguration.builder()
-                        .setEnabled(false)
-                        .setExportScheduleHandler(scheduleHandler)
-                        .build());
+                DiskBufferingConfiguration.builder().setEnabled(false).build());
 
-        OpenTelemetryRum.builder(application, config).build();
+        OpenTelemetryRum.builder(application, config)
+                .setExportScheduleHandler(scheduleHandler)
+                .build();
 
         verify(initializationEvents).spanExporterInitialized(exporterCaptor.capture());
         verify(scheduleHandler, never()).enable();

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -124,7 +124,9 @@ public class OpenTelemetryRumBuilderTest {
         ServiceManager serviceManager = createServiceManager();
         AppLifecycleService appLifecycleService = serviceManager.getAppLifecycleService();
 
-        makeBuilder().build(serviceManager);
+        makeBuilder()
+                .setServiceManager(serviceManager)
+                .build();
 
         verify(appLifecycleService).registerListener(isA(ApplicationStateListener.class));
     }
@@ -203,7 +205,8 @@ public class OpenTelemetryRumBuilderTest {
 
         new OpenTelemetryRumBuilder(application, buildConfig(), timeoutHandler)
                 .addInstrumentation(localInstrumentation)
-                .build(serviceManager);
+                .setServiceManager(serviceManager)
+                .build();
 
         verify(serviceManager.getAppLifecycleService()).registerListener(timeoutHandler);
 
@@ -226,7 +229,8 @@ public class OpenTelemetryRumBuilderTest {
                         buildConfig().disableInstrumentationDiscovery(),
                         timeoutHandler)
                 .addInstrumentation(localInstrumentation)
-                .build(serviceManager);
+                .setServiceManager(serviceManager)
+                .build();
 
         verify(serviceManager.getAppLifecycleService()).registerListener(timeoutHandler);
 
@@ -328,7 +332,7 @@ public class OpenTelemetryRumBuilderTest {
                         .build());
         ArgumentCaptor<SpanExporter> exporterCaptor = ArgumentCaptor.forClass(SpanExporter.class);
 
-        OpenTelemetryRum.builder(application, config).build(serviceManager);
+        OpenTelemetryRum.builder(application, config).setServiceManager(serviceManager).build();
 
         assertThat(SignalFromDiskExporter.get()).isNotNull();
         verify(scheduleHandler).enable();
@@ -357,7 +361,7 @@ public class OpenTelemetryRumBuilderTest {
                         .setExportScheduleHandler(scheduleHandler)
                         .build());
 
-        OpenTelemetryRum.builder(application, config).build(serviceManager);
+        OpenTelemetryRum.builder(application, config).setServiceManager(serviceManager).build();
 
         verify(initializationEvents).spanExporterInitialized(exporterCaptor.capture());
         verify(scheduleHandler, never()).enable();
@@ -372,7 +376,8 @@ public class OpenTelemetryRumBuilderTest {
         AtomicReference<OpenTelemetrySdk> seen = new AtomicReference<>();
         OpenTelemetryRum.builder(application, config)
                 .addOtelSdkReadyListener(seen::set)
-                .build(createServiceManager());
+                .setServiceManager(createServiceManager())
+                .build();
         assertThat(seen.get()).isNotNull();
     }
 
@@ -437,7 +442,7 @@ public class OpenTelemetryRumBuilderTest {
         ServiceManager serviceManager = mock();
         doReturn(mock(AppLifecycleService.class)).when(serviceManager).getAppLifecycleService();
 
-        makeBuilder().build(serviceManager);
+        makeBuilder().setServiceManager(serviceManager).build();
 
         verify(serviceManager).start();
     }

--- a/core/src/test/java/io/opentelemetry/android/instrumentation/TestAndroidInstrumentation.kt
+++ b/core/src/test/java/io/opentelemetry/android/instrumentation/TestAndroidInstrumentation.kt
@@ -5,17 +5,11 @@
 
 package io.opentelemetry.android.instrumentation
 
-import android.app.Application
-import io.opentelemetry.api.OpenTelemetry
-
 class TestAndroidInstrumentation : AndroidInstrumentation {
     var installed = false
         private set
 
-    override fun install(
-        application: Application,
-        openTelemetry: OpenTelemetry,
-    ) {
+    override fun install(ctx: InstallationContext) {
         installed = true
     }
 }

--- a/core/src/test/java/io/opentelemetry/android/internal/instrumentation/AndroidInstrumentationLoaderImplTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/instrumentation/AndroidInstrumentationLoaderImplTest.kt
@@ -25,7 +25,7 @@ class AndroidInstrumentationLoaderImplTest {
 
         assertThat(instrumentation.installed).isFalse()
 
-        instrumentation.install(mockk(), mockk())
+        instrumentation.install(mockk())
 
         assertThat(loader.getByType(TestAndroidInstrumentation::class.java)!!.installed).isTrue()
     }

--- a/core/src/test/java/io/opentelemetry/android/internal/services/ServiceManagerImplTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/services/ServiceManagerImplTest.kt
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.android.internal.services
 
-import io.opentelemetry.android.internal.services.ServiceManager.Companion.initialize
 import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
 import io.opentelemetry.android.internal.services.periodicwork.PeriodicWorkService
 import org.assertj.core.api.Assertions.assertThat
@@ -21,10 +20,10 @@ import org.robolectric.RuntimeEnvironment
 @RunWith(RobolectricTestRunner::class)
 class ServiceManagerImplTest {
     @Test
-    fun verifyAvailableServices() {
-        initialize(RuntimeEnvironment.getApplication())
+    fun verifyAvailableDefaultServices() {
+        val app = RuntimeEnvironment.getApplication()
 
-        val serviceManager = ServiceManager.get()
+        val serviceManager = ServiceManagerImpl.create(app)
 
         assertThat(serviceManager.getPeriodicWorkService()).isInstanceOf(PeriodicWorkService::class.java)
         assertThat(serviceManager.getCacheStorage()).isInstanceOf(CacheStorage::class.java)

--- a/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentation.kt
+++ b/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentation.kt
@@ -12,9 +12,7 @@ import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.instrumentation.activity.startup.AppStartupTimer
 import io.opentelemetry.android.instrumentation.common.Constants.INSTRUMENTATION_SCOPE
 import io.opentelemetry.android.instrumentation.common.ScreenNameExtractor
-import io.opentelemetry.android.internal.services.ServiceManager
 import io.opentelemetry.android.internal.services.visiblescreen.activities.DefaultingActivityLifecycleCallbacks
-import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.Tracer
 
 @AutoService(AndroidInstrumentation::class)
@@ -34,12 +32,12 @@ class ActivityLifecycleInstrumentation : AndroidInstrumentation {
     override fun install(ctx: InstallationContext) {
         startupTimer.start(ctx.openTelemetry.getTracer(INSTRUMENTATION_SCOPE))
         ctx.application.registerActivityLifecycleCallbacks(startupTimer.createLifecycleCallback())
-        ctx.application.registerActivityLifecycleCallbacks(buildActivityLifecycleTracer(ctx.openTelemetry))
+        ctx.application.registerActivityLifecycleCallbacks(buildActivityLifecycleTracer(ctx))
     }
 
-    private fun buildActivityLifecycleTracer(openTelemetry: OpenTelemetry): DefaultingActivityLifecycleCallbacks {
-        val visibleScreenService = ServiceManager.get().getVisibleScreenService()
-        val delegateTracer: Tracer = openTelemetry.getTracer(INSTRUMENTATION_SCOPE)
+    private fun buildActivityLifecycleTracer(ctx: InstallationContext): DefaultingActivityLifecycleCallbacks {
+        val visibleScreenService = ctx.serviceManager.getVisibleScreenService()
+        val delegateTracer: Tracer = ctx.openTelemetry.getTracer(INSTRUMENTATION_SCOPE)
         val tracers =
             ActivityTracerCache(
                 tracerCustomizer.invoke(delegateTracer),

--- a/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentation.kt
+++ b/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentation.kt
@@ -5,10 +5,10 @@
 
 package io.opentelemetry.android.instrumentation.activity
 
-import android.app.Application
 import android.os.Build
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
+import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.instrumentation.activity.startup.AppStartupTimer
 import io.opentelemetry.android.instrumentation.common.Constants.INSTRUMENTATION_SCOPE
 import io.opentelemetry.android.instrumentation.common.ScreenNameExtractor
@@ -31,13 +31,10 @@ class ActivityLifecycleInstrumentation : AndroidInstrumentation {
         this.screenNameExtractor = screenNameExtractor
     }
 
-    override fun install(
-        application: Application,
-        openTelemetry: OpenTelemetry,
-    ) {
-        startupTimer.start(openTelemetry.getTracer(INSTRUMENTATION_SCOPE))
-        application.registerActivityLifecycleCallbacks(startupTimer.createLifecycleCallback())
-        application.registerActivityLifecycleCallbacks(buildActivityLifecycleTracer(openTelemetry))
+    override fun install(ctx: InstallationContext) {
+        startupTimer.start(ctx.openTelemetry.getTracer(INSTRUMENTATION_SCOPE))
+        ctx.application.registerActivityLifecycleCallbacks(startupTimer.createLifecycleCallback())
+        ctx.application.registerActivityLifecycleCallbacks(buildActivityLifecycleTracer(ctx.openTelemetry))
     }
 
     private fun buildActivityLifecycleTracer(openTelemetry: OpenTelemetry): DefaultingActivityLifecycleCallbacks {

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityInstrumentationTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityInstrumentationTest.kt
@@ -12,6 +12,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.common.RumConstants
+import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.internal.services.ServiceManager.Companion
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanBuilder
@@ -52,7 +53,8 @@ class ActivityInstrumentationTest {
         )
         every { startupSpanBuilder.startSpan() }.returns(startupSpan)
 
-        activityLifecycleInstrumentation.install(application, openTelemetry)
+        val ctx = InstallationContext(application, openTelemetry, mockk())
+        activityLifecycleInstrumentation.install(ctx)
 
         verify {
             tracer.spanBuilder("AppStart")

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityInstrumentationTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityInstrumentationTest.kt
@@ -27,7 +27,6 @@ import org.robolectric.RuntimeEnvironment
 class ActivityInstrumentationTest {
     private lateinit var activityLifecycleInstrumentation: ActivityLifecycleInstrumentation
     private lateinit var application: Application
-    private lateinit var openTelemetryRum: OpenTelemetryRum
     private lateinit var openTelemetry: OpenTelemetrySdk
 
     @Before

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentationTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentationTest.kt
@@ -10,10 +10,10 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.common.RumConstants
 import io.opentelemetry.android.instrumentation.InstallationContext
-import io.opentelemetry.android.internal.services.ServiceManager.Companion
+import io.opentelemetry.android.internal.services.ServiceManager
+import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenService
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanBuilder
 import io.opentelemetry.api.trace.Tracer
@@ -24,18 +24,19 @@ import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
 
 @RunWith(AndroidJUnit4::class)
-class ActivityInstrumentationTest {
+class ActivityLifecycleInstrumentationTest {
     private lateinit var activityLifecycleInstrumentation: ActivityLifecycleInstrumentation
     private lateinit var application: Application
     private lateinit var openTelemetry: OpenTelemetrySdk
+    private lateinit var serviceManager: ServiceManager
 
     @Before
     fun setUp() {
         application = RuntimeEnvironment.getApplication()
         openTelemetry = mockk()
         activityLifecycleInstrumentation = ActivityLifecycleInstrumentation()
-
-        Companion.initialize(application)
+        serviceManager = mockk()
+        every { serviceManager.getVisibleScreenService() }.returns(mockk<VisibleScreenService>())
     }
 
     @Test
@@ -52,7 +53,7 @@ class ActivityInstrumentationTest {
         )
         every { startupSpanBuilder.startSpan() }.returns(startupSpan)
 
-        val ctx = InstallationContext(application, openTelemetry, mockk())
+        val ctx = InstallationContext(application, openTelemetry, serviceManager)
         activityLifecycleInstrumentation.install(ctx)
 
         verify {

--- a/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrInstrumentation.java
+++ b/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrInstrumentation.java
@@ -5,13 +5,11 @@
 
 package io.opentelemetry.android.instrumentation.anr;
 
-import android.app.Application;
 import android.os.Looper;
 import androidx.annotation.NonNull;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
-import io.opentelemetry.android.internal.services.ServiceManager;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.android.instrumentation.InstallationContext;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.util.ArrayList;
 import java.util.List;
@@ -47,14 +45,14 @@ public final class AnrInstrumentation implements AndroidInstrumentation {
     }
 
     @Override
-    public void install(@NonNull Application application, @NonNull OpenTelemetry openTelemetry) {
+    public void install(@NonNull InstallationContext ctx) {
         AnrDetector anrDetector =
                 new AnrDetector(
                         additionalExtractors,
                         mainLooper,
                         scheduler,
-                        ServiceManager.get().getAppLifecycleService(),
-                        openTelemetry);
+                        ctx.getServiceManager().getAppLifecycleService(),
+                        ctx.getOpenTelemetry());
         anrDetector.start();
     }
 }

--- a/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporterInstrumentation.java
+++ b/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporterInstrumentation.java
@@ -5,12 +5,11 @@
 
 package io.opentelemetry.android.instrumentation.crash;
 
-import android.app.Application;
 import androidx.annotation.NonNull;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.android.RuntimeDetailsExtractor;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.android.instrumentation.InstallationContext;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import java.util.ArrayList;
@@ -28,9 +27,9 @@ public final class CrashReporterInstrumentation implements AndroidInstrumentatio
     }
 
     @Override
-    public void install(@NonNull Application application, @NonNull OpenTelemetry openTelemetry) {
-        addAttributesExtractor(RuntimeDetailsExtractor.create(application));
+    public void install(@NonNull InstallationContext ctx) {
+        addAttributesExtractor(RuntimeDetailsExtractor.create(ctx.getApplication()));
         CrashReporter crashReporter = new CrashReporter(additionalExtractors);
-        crashReporter.install((OpenTelemetrySdk) openTelemetry);
+        crashReporter.install((OpenTelemetrySdk) ctx.getOpenTelemetry());
     }
 }

--- a/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReporterTest.java
+++ b/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReporterTest.java
@@ -8,8 +8,11 @@ package io.opentelemetry.android.instrumentation.crash;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor.constant;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import io.opentelemetry.android.instrumentation.InstallationContext;
+import io.opentelemetry.android.internal.services.ServiceManager;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.logs.SdkLoggerProvider;
@@ -57,7 +60,12 @@ public class CrashReporterTest {
     public void integrationTest() throws InterruptedException {
         CrashReporterInstrumentation instrumentation = new CrashReporterInstrumentation();
         instrumentation.addAttributesExtractor(constant(stringKey("test.key"), "abc"));
-        instrumentation.install(RuntimeEnvironment.getApplication(), openTelemetrySdk);
+        InstallationContext ctx =
+                new InstallationContext(
+                        RuntimeEnvironment.getApplication(),
+                        openTelemetrySdk,
+                        mock(ServiceManager.class));
+        instrumentation.install(ctx);
 
         String exceptionMessage = "boooom!";
         RuntimeException crash = new RuntimeException(exceptionMessage);

--- a/instrumentation/fragment/src/main/java/io/opentelemetry/android/instrumentation/fragment/FragmentLifecycleInstrumentation.kt
+++ b/instrumentation/fragment/src/main/java/io/opentelemetry/android/instrumentation/fragment/FragmentLifecycleInstrumentation.kt
@@ -5,11 +5,11 @@
 
 package io.opentelemetry.android.instrumentation.fragment
 
-import android.app.Application
 import android.app.Application.ActivityLifecycleCallbacks
 import android.os.Build
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
+import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.instrumentation.common.Constants.INSTRUMENTATION_SCOPE
 import io.opentelemetry.android.instrumentation.common.ScreenNameExtractor
 import io.opentelemetry.android.internal.services.ServiceManager
@@ -30,11 +30,8 @@ class FragmentLifecycleInstrumentation : AndroidInstrumentation {
         this.screenNameExtractor = screenNameExtractor
     }
 
-    override fun install(
-        application: Application,
-        openTelemetry: OpenTelemetry,
-    ) {
-        application.registerActivityLifecycleCallbacks(buildFragmentRegisterer(openTelemetry))
+    override fun install(ctx: InstallationContext) {
+        ctx.application.registerActivityLifecycleCallbacks(buildFragmentRegisterer(ctx.openTelemetry))
     }
 
     private fun buildFragmentRegisterer(openTelemetry: OpenTelemetry): ActivityLifecycleCallbacks {

--- a/instrumentation/fragment/src/main/java/io/opentelemetry/android/instrumentation/fragment/FragmentLifecycleInstrumentation.kt
+++ b/instrumentation/fragment/src/main/java/io/opentelemetry/android/instrumentation/fragment/FragmentLifecycleInstrumentation.kt
@@ -12,9 +12,7 @@ import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.instrumentation.common.Constants.INSTRUMENTATION_SCOPE
 import io.opentelemetry.android.instrumentation.common.ScreenNameExtractor
-import io.opentelemetry.android.internal.services.ServiceManager
 import io.opentelemetry.android.internal.services.visiblescreen.fragments.RumFragmentActivityRegisterer
-import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.Tracer
 
 @AutoService(AndroidInstrumentation::class)
@@ -31,12 +29,12 @@ class FragmentLifecycleInstrumentation : AndroidInstrumentation {
     }
 
     override fun install(ctx: InstallationContext) {
-        ctx.application.registerActivityLifecycleCallbacks(buildFragmentRegisterer(ctx.openTelemetry))
+        ctx.application.registerActivityLifecycleCallbacks(buildFragmentRegisterer(ctx))
     }
 
-    private fun buildFragmentRegisterer(openTelemetry: OpenTelemetry): ActivityLifecycleCallbacks {
-        val visibleScreenService = ServiceManager.get().getVisibleScreenService()
-        val delegateTracer: Tracer = openTelemetry.getTracer(INSTRUMENTATION_SCOPE)
+    private fun buildFragmentRegisterer(ctx: InstallationContext): ActivityLifecycleCallbacks {
+        val visibleScreenService = ctx.serviceManager.getVisibleScreenService()
+        val delegateTracer: Tracer = ctx.openTelemetry.getTracer(INSTRUMENTATION_SCOPE)
         val fragmentLifecycle =
             RumFragmentLifecycleCallbacks(
                 tracerCustomizer.invoke(delegateTracer),

--- a/instrumentation/httpurlconnection/library/src/main/java/io/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlInstrumentation.java
+++ b/instrumentation/httpurlconnection/library/src/main/java/io/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlInstrumentation.java
@@ -5,10 +5,9 @@
 
 package io.opentelemetry.instrumentation.library.httpurlconnection;
 
-import android.app.Application;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.android.instrumentation.InstallationContext;
 import io.opentelemetry.instrumentation.api.incubator.semconv.net.PeerServiceResolver;
 import io.opentelemetry.instrumentation.api.internal.HttpConstants;
 import io.opentelemetry.instrumentation.library.httpurlconnection.internal.HttpUrlConnectionSingletons;
@@ -123,8 +122,8 @@ public class HttpUrlInstrumentation implements AndroidInstrumentation {
     }
 
     @Override
-    public void install(@NotNull Application application, @NotNull OpenTelemetry openTelemetry) {
-        HttpUrlConnectionSingletons.configure(this, openTelemetry);
+    public void install(@NotNull InstallationContext ctx) {
+        HttpUrlConnectionSingletons.configure(this, ctx.getOpenTelemetry());
     }
 
     /**

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentation.java
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentation.java
@@ -9,7 +9,6 @@ import androidx.annotation.NonNull;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
 import io.opentelemetry.android.instrumentation.InstallationContext;
-import io.opentelemetry.android.internal.services.ServiceManager;
 import io.opentelemetry.android.internal.services.network.data.CurrentNetwork;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.util.ArrayList;
@@ -34,8 +33,8 @@ public final class NetworkChangeInstrumentation implements AndroidInstrumentatio
         NetworkChangeMonitor networkChangeMonitor =
                 new NetworkChangeMonitor(
                         ctx.getOpenTelemetry(),
-                        ServiceManager.get().getAppLifecycleService(),
-                        ServiceManager.get().getCurrentNetworkProvider(),
+                        ctx.getServiceManager().getAppLifecycleService(),
+                        ctx.getServiceManager().getCurrentNetworkProvider(),
                         Collections.unmodifiableList(additionalExtractors));
         networkChangeMonitor.start();
     }

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentation.java
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentation.java
@@ -5,13 +5,12 @@
 
 package io.opentelemetry.android.instrumentation.network;
 
-import android.app.Application;
 import androidx.annotation.NonNull;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
+import io.opentelemetry.android.instrumentation.InstallationContext;
 import io.opentelemetry.android.internal.services.ServiceManager;
 import io.opentelemetry.android.internal.services.network.data.CurrentNetwork;
-import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -31,10 +30,10 @@ public final class NetworkChangeInstrumentation implements AndroidInstrumentatio
     }
 
     @Override
-    public void install(@NonNull Application application, @NonNull OpenTelemetry openTelemetry) {
+    public void install(@NonNull InstallationContext ctx) {
         NetworkChangeMonitor networkChangeMonitor =
                 new NetworkChangeMonitor(
-                        openTelemetry,
+                        ctx.getOpenTelemetry(),
                         ServiceManager.get().getAppLifecycleService(),
                         ServiceManager.get().getCurrentNetworkProvider(),
                         Collections.unmodifiableList(additionalExtractors));

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/OkHttpInstrumentation.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/OkHttpInstrumentation.java
@@ -5,10 +5,9 @@
 
 package io.opentelemetry.instrumentation.library.okhttp.v3_0;
 
-import android.app.Application;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.android.instrumentation.InstallationContext;
 import io.opentelemetry.instrumentation.api.incubator.semconv.net.PeerServiceResolver;
 import io.opentelemetry.instrumentation.api.internal.HttpConstants;
 import io.opentelemetry.instrumentation.library.okhttp.v3_0.internal.OkHttp3Singletons;
@@ -123,7 +122,7 @@ public class OkHttpInstrumentation implements AndroidInstrumentation {
     }
 
     @Override
-    public void install(@NotNull Application application, @NotNull OpenTelemetry openTelemetry) {
-        OkHttp3Singletons.configure(this, openTelemetry);
+    public void install(@NotNull InstallationContext ctx) {
+        OkHttp3Singletons.configure(this, ctx.getOpenTelemetry());
     }
 }

--- a/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentation.java
+++ b/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentation.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.android.instrumentation.slowrendering;
 
-import android.app.Application;
 import android.os.Build;
 import android.util.Log;
 import androidx.annotation.NonNull;
@@ -13,7 +12,7 @@ import androidx.annotation.RequiresApi;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.android.common.RumConstants;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
-import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.android.instrumentation.InstallationContext;
 import java.time.Duration;
 
 /** Entrypoint for installing the slow rendering detection instrumentation. */
@@ -43,7 +42,7 @@ public final class SlowRenderingInstrumentation implements AndroidInstrumentatio
 
     @RequiresApi(Build.VERSION_CODES.N)
     @Override
-    public void install(@NonNull Application application, @NonNull OpenTelemetry openTelemetry) {
+    public void install(@NonNull InstallationContext ctx) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             Log.w(
                     RumConstants.OTEL_RUM_LOG_TAG,
@@ -53,10 +52,10 @@ public final class SlowRenderingInstrumentation implements AndroidInstrumentatio
 
         SlowRenderListener detector =
                 new SlowRenderListener(
-                        openTelemetry.getTracer("io.opentelemetry.slow-rendering"),
+                        ctx.getOpenTelemetry().getTracer("io.opentelemetry.slow-rendering"),
                         slowRenderingDetectionPollInterval);
 
-        application.registerActivityLifecycleCallbacks(detector);
+        ctx.getApplication().registerActivityLifecycleCallbacks(detector);
         detector.start();
     }
 }

--- a/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentationTest.kt
+++ b/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentationTest.kt
@@ -14,6 +14,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -63,7 +64,8 @@ class SlowRenderingInstrumentationTest {
     @Config(sdk = [23])
     @Test
     fun `Not installing instrumentation on devices with API level lower than 24`() {
-        slowRenderingInstrumentation.install(application, openTelemetry)
+        val ctx = InstallationContext(application, openTelemetry, mockk())
+        slowRenderingInstrumentation.install(ctx)
 
         verify {
             application wasNot Called
@@ -79,8 +81,8 @@ class SlowRenderingInstrumentationTest {
         val capturedListener = slot<SlowRenderListener>()
         every { openTelemetry.getTracer(any()) }.returns(mockk())
         every { application.registerActivityLifecycleCallbacks(any()) } just Runs
-
-        slowRenderingInstrumentation.install(application, openTelemetry)
+        val ctx = InstallationContext(application, openTelemetry, mockk())
+        slowRenderingInstrumentation.install(ctx)
 
         verify { openTelemetry.getTracer("io.opentelemetry.slow-rendering") }
         verify { application.registerActivityLifecycleCallbacks(capture(capturedListener)) }

--- a/instrumentation/startup/src/main/java/io/opentelemetry/android/instrumentation/startup/StartupInstrumentation.kt
+++ b/instrumentation/startup/src/main/java/io/opentelemetry/android/instrumentation/startup/StartupInstrumentation.kt
@@ -5,21 +5,17 @@
 
 package io.opentelemetry.android.instrumentation.startup
 
-import android.app.Application
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
+import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.internal.initialization.InitializationEvents
-import io.opentelemetry.api.OpenTelemetry
 
 @AutoService(AndroidInstrumentation::class)
 class StartupInstrumentation : AndroidInstrumentation {
-    override fun install(
-        application: Application,
-        openTelemetry: OpenTelemetry,
-    ) {
+    override fun install(ctx: InstallationContext) {
         val events = InitializationEvents.get()
         if (events is SdkInitializationEvents) {
-            events.finish(openTelemetry)
+            events.finish(ctx.openTelemetry)
         }
     }
 }

--- a/instrumentation/startup/src/test/java/io/opentelemetry/android/instrumentation/startup/StartupInstrumentationTest.kt
+++ b/instrumentation/startup/src/test/java/io/opentelemetry/android/instrumentation/startup/StartupInstrumentationTest.kt
@@ -5,14 +5,16 @@
 
 package io.opentelemetry.android.instrumentation.startup
 
+import android.app.Application
 import io.mockk.Called
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
-import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.internal.initialization.InitializationEvents
+import io.opentelemetry.android.internal.services.ServiceManager
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -41,7 +43,7 @@ class StartupInstrumentationTest {
         every { sdkInitializationEvents.finish(any()) } just Runs
         InitializationEvents.set(sdkInitializationEvents)
 
-        instrumentation.install(mockk(), otelTesting.openTelemetry)
+        instrumentation.install(makeContext())
 
         verify {
             sdkInitializationEvents.finish(otelTesting.openTelemetry)
@@ -51,11 +53,18 @@ class StartupInstrumentationTest {
     @Test
     fun `No action when the InitializationEvents instance is not SdkInitializationEvents`() {
         val initializationEvents = mockk<InitializationEvents>()
-        val openTelemetryRum = mockk<OpenTelemetryRum>()
         InitializationEvents.set(initializationEvents)
 
-        instrumentation.install(mockk(), otelTesting.openTelemetry)
+        instrumentation.install(makeContext())
 
         verify { initializationEvents wasNot Called }
+    }
+
+    private fun makeContext(): InstallationContext {
+        return InstallationContext(
+            mockk<Application>(),
+            otelTesting.openTelemetry,
+            mockk<ServiceManager>(),
+        )
     }
 }


### PR DESCRIPTION
As noted elsewhere and discussed in the Android SIG today, the static singleton nature of the `ServiceManager` both causes modularity challenges and makes testing in vendor distros that wrap the `OpenTelmetryRumBuilder` difficult if not impossible. So this makes a first attempt at the following:

1. Eliminate the static singleton nature of the `ServiceManager`. This primarily means that any class that depends on this must have it injected (via construction). There is still only one instance used at runtime, but no longer can classes reach out statically to randomly call `ServiceManager.get()` in an ad-hoc manner.
2. Allows a custom `ServiceManager` instance to be injected into the `OpenTelemetryRumBuilder` in case the (power) user needs to override some defaults or provide their own implementation of a service.
2. Several instrumentations need to get access to services during installation time, so the instrumentation API needed to change to accommodate this. As a result, we now have an `InstallationContext` data class in the instrumentation package that bundles up the app, the otel instance, and service manager instance.
3. Unfortunately, some of the disk buffering configuration ended up hitting the static `ServiceManager.get()` singleton to get the `PeriodicWorkService` when creating the default implementations of the (from disk) export scheduler. I decided that having functional components as "configuration" was probably stupid, so I just pulled them out all the way up to the builder.
4. The list of services that are implied/default is no longer coupled inside the `ServiceManager` interface, but instead fixed in the sole implementation: `ServiceManagerImpl`. 


Two things that this PR does not yet do that will need to be addressed in follow-up efforts:

1. `ServiceManager` interface is still marked as internal and lives in an internal package. This is problematic because the OTRB now has a public interface method that can take a `ServiceManager` instance. Maybe we just make the interface no longer internal?
2. As @surbhiia has pointed out elsewhere, the list of created and started services still doesn't map well or appropriately to the requirements of the actual instrumentation. In other words, there could still be services created and started that are not used by any instrumentation or exporters or anything.

In any case, I think the testability is greatly improved and the lifecycle is less complex.