### PR TITLE
Remove deprecated EXCEPTION_ESCAPED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### ⚠️⚠️Breaking changes
+
+- Remove deprecated `exception.escaped` attribute from crash events ([#796](https://github.com/open-telemetry/opentelemetry-android/pull/796))
+
 ## Version 0.9.0 (2025-01-15)
 
 - This version builds on opentelemetry-java-instrumentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### ⚠️⚠️Breaking changes
 
+- New maven coordinates for http client instrumentations ([#791](https://github.com/open-telemetry/opentelemetry-android/pull/791))
+  - `okhttp-3.0-library` -> `instrumentation-okhttp-3.0-library`
+  - `okhttp-3.0-agent` -> `instrumentation-okhttp-3.0-agent`
+  - `httpurlconnection-library` -> `instrumentation-httpurlconnection-library`
+  - `httpurlconnection-agent` -> `instrumentation-httpurlconnection-agent`
 - Remove deprecated `exception.escaped` attribute from crash events ([#796](https://github.com/open-telemetry/opentelemetry-android/pull/796))
 
 ## Version 0.9.0 (2025-01-15)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### ⚠️⚠️Breaking changes
+### ⚠️⚠️ Breaking changes
 
 - New maven coordinates for http client instrumentations ([#791](https://github.com/open-telemetry/opentelemetry-android/pull/791))
   - `okhttp-3.0-library` -> `instrumentation-okhttp-3.0-library`

--- a/instrumentation/crash/README.md
+++ b/instrumentation/crash/README.md
@@ -17,7 +17,6 @@ This instrumentation produces the following telemetry:
 * Description: An event that is generated for exceptions not handled by user code.
 * Attributes:
     * `event.name`: `device.crash` (see note below)
-    * `exception.escaped` ([see semconv here](https://github.com/open-telemetry/semantic-conventions/blob/727700406f9e6cc3f4e4680a81c4c28f2eb71569/docs/attributes-registry/exception.md#exception-escaped))
     * `exception.message` ([see semconv here](https://github.com/open-telemetry/semantic-conventions/blob/727700406f9e6cc3f4e4680a81c4c28f2eb71569/docs/attributes-registry/exception.md#exception-message))
     * `exception.stacktrace` ([see semconv here](https://github.com/open-telemetry/semantic-conventions/blob/727700406f9e6cc3f4e4680a81c4c28f2eb71569/docs/attributes-registry/exception.md#exception-stacktrace))
     * `exception.type` ([see semconv here](https://github.com/open-telemetry/semantic-conventions/blob/727700406f9e6cc3f4e4680a81c4c28f2eb71569/docs/attributes-registry/exception.md#exception-type))

--- a/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.java
+++ b/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.java
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.android.instrumentation.crash;
 
-import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_ESCAPED;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
@@ -50,7 +49,6 @@ public final class CrashReporter {
         Thread thread = crashDetails.getThread();
         AttributesBuilder attributesBuilder =
                 Attributes.builder()
-                        .put(EXCEPTION_ESCAPED, true)
                         .put(THREAD_ID, thread.getId())
                         .put(THREAD_NAME, thread.getName())
                         .put(EXCEPTION_MESSAGE, throwable.getMessage())

--- a/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReporterTest.java
+++ b/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReporterTest.java
@@ -83,7 +83,6 @@ public class CrashReporterTest {
 
         Attributes crashAttributes = logRecords.get(0).getAttributes();
         OpenTelemetryAssertions.assertThat(crashAttributes)
-                .containsEntry(ExceptionAttributes.EXCEPTION_ESCAPED, true)
                 .containsEntry(ExceptionAttributes.EXCEPTION_MESSAGE, exceptionMessage)
                 .containsEntry(ExceptionAttributes.EXCEPTION_TYPE, "java.lang.RuntimeException")
                 .containsEntry(ThreadIncubatingAttributes.THREAD_ID, crashingThread.getId())


### PR DESCRIPTION
See here: https://github.com/open-telemetry/semantic-conventions/blob/727700406f9e6cc3f4e4680a81c4c28f2eb71569/docs/attributes-registry/exception.md#deprecated-exception-attributes

Very little value in a hard-coded attribute value anyway. 😁 