### PR TITLE
Add SessionIdLogRecordAppender

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -308,7 +308,8 @@ public final class OpenTelemetryRumBuilder {
                 OpenTelemetrySdk.builder()
                         .setTracerProvider(
                                 buildTracerProvider(sessionManager, application, spanExporter))
-                        .setLoggerProvider(buildLoggerProvider(sessionManager, application, logsExporter))
+                        .setLoggerProvider(
+                                buildLoggerProvider(sessionManager, application, logsExporter))
                         .setMeterProvider(buildMeterProvider(application))
                         .setPropagators(buildFinalPropagators())
                         .build();
@@ -439,7 +440,9 @@ public final class OpenTelemetryRumBuilder {
     }
 
     private SdkLoggerProvider buildLoggerProvider(
-            SessionProvider sessionProvider, Application application, LogRecordExporter logsExporter) {
+            SessionProvider sessionProvider,
+            Application application,
+            LogRecordExporter logsExporter) {
         SdkLoggerProviderBuilder loggerProviderBuilder =
                 SdkLoggerProvider.builder()
                         .setResource(resource)

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -308,8 +308,8 @@ public final class OpenTelemetryRumBuilder {
                 OpenTelemetrySdk.builder()
                         .setTracerProvider(
                                 buildTracerProvider(sessionManager, application, spanExporter))
+                        .setLoggerProvider(buildLoggerProvider(sessionManager, application, logsExporter))
                         .setMeterProvider(buildMeterProvider(application))
-                        .setLoggerProvider(buildLoggerProvider(application, logsExporter))
                         .setPropagators(buildFinalPropagators())
                         .build();
 
@@ -439,13 +439,14 @@ public final class OpenTelemetryRumBuilder {
     }
 
     private SdkLoggerProvider buildLoggerProvider(
-            Application application, LogRecordExporter logsExporter) {
+            SessionProvider sessionProvider, Application application, LogRecordExporter logsExporter) {
         SdkLoggerProviderBuilder loggerProviderBuilder =
                 SdkLoggerProvider.builder()
+                        .setResource(resource)
+                        .addLogRecordProcessor(new SessionIdLogRecordAppender(sessionProvider))
                         .addLogRecordProcessor(
                                 new GlobalAttributesLogRecordAppender(
-                                        config.getGlobalAttributesSupplier()))
-                        .setResource(resource);
+                                        config.getGlobalAttributesSupplier()));
         LogRecordProcessor batchLogsProcessor =
                 BatchLogRecordProcessor.builder(logsExporter).build();
         loggerProviderBuilder.addLogRecordProcessor(batchLogsProcessor);

--- a/core/src/main/java/io/opentelemetry/android/SessionIdLogRecordAppender.kt
+++ b/core/src/main/java/io/opentelemetry/android/SessionIdLogRecordAppender.kt
@@ -1,0 +1,14 @@
+package io.opentelemetry.android
+
+import io.opentelemetry.android.session.SessionProvider
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.logs.LogRecordProcessor
+import io.opentelemetry.sdk.logs.ReadWriteLogRecord
+import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes.SESSION_ID
+
+internal class SessionIdLogRecordAppender(private val sessionProvider: SessionProvider) :
+    LogRecordProcessor {
+    override fun onEmit(context: Context, logRecord: ReadWriteLogRecord) {
+        logRecord.setAttribute(SESSION_ID, sessionProvider.getSessionId())
+    }
+}

--- a/core/src/main/java/io/opentelemetry/android/SessionIdLogRecordAppender.kt
+++ b/core/src/main/java/io/opentelemetry/android/SessionIdLogRecordAppender.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.android
 
 import io.opentelemetry.android.session.SessionProvider
@@ -8,7 +13,10 @@ import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes.SESSION_I
 
 internal class SessionIdLogRecordAppender(private val sessionProvider: SessionProvider) :
     LogRecordProcessor {
-    override fun onEmit(context: Context, logRecord: ReadWriteLogRecord) {
+    override fun onEmit(
+        context: Context,
+        logRecord: ReadWriteLogRecord,
+    ) {
         logRecord.setAttribute(SESSION_ID, sessionProvider.getSessionId())
     }
 }

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.android.common.RumConstants.SCREEN_NAME_KEY;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
+import static io.opentelemetry.semconv.incubating.SessionIncubatingAttributes.SESSION_ID;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
@@ -69,7 +70,6 @@ import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
@@ -154,8 +154,7 @@ public class OpenTelemetryRumBuilderTest {
                 .hasName("test span")
                 .hasResource(resource)
                 .hasAttributesSatisfyingExactly(
-                        equalTo(SessionIncubatingAttributes.SESSION_ID, sessionId),
-                        equalTo(SCREEN_NAME_KEY, "unknown"));
+                        equalTo(SESSION_ID, sessionId), equalTo(SCREEN_NAME_KEY, "unknown"));
     }
 
     @Test
@@ -180,6 +179,7 @@ public class OpenTelemetryRumBuilderTest {
         assertThat(logs).hasSize(1);
         assertThat(logs.get(0))
                 .hasAttributesSatisfyingExactly(
+                        equalTo(SESSION_ID, openTelemetryRum.getRumSessionId()),
                         equalTo(stringKey("event.name"), "test.event"),
                         equalTo(stringKey("mega"), "hit"))
                 .hasResource(resource);
@@ -310,7 +310,9 @@ public class OpenTelemetryRumBuilderTest {
         assertThat(logs).hasSize(1);
         assertThat(logs.iterator().next())
                 .hasBody("foo")
-                .hasAttributesSatisfyingExactly(equalTo(stringKey("bing"), "bang"))
+                .hasAttributesSatisfyingExactly(
+                        equalTo(stringKey("bing"), "bang"),
+                        equalTo(SESSION_ID, rum.getRumSessionId()))
                 .hasSeverity(Severity.FATAL3);
     }
 
@@ -420,6 +422,7 @@ public class OpenTelemetryRumBuilderTest {
         OpenTelemetryAssertions.assertThat(logRecordData)
                 .hasAttributes(
                         Attributes.builder()
+                                .put(SESSION_ID, rum.getRumSessionId())
                                 .put("someGlobalKey", "someGlobalValue")
                                 .put("localAttrKey", "localAttrValue")
                                 .build());

--- a/core/src/test/java/io/opentelemetry/android/SessionIdLogRecordAppenderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/SessionIdLogRecordAppenderTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.android
 
 import io.mockk.MockKAnnotations

--- a/core/src/test/java/io/opentelemetry/android/SessionIdLogRecordAppenderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/SessionIdLogRecordAppenderTest.kt
@@ -1,0 +1,39 @@
+package io.opentelemetry.android
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import io.opentelemetry.android.session.SessionProvider
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.logs.ReadWriteLogRecord
+import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes.SESSION_ID
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+private const val SESSION_ID_VALUE = "0666"
+
+class SessionIdLogRecordAppenderTest {
+    @MockK
+    lateinit var sessionProvider: SessionProvider
+
+    @MockK
+    lateinit var log: ReadWriteLogRecord
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this)
+        every { sessionProvider.getSessionId() }.returns(SESSION_ID_VALUE)
+        every { log.setAttribute(any<AttributeKey<String>>(), any<String>()) } returns log
+    }
+
+    @Test
+    fun `should set sessionId as log record attribute`() {
+        val underTest = SessionIdLogRecordAppender(sessionProvider)
+
+        underTest.onEmit(Context.root(), log)
+
+        verify { log.setAttribute(SESSION_ID, SESSION_ID_VALUE) }
+    }
+}

--- a/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.java
+++ b/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_ESCAPED;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
+import static io.opentelemetry.semconv.incubating.EventIncubatingAttributes.EVENT_NAME;
 import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID;
 import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME;
 
@@ -19,6 +20,8 @@ import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.semconv.incubating.EventIncubatingAttributes;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.List;
@@ -60,6 +63,8 @@ public final class CrashReporter {
             extractor.onStart(attributesBuilder, Context.current(), crashDetails);
         }
 
+        //TODO: use emitEvent() when available, with event name from semantic conventions.
+        attributesBuilder.put(EVENT_NAME, "device.crash");
         crashReporter.logRecordBuilder().setAllAttributes(attributesBuilder.build()).emit();
     }
 

--- a/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.java
+++ b/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.java
@@ -20,8 +20,6 @@ import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
-import io.opentelemetry.semconv.incubating.EventIncubatingAttributes;
-
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.List;
@@ -63,7 +61,7 @@ public final class CrashReporter {
             extractor.onStart(attributesBuilder, Context.current(), crashDetails);
         }
 
-        //TODO: use emitEvent() when available, with event name from semantic conventions.
+        // TODO: use emitEvent() when available, with event name from semantic conventions.
         attributesBuilder.put(EVENT_NAME, "device.crash");
         crashReporter.logRecordBuilder().setAllAttributes(attributesBuilder.build()).emit();
     }


### PR DESCRIPTION
I happened to notice that the crash event (log for now) didn't contain the session information...which was likely fallout from the crash event changing from a span to a log record. This led me to discover that we hadn't yet built the `SessionIdLogRecordAppender`....so here it is.