### PR TITLE
Add gradle build scans

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -78,6 +78,10 @@
         "^androidx.core"
       ],
       "groupName": "androidx.core"
+    },
+    {
+      "matchPackagePrefixes": ["com.gradle.develocity"],
+      "groupName": "gradle develocity packages"
     }
   ]
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,17 @@
 rootProject.name = "opentelemetry-android"
 
+plugins {
+    id("com.gradle.develocity") version "3.19"
+}
+
+develocity {
+    buildScan {
+        publishing.onlyIf { System.getenv("CI") != null }
+        termsOfUseUrl.set("https://gradle.com/help/legal-terms-of-use")
+        termsOfUseAgree.set("yes")
+    }
+}
+
 include(":core")
 include(":android-agent")
 include(":instrumentation:activity")


### PR DESCRIPTION
PR builds are taking in excess of 15 minutes, which seems excessive. In order to help troubleshoot, we are enabling build scans.