### PR TITLE
[breaking] Adjust artifact coordinates for nested instrumentations

### DIFF
--- a/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -82,14 +82,17 @@ afterEvaluate {
 fun computeArtifactId(): String {
     val path = project.path
     if (!path.contains("instrumentation")) {
-        // Return default artifacId for non auto-instrumentation publications.
+        // Return default artifactId for non auto-instrumentation publications.
         return project.name
     }
 
     // Adding library name to its related auto-instrumentation subprojects.
     // For example, prepending "okhttp-3.0-" to both the "library" and "agent" subprojects inside the "okhttp-3.0" folder.
     val match = Regex("[^:]+:[^:]+\$").find(path)
-    val artifactId = match!!.value.replace(":", "-")
+    var artifactId = match!!.value.replace(":", "-")
+    if ( !artifactId.startsWith("instrumentation-")){
+        artifactId = "instrumentation-$artifactId"
+    }
 
     logger.debug("Using artifact id: '{}' for subproject: '{}'", artifactId, path)
     return artifactId


### PR DESCRIPTION
Resolves #533 if we like it.

We haven't really discussed this, but after reviewing #533 it seems that the main issue is that there is inconsistency with the two modules (okhttp, httpurlconnection) that are nested and have library+agent components. This prepends `instrumentation` in those cases where it is missing. The result, for example, looks like this:

```xml
<groupId>io.opentelemetry.android</groupId>
<artifactId>instrumentation-okhttp-3.0-agent</artifactId>
```

and similarly 

```xml
<groupId>io.opentelemetry.android</groupId>
<artifactId>instrumentation-httpurlconnection-agent</artifactId>
```
(and the two `-library` versions also not shown here).