### PR TITLE
Add the current screen name to crash events

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -23,6 +23,7 @@ import io.opentelemetry.android.internal.features.persistence.DiskManager;
 import io.opentelemetry.android.internal.features.persistence.SimpleTemporaryFileProvider;
 import io.opentelemetry.android.internal.initialization.InitializationEvents;
 import io.opentelemetry.android.internal.processors.GlobalAttributesLogRecordAppender;
+import io.opentelemetry.android.internal.processors.SessionIdLogRecordAppender;
 import io.opentelemetry.android.internal.services.CacheStorage;
 import io.opentelemetry.android.internal.services.Preferences;
 import io.opentelemetry.android.internal.services.ServiceManager;

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -480,7 +480,9 @@ public final class OpenTelemetryRumBuilder {
                 SdkLoggerProvider.builder()
                         .setResource(resource)
                         .addLogRecordProcessor(new SessionIdLogRecordAppender(sessionProvider))
-                        .addLogRecordProcessor(new ScreenAttributesLogRecordProcessor(getServiceManager().getVisibleScreenService()))
+                        .addLogRecordProcessor(
+                                new ScreenAttributesLogRecordProcessor(
+                                        getServiceManager().getVisibleScreenService()))
                         .addLogRecordProcessor(
                                 new GlobalAttributesLogRecordAppender(
                                         config.getGlobalAttributesSupplier()));

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -23,6 +23,7 @@ import io.opentelemetry.android.internal.features.persistence.DiskManager;
 import io.opentelemetry.android.internal.features.persistence.SimpleTemporaryFileProvider;
 import io.opentelemetry.android.internal.initialization.InitializationEvents;
 import io.opentelemetry.android.internal.processors.GlobalAttributesLogRecordAppender;
+import io.opentelemetry.android.internal.processors.ScreenAttributesLogRecordProcessor;
 import io.opentelemetry.android.internal.processors.SessionIdLogRecordAppender;
 import io.opentelemetry.android.internal.services.CacheStorage;
 import io.opentelemetry.android.internal.services.Preferences;
@@ -479,6 +480,7 @@ public final class OpenTelemetryRumBuilder {
                 SdkLoggerProvider.builder()
                         .setResource(resource)
                         .addLogRecordProcessor(new SessionIdLogRecordAppender(sessionProvider))
+                        .addLogRecordProcessor(new ScreenAttributesLogRecordProcessor(getServiceManager().getVisibleScreenService()))
                         .addLogRecordProcessor(
                                 new GlobalAttributesLogRecordAppender(
                                         config.getGlobalAttributesSupplier()));

--- a/core/src/main/java/io/opentelemetry/android/internal/processors/ScreenAttributesLogRecordProcessor.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/processors/ScreenAttributesLogRecordProcessor.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.internal.processors
+
+import io.opentelemetry.android.common.RumConstants
+import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenService
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.logs.LogRecordProcessor
+import io.opentelemetry.sdk.logs.ReadWriteLogRecord
+
+class ScreenAttributesLogRecordProcessor(val visibleScreenService: VisibleScreenService) : LogRecordProcessor {
+    override fun onEmit(
+        context: Context,
+        logRecord: ReadWriteLogRecord,
+    ) {
+        val currentScreen = visibleScreenService.currentlyVisibleScreen
+        logRecord.setAttribute(RumConstants.SCREEN_NAME_KEY, currentScreen)
+    }
+}

--- a/core/src/main/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppender.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppender.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.android
+package io.opentelemetry.android.internal.processors
 
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.context.Context

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -300,10 +300,11 @@ public class OpenTelemetryRumBuilderTest {
                     wasCalled.set(true);
                     return logsExporter;
                 };
-        OpenTelemetryRum rum = makeBuilder()
-                .setServiceManager(serviceManager)
-                .addLogRecordExporterCustomizer(customizer)
-                .build();
+        OpenTelemetryRum rum =
+                makeBuilder()
+                        .setServiceManager(serviceManager)
+                        .addLogRecordExporterCustomizer(customizer)
+                        .build();
 
         Logger logger = rum.getOpenTelemetry().getLogsBridge().loggerBuilder("LogScope").build();
         logger.logRecordBuilder()

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -41,6 +41,7 @@ import io.opentelemetry.android.internal.services.Preferences;
 import io.opentelemetry.android.internal.services.ServiceManager;
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycleService;
 import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateListener;
+import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenService;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.KeyValue;
 import io.opentelemetry.api.common.Value;
@@ -83,6 +84,7 @@ import org.mockito.MockitoAnnotations;
 @RunWith(AndroidJUnit4.class)
 public class OpenTelemetryRumBuilderTest {
 
+    public static final String CUR_SCREEN_NAME = "Celebratory Token";
     final Resource resource =
             Resource.getDefault().toBuilder().put("test.attribute", "abcdef").build();
     final InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
@@ -152,8 +154,10 @@ public class OpenTelemetryRumBuilderTest {
 
     @Test
     public void shouldBuildLogRecordProvider() {
+        ServiceManager serviceManager = createServiceManager();
         OpenTelemetryRum openTelemetryRum =
                 makeBuilder()
+                        .setServiceManager(serviceManager)
                         .setResource(resource)
                         .addLoggerProviderCustomizer(
                                 (logRecordProviderBuilder, app) ->
@@ -174,6 +178,7 @@ public class OpenTelemetryRumBuilderTest {
                 .hasAttributesSatisfyingExactly(
                         equalTo(SESSION_ID, openTelemetryRum.getRumSessionId()),
                         equalTo(stringKey("event.name"), "test.event"),
+                        equalTo(SCREEN_NAME_KEY, CUR_SCREEN_NAME),
                         equalTo(stringKey("mega"), "hit"))
                 .hasResource(resource);
 
@@ -288,13 +293,17 @@ public class OpenTelemetryRumBuilderTest {
 
     @Test
     public void setLogRecordExporterCustomizer() {
+        ServiceManager serviceManager = createServiceManager();
         AtomicBoolean wasCalled = new AtomicBoolean(false);
         Function<LogRecordExporter, LogRecordExporter> customizer =
                 x -> {
                     wasCalled.set(true);
                     return logsExporter;
                 };
-        OpenTelemetryRum rum = makeBuilder().addLogRecordExporterCustomizer(customizer).build();
+        OpenTelemetryRum rum = makeBuilder()
+                .setServiceManager(serviceManager)
+                .addLogRecordExporterCustomizer(customizer)
+                .build();
 
         Logger logger = rum.getOpenTelemetry().getLogsBridge().loggerBuilder("LogScope").build();
         logger.logRecordBuilder()
@@ -313,6 +322,7 @@ public class OpenTelemetryRumBuilderTest {
                 .hasBody("foo")
                 .hasAttributesSatisfyingExactly(
                         equalTo(stringKey("bing"), "bang"),
+                        equalTo(SCREEN_NAME_KEY, CUR_SCREEN_NAME),
                         equalTo(SESSION_ID, rum.getRumSessionId()))
                 .hasSeverity(Severity.FATAL3);
     }
@@ -402,12 +412,14 @@ public class OpenTelemetryRumBuilderTest {
 
     @Test
     public void verifyGlobalAttrsForLogs() {
+        ServiceManager serviceManager = createServiceManager();
         OtelRumConfig otelRumConfig = buildConfig();
         otelRumConfig.setGlobalAttributes(
                 () -> Attributes.of(stringKey("someGlobalKey"), "someGlobalValue"));
 
         OpenTelemetryRum rum =
                 OpenTelemetryRum.builder(application, otelRumConfig)
+                        .setServiceManager(serviceManager)
                         .addLoggerProviderCustomizer(
                                 (sdkLoggerProviderBuilder, application) ->
                                         sdkLoggerProviderBuilder.addLogRecordProcessor(
@@ -426,6 +438,7 @@ public class OpenTelemetryRumBuilderTest {
                                 .put(SESSION_ID, rum.getRumSessionId())
                                 .put("someGlobalKey", "someGlobalValue")
                                 .put("localAttrKey", "localAttrValue")
+                                .put(SCREEN_NAME_KEY, CUR_SCREEN_NAME)
                                 .build());
     }
 
@@ -459,6 +472,9 @@ public class OpenTelemetryRumBuilderTest {
         when(serviceManager.getAppLifecycleService()).thenReturn(mock(AppLifecycleService.class));
         when(serviceManager.getCacheStorage()).thenReturn(mock(CacheStorage.class));
         when(serviceManager.getPreferences()).thenReturn(mock(Preferences.class));
+        VisibleScreenService screenService = mock(VisibleScreenService.class);
+        when(screenService.getCurrentlyVisibleScreen()).thenReturn(CUR_SCREEN_NAME);
+        when(serviceManager.getVisibleScreenService()).thenReturn(screenService);
         return serviceManager;
     }
 

--- a/core/src/test/java/io/opentelemetry/android/SessionIdLogRecordAppenderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/SessionIdLogRecordAppenderTest.kt
@@ -5,40 +5,5 @@
 
 package io.opentelemetry.android
 
-import io.mockk.MockKAnnotations
-import io.mockk.every
-import io.mockk.impl.annotations.MockK
-import io.mockk.verify
-import io.opentelemetry.android.session.SessionProvider
-import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.context.Context
-import io.opentelemetry.sdk.logs.ReadWriteLogRecord
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes.SESSION_ID
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
-
 private const val SESSION_ID_VALUE = "0666"
 
-class SessionIdLogRecordAppenderTest {
-    @MockK
-    lateinit var sessionProvider: SessionProvider
-
-    @MockK
-    lateinit var log: ReadWriteLogRecord
-
-    @BeforeEach
-    fun setUp() {
-        MockKAnnotations.init(this)
-        every { sessionProvider.getSessionId() }.returns(SESSION_ID_VALUE)
-        every { log.setAttribute(any<AttributeKey<String>>(), any<String>()) } returns log
-    }
-
-    @Test
-    fun `should set sessionId as log record attribute`() {
-        val underTest = SessionIdLogRecordAppender(sessionProvider)
-
-        underTest.onEmit(Context.root(), log)
-
-        verify { log.setAttribute(SESSION_ID, SESSION_ID_VALUE) }
-    }
-}

--- a/core/src/test/java/io/opentelemetry/android/SessionIdLogRecordAppenderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/SessionIdLogRecordAppenderTest.kt
@@ -1,9 +1,0 @@
-/*
- * Copyright The OpenTelemetry Authors
- * SPDX-License-Identifier: Apache-2.0
- */
-
-package io.opentelemetry.android
-
-private const val SESSION_ID_VALUE = "0666"
-

--- a/core/src/test/java/io/opentelemetry/android/internal/processors/ScreenAttributesLogRecordProcessorTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/processors/ScreenAttributesLogRecordProcessorTest.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.internal.processors
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.opentelemetry.android.common.RumConstants.SCREEN_NAME_KEY
+import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenService
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.sdk.logs.ReadWriteLogRecord
+import org.junit.Test
+
+private const val CURRENT_SCREEN = "party favors"
+
+class ScreenAttributesLogRecordProcessorTest {
+    @Test
+    fun `current screen name is appended`() {
+        val visibleScreenService: VisibleScreenService = mockk()
+        val logRecord: ReadWriteLogRecord = mockk()
+        every { visibleScreenService.currentlyVisibleScreen }.returns(CURRENT_SCREEN)
+        every { logRecord.setAttribute(any<AttributeKey<String>>(), any<String>()) } returns logRecord
+        val testClass = ScreenAttributesLogRecordProcessor(visibleScreenService)
+        testClass.onEmit(mockk(), logRecord)
+        verify { logRecord.setAttribute(SCREEN_NAME_KEY, CURRENT_SCREEN) }
+    }
+}

--- a/core/src/test/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppenderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppenderTest.kt
@@ -1,0 +1,38 @@
+package io.opentelemetry.android.internal.processors
+
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.verify
+import io.opentelemetry.android.SESSION_ID_VALUE
+import io.opentelemetry.android.session.SessionProvider
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.logs.ReadWriteLogRecord
+import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class SessionIdLogRecordAppenderTest {
+    @MockK
+    lateinit var sessionProvider: SessionProvider
+
+    @MockK
+    lateinit var log: ReadWriteLogRecord
+
+    @BeforeEach
+    fun setUp() {
+        MockKAnnotations.init(this)
+        every { sessionProvider.getSessionId() }.returns(SESSION_ID_VALUE)
+        every { log.setAttribute(any<AttributeKey<String>>(), any<String>()) } returns log
+    }
+
+    @Test
+    fun `should set sessionId as log record attribute`() {
+        val underTest = SessionIdLogRecordAppender(sessionProvider)
+
+        underTest.onEmit(Context.root(), log)
+
+        verify { log.setAttribute(SessionIncubatingAttributes.SESSION_ID, SESSION_ID_VALUE) }
+    }
+}

--- a/core/src/test/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppenderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppenderTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.android.internal.processors
 
 import io.mockk.MockKAnnotations

--- a/core/src/test/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppenderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppenderTest.kt
@@ -4,7 +4,6 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.verify
-import io.opentelemetry.android.SESSION_ID_VALUE
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.context.Context
@@ -12,6 +11,8 @@ import io.opentelemetry.sdk.logs.ReadWriteLogRecord
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+
+private const val SESSION_ID_VALUE = "0666"
 
 class SessionIdLogRecordAppenderTest {
     @MockK


### PR DESCRIPTION
It's super duper helpful for developers to know what screen the app was showing when a crash happened!

This likely used to happen automatically/correctly when crashes were spans and was probably broken when migrated to events.