### PR TITLE
Relax issue mgmt from every hour to every 8 hours.

### DIFF
--- a/.github/workflows/add-stale-label.yaml
+++ b/.github/workflows/add-stale-label.yaml
@@ -2,8 +2,8 @@ name: Issue management - run stale action
 
 on:
   schedule:
-    # hourly at minute 41
-    - cron: "41 * * * *"
+    # every 8 hours at 41 past
+    - cron: "41 */8 * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
The current schedule unnecessarily clogs up the actions history, and we really don't need it to be that frequent.