### PR TITLE
Compare cached cache size with current request

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/internal/features/persistence/DiskManager.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/features/persistence/DiskManager.kt
@@ -45,15 +45,15 @@ internal class DiskManager(
          * size is stored in the preferences and returned otherwise.
          */
         get() {
+            val requestedSize = diskBufferingConfig.maxCacheSize
             val storedSize = preferences.retrieveInt(MAX_FOLDER_SIZE_KEY, -1)
-            if (storedSize > 0) {
+            if (storedSize == requestedSize) {
                 Log.d(
                     RumConstants.OTEL_RUM_LOG_TAG,
                     String.format("Returning max folder size from preferences: %s", storedSize),
                 )
                 return storedSize
             }
-            val requestedSize = diskBufferingConfig.maxCacheSize
             val availableCacheSize =
                 cacheStorage.ensureCacheSpaceAvailable(requestedSize.toLong()).toInt()
             // Divides the available cache size by 3 (for each signal's folder) and then subtracts the


### PR DESCRIPTION
Currently, if developer changes cache size, the users who have cache, will not have their cache size reduced (until some cache clear).
This might be harmful for when the cache change is made due to memory issue (too little cache was set initially, or too much)

The change simply compares caches cache size vs requested.

There could be one case when recalculation of cache size will still happen - when cached cache size was not different from requested, but the requested cache size was more than available space at that time (so available space size was cached instead). But it does not sound like a very important case.