### PR TITLE
Remove core library desugaring from android lib conventions

### DIFF
--- a/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
@@ -27,7 +27,6 @@ android {
     compileOptions {
         sourceCompatibility(javaVersion)
         targetCompatibility(javaVersion)
-        isCoreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
@@ -53,5 +52,4 @@ dependencies {
     testRuntimeOnly(libs.findLibrary("junit-platform-launcher").get())
     testImplementation(libs.findLibrary("opentelemetry-sdk-testing").get())
     testImplementation(libs.findLibrary("androidx-junit").get())
-    coreLibraryDesugaring(libs.findLibrary("desugarJdkLibs").get())
 }

--- a/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
@@ -22,6 +22,7 @@ android {
         // we rely on dependabot for dependency updates
         disable.add("GradleDependency")
         disable.add("AndroidGradlePluginVersion")
+        disable.add("NewApi")
     }
 
     compileOptions {

--- a/instrumentation/httpurlconnection/library/src/main/java/io/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlReplacements.java
+++ b/instrumentation/httpurlconnection/library/src/main/java/io/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlReplacements.java
@@ -76,7 +76,6 @@ public class HttpUrlReplacements {
         return replace(connection, () -> connection.getContentLength());
     }
 
-    @SuppressLint("NewApi")
     public static long replacementForContentLengthLong(URLConnection connection) {
         return replace(connection, () -> connection.getContentLengthLong());
     }


### PR DESCRIPTION
As discussed in today's sig meeting about issue #682, I removed the added by default core library desugaring from android lib conventions. 

Project assembles fine but `./gradlew check `errors out on `lintDebug` task with 56 instances of requiring API level 24/26 or desugaring, as our minSdk = 21 :

<img width="1164" alt="Lint errors" src="https://github.com/user-attachments/assets/62907aa9-6249-40b7-81a7-5e0d6d48d7c1">

We [earlier](https://github.com/open-telemetry/opentelemetry-android/blob/0e1d3fd9e4a3b83855facfecfba7c62532895250/instrumentation/httpurlconnection/library/src/main/java/io/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlReplacements.java#L109) used a `@SuppressLint('NewApi')` annotation to suppress such warning instead of creating a lint baseline file (as maintaining that is tedious) : 

<img width="813" alt="Screenshot 2024-11-19 at 11 41 30 AM" src="https://github.com/user-attachments/assets/2b05c514-85d9-4477-9523-0ce796eefef1">

@RequiresApi might not be correct here as it does not necessarily need that API level but can do with desugaring which is what we're going with here. 

So, I think we need to add @SuppressLint('NewApi')` annotation at all 56 places? Wanted to cross check before going forward with that :D 