### PR TITLE
Configure metrics export

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -15,6 +15,7 @@ import androidx.annotation.VisibleForTesting;
 import io.opentelemetry.android.common.RumConstants;
 import io.opentelemetry.android.config.OtelRumConfig;
 import io.opentelemetry.android.export.BufferDelegatingLogExporter;
+import io.opentelemetry.android.export.BufferDelegatingMetricExporter;
 import io.opentelemetry.android.export.BufferDelegatingSpanExporter;
 import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig;
 import io.opentelemetry.android.features.diskbuffering.SignalFromDiskExporter;
@@ -43,9 +44,12 @@ import io.opentelemetry.context.propagation.ContextPropagators;
 import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.contrib.disk.buffering.LogRecordFromDiskExporter;
 import io.opentelemetry.contrib.disk.buffering.LogRecordToDiskExporter;
+import io.opentelemetry.contrib.disk.buffering.MetricFromDiskExporter;
+import io.opentelemetry.contrib.disk.buffering.MetricToDiskExporter;
 import io.opentelemetry.contrib.disk.buffering.SpanFromDiskExporter;
 import io.opentelemetry.contrib.disk.buffering.SpanToDiskExporter;
 import io.opentelemetry.contrib.disk.buffering.StorageConfiguration;
+import io.opentelemetry.exporter.logging.LoggingMetricExporter;
 import io.opentelemetry.exporter.logging.LoggingSpanExporter;
 import io.opentelemetry.exporter.logging.SystemOutLogRecordExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -56,6 +60,7 @@ import io.opentelemetry.sdk.logs.export.BatchLogRecordProcessor;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder;
