### PR TITLE
Fragment readme creation and activity readme correction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Some of the additional features provided include:
 * [ANR detection](./instrumentation/anr/)
 * [Network change detection](./instrumentation/network/)
 * Android [Activity lifecycle instrumentation](./instrumentation/activity/)
-* Android Fragment lifecycle monitoring
+* Android [Fragment lifecycle monitoring](./instrumentation/fragment)
 * Access to the OpenTelemetry APIs for manual instrumentation
 * Helpers to redact any span from export, or change span attributes before export
 * Slow / frozen render detection

--- a/instrumentation/activity/README.md
+++ b/instrumentation/activity/README.md
@@ -23,15 +23,18 @@ This instrumentation produces the following telemetry:
 ### Activity state change
 
 * Type: Span
-* Name: {`Created` | `Resumed` | `Paused` | `Stopped` | `Destroyed`} (depends on the activity state transition)
+* Name: {`Created` | `Resumed` | `Paused` | `Stopped` | `Destroyed` | `Restarted` |} (depends on the activity state transition)
 * Description: As the activity transitions between states, a span will be created to represent the
   lifecycle of that state. Events are added for subsequent minor state changes.
 * SpanEvents: {
   `activityPreCreated` | `activityCreated` | `activityPostCreated` |
+  `activityPreStarted` | `activityStarted` | `activityPostStarted` |
   `activityPreResumed` | `activityResumed` | `activityPostResumed` |
   `activityPrePaused` | `activityPaused` | `activityPostPaused` |
   `activityPreStopped` | `activityStopped` | `activityPostStopped` |
   `activityPreDestroyed` | `activityDestroyed` | `activityPostDestroyed` }
 * Attributes:
-  * `activity.name`:  <name of activity>
+  * `activityName`:  <name of activity>
   * `screen.name`:  <name of screen>
+  * `last.screen.name`:  <name of screen>, when span contains the `activityPostResumed` event. 
+* Parent: null, unless it's a `Created` span created after `AppStart`. Then, `AppStart` is the parent.

--- a/instrumentation/activity/README.md
+++ b/instrumentation/activity/README.md
@@ -36,5 +36,4 @@ This instrumentation produces the following telemetry:
 * Attributes:
   * `activityName`:  <name of activity>
   * `screen.name`:  <name of screen>
-  * `last.screen.name`:  <name of screen>, when span contains the `activityPostResumed` event. 
-* Parent: null, unless it's a `Created` span created after `AppStart`. Then, `AppStart` is the parent.
+  * `last.screen.name`:  <name of screen>, only when span contains the `activityPostResumed` event.

--- a/instrumentation/fragment/README.md
+++ b/instrumentation/fragment/README.md
@@ -22,4 +22,3 @@ This instrumentation produces the following telemetry:
     * `fragmentName`:  <name of fragment>
     * `screen.name`:  <name of screen>
     * `last.screen.name`:  <name of screen>, when span contains the `fragmentResumed` event.
-* Parent:

--- a/instrumentation/fragment/README.md
+++ b/instrumentation/fragment/README.md
@@ -1,0 +1,25 @@
+# Fragment Instrumentation
+
+Status: experimental
+
+The fragment instrumentation helps to track the state of your application's Fragment lifecycle.
+
+## Telemetry
+
+This instrumentation produces the following telemetry:
+
+### Fragment state change
+
+* Type: Span
+* Name: {`Created` | `Restored` | `Resumed` | `Paused` | `Stopped` | `Destroyed` | `ViewDestroyed` | `Detached` |} (depends on the activity state transition)
+* Description: As the activity transitions between states, a span will be created to represent the
+  lifecycle of that state. Events are added for subsequent minor state changes.
+* SpanEvents: {
+  `fragmentPreAttached` | `fragmentAttached` | `fragmentPreCreated` | `fragmentCreated` | `fragmentViewCreated`
+  `fragmentStarted` | `fragmentResumed` | `fragmentPaused` | `fragmentStopped` | 
+  `fragmentViewDestroyed` | `fragmentDestroyed` | `fragmentDetached`
+* Attributes:
+    * `fragmentName`:  <name of fragment>
+    * `screen.name`:  <name of screen>
+    * `last.screen.name`:  <name of screen>, when span contains the `fragmentResumed` event. 
+* Parent:

--- a/instrumentation/fragment/README.md
+++ b/instrumentation/fragment/README.md
@@ -17,7 +17,7 @@ This instrumentation produces the following telemetry:
 * SpanEvents: {
   `fragmentPreAttached` | `fragmentAttached` | `fragmentPreCreated` | `fragmentCreated` | `fragmentViewCreated`
   `fragmentStarted` | `fragmentResumed` | `fragmentPaused` | `fragmentStopped` |
-  `fragmentViewDestroyed` | `fragmentDestroyed` | `fragmentDetached`
+  `fragmentViewDestroyed` | `fragmentDestroyed` | `fragmentDetached` }
 * Attributes:
     * `fragmentName`:  <name of fragment>
     * `screen.name`:  <name of screen>

--- a/instrumentation/fragment/README.md
+++ b/instrumentation/fragment/README.md
@@ -16,10 +16,10 @@ This instrumentation produces the following telemetry:
   lifecycle of that state. Events are added for subsequent minor state changes.
 * SpanEvents: {
   `fragmentPreAttached` | `fragmentAttached` | `fragmentPreCreated` | `fragmentCreated` | `fragmentViewCreated`
-  `fragmentStarted` | `fragmentResumed` | `fragmentPaused` | `fragmentStopped` | 
+  `fragmentStarted` | `fragmentResumed` | `fragmentPaused` | `fragmentStopped` |
   `fragmentViewDestroyed` | `fragmentDestroyed` | `fragmentDetached`
 * Attributes:
     * `fragmentName`:  <name of fragment>
     * `screen.name`:  <name of screen>
-    * `last.screen.name`:  <name of screen>, when span contains the `fragmentResumed` event. 
+    * `last.screen.name`:  <name of screen>, when span contains the `fragmentResumed` event.
 * Parent:


### PR DESCRIPTION
Part of #742: created the fragment instrumentation readme and corrected activity instrumentation readme (added missed spans, span events and an attribute, corrected the `activity.name` attribute name to `activityName`, which is a worse, but reflecting reality name  (#865)).