### PR TITLE
Respect screen attrs config for logs

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -330,9 +330,7 @@ public final class OpenTelemetryRumBuilder {
                                         sessionManager, application, bufferDelegatingSpanExporter))
                         .setLoggerProvider(
                                 buildLoggerProvider(
-                                        sessionManager,
-                                        application,
-                                        bufferDelegatingLogExporter))
+                                        sessionManager, application, bufferDelegatingLogExporter))
                         .setMeterProvider(
                                 buildMeterProvider(application, bufferDelegatingMetricExporter))
                         .setPropagators(buildFinalPropagators())
@@ -518,17 +516,18 @@ public final class OpenTelemetryRumBuilder {
 
         // Add processors that append screen attribute(s)
         if (config.shouldIncludeScreenAttributes()) {
-            tracerProviderCustomizers.add(0, (builder, app) ->
-                    builder.addSpanProcessor(
-                            new ScreenAttributesSpanProcessor(services.getVisibleScreenTracker())
-                    )
-            );
-            loggerProviderCustomizers.add(0, (builder, app) ->
-               builder.addLogRecordProcessor(
-                        new ScreenAttributesLogRecordProcessor(
-                                services.getVisibleScreenTracker()))
-
-            );
+            tracerProviderCustomizers.add(
+                    0,
+                    (builder, app) ->
+                            builder.addSpanProcessor(
+                                    new ScreenAttributesSpanProcessor(
+                                            services.getVisibleScreenTracker())));
+            loggerProviderCustomizers.add(
+                    0,
+                    (builder, app) ->
+                            builder.addLogRecordProcessor(
+                                    new ScreenAttributesLogRecordProcessor(
+                                            services.getVisibleScreenTracker())));
         }
     }
 

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -142,6 +142,7 @@ public class OpenTelemetryRumBuilderTest {
 
     @Test
     public void shouldBuildTracerProvider() {
+        createAndSetServiceManager();
         OpenTelemetryRum openTelemetryRum =
                 makeBuilder()
                         .setResource(resource)
@@ -169,7 +170,7 @@ public class OpenTelemetryRumBuilderTest {
                                     .hasResource(resource)
                                     .hasAttributesSatisfyingExactly(
                                             equalTo(SESSION_ID, sessionId),
-                                            equalTo(SCREEN_NAME_KEY, "unknown"));
+                                            equalTo(SCREEN_NAME_KEY, CUR_SCREEN_NAME));
                         });
     }
 


### PR DESCRIPTION
Resolves #765.

A few notes about this changeset:

* I also removed the excessive `checkNotBuilt()` functionality from all the setters. I think this is nonstandard and not really necessary -- I expect that most developers will understand that the builder is to be used just once and that calling setters or changing the builder state after calling build doesn't have expected results. I don't see the need to throw the exception.
* There is a subtle and somewhat complex ordering challenge with customizers that add processors for spans and logs. In the `applyConfig()` method is where we add in various customers that add processors, but we call `applyConfig()` from within `build()`...which means that we are adding those LATE in the lifecycle, and after the user's other customizers and thus after the users other processors. In the worst case, using the customizer to add a processor that exports would result in an export that had NOT had the internal processors applied before export. To work around this, the `applyConfig()` method inserts its customizers at the beginning of the chain. 

The latter bit probably warrants a larger discussion...and also whether or not the exporting processor should be created prior to the list of user processors.