### PR TITLE
Make getAvailableSpace return available space instead of max requested space

### DIFF
--- a/services/src/main/java/io/opentelemetry/android/internal/services/CacheStorage.java
+++ b/services/src/main/java/io/opentelemetry/android/internal/services/CacheStorage.java
@@ -60,14 +60,12 @@ public class CacheStorage {
         try {
             StorageManager storageManager = appContext.getSystemService(StorageManager.class);
             UUID appSpecificInternalDirUuid = storageManager.getUuidForPath(directory);
+            long availableSpace = storageManager.getAllocatableBytes(appSpecificInternalDirUuid);
             // Get the minimum amount of allocatable space.
-            long spaceToAllocate =
-                    Math.min(
-                            storageManager.getAllocatableBytes(appSpecificInternalDirUuid),
-                            maxSpaceNeeded);
+            long spaceToAllocate = Math.min(availableSpace, maxSpaceNeeded);
             // Ensure the space is available by asking the OS to clear stale cache if needed.
             storageManager.allocateBytes(appSpecificInternalDirUuid, spaceToAllocate);
-            return spaceToAllocate;
+            return availableSpace;
         } catch (IOException e) {
             Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to get available space", e);
             return getLegacyAvailableSpace(directory, maxSpaceNeeded);
@@ -80,6 +78,6 @@ public class CacheStorage {
                 String.format(
                         "Getting legacy available space for %s max needed is: %s",
                         directory, maxSpaceNeeded));
-        return Math.min(directory.getUsableSpace(), maxSpaceNeeded);
+        return directory.getUsableSpace();
     }
 }


### PR DESCRIPTION
Hey, fixing a bug when disk persistence is not being used if requested max cache size (in DiskBufferingConfiguration.builder().setMaxCacheSize) is less than 7mb. Default 60mb sounds alot.

This log gave me a confusing hint: `Insufficient folder cache size: -715243, it must be at least: 1048576`.

The issue lies within fixed method `getAvailableSpace`, which returns available space only if max needed space is higher than available space. 

It seems the fixed behavior is intended, as this method is used in [DiskManager](https://github.com/open-telemetry/opentelemetry-android/blob/349a8cf077945c0d520b55ee504b1ee910e2da18/core/src/main/java/io/opentelemetry/android/internal/features/persistence/DiskManager.kt#L57), names the returned value as `availableCacheSize`. 

Screenshot of my debug breakpoint (requesting max 1_000_000 cache storage):
<img width="893" alt="Screenshot 2025-01-28 at 15 09 04" src="https://github.com/user-attachments/assets/502c2f63-874b-4ed8-83df-1b4e9dbdf787" />

From the numbers here, in current solution, given unlimited available disk space, more than 6_000_000 bytes have to be requested for max cache size for the  `if (calculatedSize < maxCacheFileSize) {` to be false (and have persistence enabled).

Now writing this I got confused why would there be a min limit for cache file? Why do each signals folder have to be bigger than `maxCacheFileSize` with another `maxCacheFileSize` subtracted from the size? When [CacheStorage](https://github.com/open-telemetry/opentelemetry-android/blob/349a8cf077945c0d520b55ee504b1ee910e2da18/services/src/main/java/io/opentelemetry/android/internal/services/CacheStorage.java#L69) already allocates the requested max bytes?