### PR TITLE
Flush signals after initializing exporters

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -367,7 +367,7 @@ public final class OpenTelemetryRumBuilder {
             Services services,
             InitializationEvents initializationEvents,
             BufferDelegatingSpanExporter bufferDelegatingSpanExporter,
-            BufferDelegatingLogExporter bufferedDelegatingLogExporter,
+            BufferDelegatingLogExporter bufferDelegatingLogExporter,
             BufferDelegatingMetricExporter bufferDelegatingMetricExporter) {
 
         DiskBufferingConfig diskBufferingConfig = config.getDiskBufferingConfig();
@@ -403,10 +403,14 @@ public final class OpenTelemetryRumBuilder {
             }
         }
         initializationEvents.spanExporterInitialized(spanExporter);
-        bufferedDelegatingLogExporter.setDelegate(logsExporter);
+        bufferDelegatingLogExporter.setDelegate(logsExporter);
         bufferDelegatingSpanExporter.setDelegate(spanExporter);
         bufferDelegatingMetricExporter.setDelegate(metricExporter);
         scheduleDiskTelemetryReader(services, signalFromDiskExporter);
+
+        bufferDelegatingSpanExporter.flush();
+        bufferDelegatingLogExporter.flush();
+        bufferDelegatingMetricExporter.flush();
     }
 
     @VisibleForTesting


### PR DESCRIPTION
Based on [issue](https://github.com/open-telemetry/opentelemetry-android/issues/815), flushing existing events on sdk initialization to increase chances signals are sent.

Flushes all exporters during SDK build, in async task of initiating exporters.

Maybe there is a better place and time to do it? Sometime after build?

If location is suitable, I will add tests.