### PR TITLE
Addressing lint warning

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ byteBuddy = "1.17.1"
 okhttp = "4.12.0"
 spotless = "7.0.2"
 kotlin = "2.1.10"
-androidPlugin = "8.7.3"
+androidPlugin = "8.8.1"
 junitKtx = "1.2.1"
 autoService = "1.1.1"
 

--- a/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentation.java
+++ b/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentation.java
@@ -8,7 +8,6 @@ package io.opentelemetry.android.instrumentation.slowrendering;
 import android.os.Build;
 import android.util.Log;
 import androidx.annotation.NonNull;
-import androidx.annotation.RequiresApi;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.android.common.RumConstants;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
@@ -40,7 +39,6 @@ public final class SlowRenderingInstrumentation implements AndroidInstrumentatio
         return this;
     }
 
-    @RequiresApi(Build.VERSION_CODES.N)
     @Override
     public void install(@NonNull InstallationContext ctx) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {


### PR DESCRIPTION
Supersedes https://github.com/open-telemetry/opentelemetry-android/pull/824

The warning was triggered because [the SDK lint check is now smarter](https://issuetracker.google.com/issues/373506498#comment6), so it sees that we had annotated a method with `@RequiresApi(N)` and thought that a second validation inside the method wasn't needed. However, the annotation was there for info purposes, as this is an SPI method that should always be called regardless of the environment, therefore it seems like this is a false-positive from the check, so I removed the `@RequiresApi` annotation to avoid it.