@@ -91,6 +96,8 @@ public final class OpenTelemetryRumBuilder {
     private final List<Consumer<OpenTelemetrySdk>> otelSdkReadyListeners = new ArrayList<>();
     private final SessionIdTimeoutHandler timeoutHandler;
     private Function<? super SpanExporter, ? extends SpanExporter> spanExporterCustomizer = a -> a;
+    private Function<? super MetricExporter, ? extends MetricExporter> metricExporterCustomizer =
+            a -> a;
     private Function<? super LogRecordExporter, ? extends LogRecordExporter>
             logRecordExporterCustomizer = a -> a;
     private Function<? super TextMapPropagator, ? extends TextMapPropagator> propagatorCustomizer =
@@ -261,6 +268,26 @@ public final class OpenTelemetryRumBuilder {
     }
 
     /**
+     * Adds a {@link Function} to invoke with the default {@link MetricExporter} to allow
+     * customization. The return value of the {@link Function} will replace the passed-in argument.
+     *
+     * <p>Multiple calls will execute the customizers in order.
+     */
+    public OpenTelemetryRumBuilder addMetricExporterCustomizer(
+            Function<? super MetricExporter, ? extends MetricExporter> metricExporterCustomizer) {
+        requireNonNull(metricExporterCustomizer, "metricExporterCustomizer");
+        checkNotBuilt();
+        Function<? super MetricExporter, ? extends MetricExporter> existing =
+                this.metricExporterCustomizer;
+        this.metricExporterCustomizer =
+                exporter -> {
+                    MetricExporter intermediate = existing.apply(exporter);
+                    return metricExporterCustomizer.apply(intermediate);
+                };
+        return this;
+    }
+
+    /**
      * Adds a {@link Function} to invoke with the default {@link LogRecordExporter} to allow
      * customization. The return value of the {@link Function} will replace the passed-in argument.
      *
@@ -298,10 +325,11 @@ public final class OpenTelemetryRumBuilder {
         InitializationEvents initializationEvents = InitializationEvents.get();
         applyConfiguration(services, initializationEvents);
 
-        BufferDelegatingLogExporter bufferDelegatingLogExporter = new BufferDelegatingLogExporter();
-
         BufferDelegatingSpanExporter bufferDelegatingSpanExporter =
                 new BufferDelegatingSpanExporter();
+        BufferDelegatingLogExporter bufferDelegatingLogExporter = new BufferDelegatingLogExporter();
+        BufferDelegatingMetricExporter bufferDelegatingMetricExporter =
+                new BufferDelegatingMetricExporter();
 
         if (sessionManager == null) {
             sessionManager =
@@ -342,7 +370,8 @@ public final class OpenTelemetryRumBuilder {
                                 services,
                                 initializationEvents,
                                 bufferDelegatingSpanExporter,
-                                bufferDelegatingLogExporter));
+                                bufferDelegatingLogExporter,
+                                bufferDelegatingMetricExporter));
 
         instrumentations.forEach(delegate::addInstrumentation);
 
@@ -353,11 +382,13 @@ public final class OpenTelemetryRumBuilder {
             Services services,
             InitializationEvents initializationEvents,
             BufferDelegatingSpanExporter bufferDelegatingSpanExporter,
-            BufferDelegatingLogExporter bufferedDelegatingLogExporter) {
+            BufferDelegatingLogExporter bufferedDelegatingLogExporter,
+            BufferDelegatingMetricExporter bufferDelegatingMetricExporter) {
 
         DiskBufferingConfig diskBufferingConfig = config.getDiskBufferingConfig();
         SpanExporter spanExporter = buildSpanExporter();
         LogRecordExporter logsExporter = buildLogsExporter();
+        MetricExporter metricExporter = buildMetricExporter();
         SignalFromDiskExporter signalFromDiskExporter = null;
         if (diskBufferingConfig.getEnabled()) {
             try {
@@ -368,11 +399,18 @@ public final class OpenTelemetryRumBuilder {
                 final LogRecordExporter originalLogsExporter = logsExporter;
                 logsExporter =
                         LogRecordToDiskExporter.create(originalLogsExporter, storageConfiguration);
+                final MetricExporter originalMetricExporter = metricExporter;
+                metricExporter =
+                        MetricToDiskExporter.create(
+                                originalMetricExporter,
+                                storageConfiguration,
+                                originalMetricExporter::getAggregationTemporality);
                 signalFromDiskExporter =
                         new SignalFromDiskExporter(
                                 SpanFromDiskExporter.create(
                                         originalSpanExporter, storageConfiguration),
-                                null,
+                                MetricFromDiskExporter.create(
+                                        originalMetricExporter, storageConfiguration),
                                 LogRecordFromDiskExporter.create(
                                         originalLogsExporter, storageConfiguration));
             } catch (IOException e) {
@@ -382,6 +420,7 @@ public final class OpenTelemetryRumBuilder {
         initializationEvents.spanExporterInitialized(spanExporter);
         bufferedDelegatingLogExporter.setDelegate(logsExporter);
         bufferDelegatingSpanExporter.setDelegate(spanExporter);
+        bufferDelegatingMetricExporter.setDelegate(metricExporter);
         scheduleDiskTelemetryReader(services, signalFromDiskExporter);
     }
 
@@ -552,7 +591,14 @@ public final class OpenTelemetryRumBuilder {
         return spanExporterCustomizer.apply(defaultExporter);
     }
 
+    private MetricExporter buildMetricExporter() {
+        // TODO: Default to otlp...but how can we make endpoint and auth mandatory?
+        MetricExporter defaultExporter = LoggingMetricExporter.create();
+        return metricExporterCustomizer.apply(defaultExporter);
+    }
+
     private LogRecordExporter buildLogsExporter() {
+        // TODO: Default to otlp...but how can we make endpoint and auth mandatory?
         LogRecordExporter defaultExporter = SystemOutLogRecordExporter.create();
         return logRecordExporterCustomizer.apply(defaultExporter);
     }

--- a/core/src/main/java/io/opentelemetry/android/export/BufferDelegatingMetricExporter.kt
+++ b/core/src/main/java/io/opentelemetry/android/export/BufferDelegatingMetricExporter.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.export
+
+import io.opentelemetry.sdk.common.CompletableResultCode
+import io.opentelemetry.sdk.metrics.InstrumentType
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality
+import io.opentelemetry.sdk.metrics.data.MetricData
+import io.opentelemetry.sdk.metrics.export.AggregationTemporalitySelector
+import io.opentelemetry.sdk.metrics.export.MetricExporter
+
+/**
+ * An in-memory buffer delegating metric exporter that buffers metrics in memory until a delegate is set.
+ * Once a delegate is set, the buffered metrics are exported to the delegate.
+ *
+ * The buffer size is set to 5,000 metrics by default. If the buffer is full, the exporter will drop new metrics.
+ */
+internal class BufferDelegatingMetricExporter(
+    maxBufferedMetrics: Int = 5_000,
+) : MetricExporter {
+    private val delegatingExporter =
+        DelegatingExporter<MetricExporter, MetricData>(
+            doExport = MetricExporter::export,
+            doFlush = MetricExporter::flush,
+            doShutdown = MetricExporter::shutdown,
+            maxBufferedData = maxBufferedMetrics,
+            logType = "metrics",
+        )
+    private var aggregationTemporalitySelector: AggregationTemporalitySelector = AggregationTemporalitySelector.alwaysCumulative()
+
+    fun setDelegate(delegate: MetricExporter) {
+        delegatingExporter.setDelegate(delegate)
+        aggregationTemporalitySelector = delegate
+    }
+
+    override fun getAggregationTemporality(instrumentType: InstrumentType): AggregationTemporality =
+        aggregationTemporalitySelector.getAggregationTemporality(instrumentType)
+
+    override fun export(metrics: Collection<MetricData>): CompletableResultCode = delegatingExporter.export(metrics)
+
+    override fun flush(): CompletableResultCode = delegatingExporter.flush()
+
+    override fun shutdown(): CompletableResultCode = delegatingExporter.shutdown()
+}

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -6,6 +6,7 @@
 package io.opentelemetry.android;
 
 import static io.opentelemetry.android.common.RumConstants.SCREEN_NAME_KEY;
+import static io.opentelemetry.api.common.AttributeKey.longKey;
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat;
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
@@ -51,6 +52,9 @@ import io.opentelemetry.api.common.Value;
 import io.opentelemetry.api.incubator.events.EventLogger;
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.api.logs.Severity;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongCounterBuilder;
+import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
@@ -62,19 +66,30 @@ import io.opentelemetry.sdk.logs.data.LogRecordData;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
 import io.opentelemetry.sdk.logs.internal.SdkEventLoggerProvider;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import io.opentelemetry.sdk.metrics.export.MetricReader;
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions;
 import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricExporter;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.junit.After;
 import org.junit.Before;
@@ -92,7 +107,6 @@ public class OpenTelemetryRumBuilderTest {
             Resource.getDefault().toBuilder().put("test.attribute", "abcdef").build();
     final InMemorySpanExporter spanExporter = InMemorySpanExporter.create();
     final InMemoryLogRecordExporter logsExporter = InMemoryLogRecordExporter.create();
-    final InMemoryLogRecordExporter logRecordExporter = InMemoryLogRecordExporter.create();
 
     @Mock Application application;
     @Mock Looper looper;
@@ -198,6 +212,80 @@ public class OpenTelemetryRumBuilderTest {
         assertThat(payload).hasSize(1);
         KeyValue expected = KeyValue.of("body.field", Value.of("foo"));
         assertThat(payload.get(0)).isEqualTo(expected);
+    }
+
+    @Test
+    public void canCustomizeMetrics(){
+        InMemoryMetricReader metricReader = InMemoryMetricReader.create();
+        OpenTelemetryRum openTelemetryRum =
+                makeBuilder()
+                        .setResource(resource)
+                        .addMeterProviderCustomizer((sdkMeterProviderBuilder, application) -> {
+                            Attributes metricResAttrs = Attributes.of(stringKey("mmm"), "nnn");
+                            return sdkMeterProviderBuilder
+                                    .setResource(Resource.create(metricResAttrs))
+                                    .registerMetricReader(metricReader);
+                        })
+                        .build();
+
+        OpenTelemetrySdk sdk = (OpenTelemetrySdk) openTelemetryRum.getOpenTelemetry();
+        Meter meter = sdk.getSdkMeterProvider()
+                .meterBuilder("myMeter")
+                .build();
+        Attributes counterAttrs = Attributes.of(longKey("adams"), 42L);
+        LongCounter counter = meter.counterBuilder("myCounter").build();
+        counter.add(40, counterAttrs);
+        metricReader.forceFlush();
+        counter.add(2, counterAttrs);
+
+        List<MetricData> metrics = new ArrayList<>(metricReader.collectAllMetrics());
+        assertThat(metrics).hasSize(1);
+        assertThat(metrics.get(0))
+                .hasName("myCounter")
+                .hasLongSumSatisfying(sum ->
+                        sum.hasPointsSatisfying(
+                                pt -> pt.hasValue(42L)
+                                        .hasAttributes(counterAttrs))
+                )
+                .hasResourceSatisfying(res -> res.hasAttribute(stringKey("mmm"), "nnn"));
+    }
+
+    @Test
+    public void canCustomizeMetricExport(){
+        InMemoryMetricExporter exporter = InMemoryMetricExporter.create(AggregationTemporality.DELTA); // NOT THE DEFAULT
+        PeriodicMetricReader periodicReader = PeriodicMetricReader.builder(exporter).build();
+        OpenTelemetryRum openTelemetryRum =
+                makeBuilder()
+                        .setResource(resource)
+                        .addMeterProviderCustomizer((builder, app) -> SdkMeterProvider.builder().registerMetricReader(periodicReader))
+                        .addMetricExporterCustomizer(x -> exporter)
+                        .build();
+
+        OpenTelemetrySdk sdk = (OpenTelemetrySdk) openTelemetryRum.getOpenTelemetry();
+        Meter meter = sdk.getSdkMeterProvider()
+                .meterBuilder("FOOMETER")
+                .build();
+        LongCounter counter = meter.counterBuilder("FOOCOUNTER").build();
+        counter.add(22);
+        periodicReader.forceFlush();
+        counter.add(2);
+        counter.add(3);
+        periodicReader.forceFlush();
+        List<MetricData> metrics = exporter.getFinishedMetricItems();
+
+        assertThat(metrics).hasSize(2);
+        assertThat(metrics.get(0))
+                .hasName("FOOCOUNTER")
+                .hasLongSumSatisfying(sum ->
+                        sum.hasPointsSatisfying(
+                                pt -> pt.hasValue(22L))
+                );
+        assertThat(metrics.get(1))
+                .hasName("FOOCOUNTER")
+                .hasLongSumSatisfying(sum ->
+                        sum.hasPointsSatisfying(
+                                pt -> pt.hasValue(5L))
+                );
     }
 
     @Test
@@ -443,13 +531,13 @@ public class OpenTelemetryRumBuilderTest {
                         .addLoggerProviderCustomizer(
                                 (sdkLoggerProviderBuilder, application) ->
                                         sdkLoggerProviderBuilder.addLogRecordProcessor(
-                                                SimpleLogRecordProcessor.create(logRecordExporter)))
+                                                SimpleLogRecordProcessor.create(logsExporter)))
                         .build();
 
         Logger logger = rum.getOpenTelemetry().getLogsBridge().loggerBuilder("LogScope").build();
         logger.logRecordBuilder().setAttribute(stringKey("localAttrKey"), "localAttrValue").emit();
 
-        List<LogRecordData> recordedLogs = logRecordExporter.getFinishedLogRecordItems();
+        List<LogRecordData> recordedLogs = logsExporter.getFinishedLogRecordItems();
         assertThat(recordedLogs).hasSize(1);
         LogRecordData logRecordData = recordedLogs.get(0);
         OpenTelemetryAssertions.assertThat(logRecordData)

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/MainOtelButton.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/MainOtelButton.kt
@@ -18,14 +18,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.unit.dp
+import io.opentelemetry.api.metrics.LongCounter
 import io.opentelemetry.api.trace.SpanKind
 
 @Composable
-fun MainOtelButton(icon: Painter) {
+fun MainOtelButton(icon: Painter,
+                   clickCounter: LongCounter? = OtelDemoApplication.counter("logo.clicks")) {
     Row {
         Spacer(modifier = Modifier.height(5.dp))
         Button(
-            onClick = { generateClickEvent() },
+            onClick = { generateClickEvent(clickCounter) },
             modifier = Modifier.padding(20.dp),
             colors = ButtonDefaults.buttonColors(containerColor = Color.Black),
             content = {
@@ -41,12 +43,14 @@ fun MainOtelButton(icon: Painter) {
     }
 }
 
-fun generateClickEvent() {
+fun generateClickEvent(counter: LongCounter?) {
     val scope = "otel.demo.app"
     OtelDemoApplication.eventBuilder(scope, "logo.clicked")
         .emit()
     // For now, we also emit a span, so that we can see something in a UI
     val tracer = OtelDemoApplication.tracer(scope)
+    // And we also increment a counter, to test metrics
+    counter?.add(1)
     val span =
         tracer
             ?.spanBuilder("logo.clicked")

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/OtelDemoApplication.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/OtelDemoApplication.kt
@@ -16,6 +16,7 @@ import io.opentelemetry.android.instrumentation.sessions.SessionInstrumentation
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.incubator.events.EventBuilder
+import io.opentelemetry.api.metrics.LongCounter
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
@@ -88,6 +89,10 @@ class OtelDemoApplication : Application() {
 
         fun tracer(name: String): Tracer? {
             return rum?.openTelemetry?.tracerProvider?.get(name)
+        }
+
+        fun counter(name: String): LongCounter? {
+            return rum?.openTelemetry?.meterProvider?.get("demo.app")?.counterBuilder(name)?.build()
         }
 
         fun eventBuilder(scopeName: String, eventName: String): EventBuilder {


### PR DESCRIPTION
Resolves #527.

A few notes about this:

* I'm still not convinced that most users want/need metrics, but we've had enough interest lately that I think it's warranted.
* The logging exporter is based on `java.util.logging` and doesn't seem to actually template the `MetricData` values correctly, so the actual output in logcat is less than helpful.
* Maybe eventually we can make it easy for users to specify which resource attributes they want on metrics, because the exporter takes a Resource, we could customize this at creation time. It's a rabbit hole that we should discuss. 
* With the metrics exporter customizer functionality now, users can override and customize every aspect (including resource), but it's honestly pretty challenging to get correct, especially if you want disk buffering too...which most users want and which we want to be default.
