### PR TITLE
Update renovate rules 

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,9 @@
         "io.opentelemetry.contrib:opentelemetry-disk-buffering",
         "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha",
         "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator",
-        "io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0"
+        "io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0",
+        "io.opentelemetry.semconv:**",
+        "io.opentelemetry.proto:**"
       ],
       // Renovate's default behavior is only to update from unstable -> unstable if it's for the
       // major.minor.patch, under the assumption that you would want to update to the stable version


### PR DESCRIPTION
Looks like we are at least 5 version behind on semconv due to a problem with renovate. We think this will help clear that up, and we will expect a renovate update shortly after this is merged.

We need to include io.opentelemetry.proto and .semconv packages in the `ignoreUnstable: false` section.