### PR TITLE
Add attribute extractors to auto-http instrumentations and a null check

### DIFF
--- a/instrumentation/httpurlconnection/library/src/main/java/io/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlReplacements.java
+++ b/instrumentation/httpurlconnection/library/src/main/java/io/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlReplacements.java
@@ -290,7 +290,9 @@ public class HttpUrlReplacements {
 
     private static void startTracingAtFirstConnection(URLConnection connection) {
         Context parentContext = Context.current();
-        if (!HttpUrlConnectionSingletons.instrumenter().shouldStart(parentContext, connection)) {
+        if (HttpUrlConnectionSingletons.instrumenter() == null
+                || !HttpUrlConnectionSingletons.instrumenter()
+                        .shouldStart(parentContext, connection)) {
             return;
         }
 

--- a/instrumentation/httpurlconnection/library/src/main/java/io/opentelemetry/instrumentation/library/httpurlconnection/internal/HttpUrlConnectionSingletons.java
+++ b/instrumentation/httpurlconnection/library/src/main/java/io/opentelemetry/instrumentation/library/httpurlconnection/internal/HttpUrlConnectionSingletons.java
@@ -9,6 +9,7 @@ import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpClientExperimentalMetrics;
 import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpClientPeerServiceAttributesExtractor;
 import io.opentelemetry.instrumentation.api.incubator.semconv.http.HttpExperimentalAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.instrumenter.InstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientAttributesExtractor;
@@ -19,6 +20,7 @@ import io.opentelemetry.instrumentation.api.semconv.http.HttpSpanNameExtractorBu
 import io.opentelemetry.instrumentation.api.semconv.http.HttpSpanStatusExtractor;
 import io.opentelemetry.instrumentation.library.httpurlconnection.HttpUrlInstrumentation;
 import java.net.URLConnection;
+import java.util.List;
 
 public final class HttpUrlConnectionSingletons {
 
@@ -28,7 +30,9 @@ public final class HttpUrlConnectionSingletons {
     private static OpenTelemetry openTelemetryInstance;
 
     public static void configure(
-            HttpUrlInstrumentation instrumentation, OpenTelemetry openTelemetry) {
+            HttpUrlInstrumentation instrumentation,
+            OpenTelemetry openTelemetry,
+            List<AttributesExtractor<URLConnection, Integer>> additionalExtractors) {
 
         HttpUrlHttpAttributesGetter httpAttributesGetter = new HttpUrlHttpAttributesGetter();
 
@@ -62,6 +66,10 @@ public final class HttpUrlConnectionSingletons {
                         .addAttributesExtractor(httpClientAttributesExtractorBuilder.build())
                         .addAttributesExtractor(httpClientPeerServiceAttributesExtractor)
                         .addOperationMetrics(HttpClientMetrics.get());
+
+        for (AttributesExtractor<URLConnection, Integer> extractor : additionalExtractors) {
+            builder.addAttributesExtractor(extractor);
+        }
 
         if (instrumentation.emitExperimentalHttpClientMetrics()) {
             builder.addAttributesExtractor(

--- a/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttp3Singletons.java
+++ b/instrumentation/okhttp/okhttp-3.0/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttp3Singletons.java
@@ -8,7 +8,9 @@ package io.opentelemetry.instrumentation.library.okhttp.v3_0.internal;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.instrumentation.api.incubator.builder.internal.DefaultHttpClientInstrumenterBuilder;
 import io.opentelemetry.instrumentation.api.incubator.semconv.net.PeerServiceAttributesExtractor;
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpClientRequestResendCount;
 import io.opentelemetry.instrumentation.api.semconv.http.HttpSpanNameExtractor;
@@ -17,6 +19,7 @@ import io.opentelemetry.instrumentation.okhttp.v3_0.internal.ConnectionErrorSpan
 import io.opentelemetry.instrumentation.okhttp.v3_0.internal.OkHttpAttributesGetter;
 import io.opentelemetry.instrumentation.okhttp.v3_0.internal.OkHttpClientInstrumenterBuilderFactory;
 import io.opentelemetry.instrumentation.okhttp.v3_0.internal.TracingInterceptor;
+import java.util.List;
 import okhttp3.Interceptor;
 import okhttp3.Request;
 import okhttp3.Response;
@@ -31,8 +34,10 @@ public final class OkHttp3Singletons {
     public static Interceptor TRACING_INTERCEPTOR = NOOP_INTERCEPTOR;
 
     public static void configure(
-            OkHttpInstrumentation instrumentation, OpenTelemetry openTelemetry) {
-        Instrumenter<Interceptor.Chain, Response> instrumenter =
+            OkHttpInstrumentation instrumentation,
+            OpenTelemetry openTelemetry,
+            List<AttributesExtractor<Interceptor.Chain, Response>> additionalExtractors) {
+        DefaultHttpClientInstrumenterBuilder<Interceptor.Chain, Response> instrumenterBuilder =
                 OkHttpClientInstrumenterBuilderFactory.create(openTelemetry)
                         .setCapturedRequestHeaders(instrumentation.getCapturedRequestHeaders())
                         .setCapturedResponseHeaders(instrumentation.getCapturedResponseHeaders())
@@ -51,8 +56,14 @@ public final class OkHttp3Singletons {
                                         OkHttpAttributesGetter.INSTANCE,
                                         instrumentation.newPeerServiceResolver()))
                         .setEmitExperimentalHttpClientMetrics(
-                                instrumentation.emitExperimentalHttpClientMetrics())
-                        .build();
+                                instrumentation.emitExperimentalHttpClientMetrics());
+
+        for (AttributesExtractor<Interceptor.Chain, Response> extractor : additionalExtractors) {
+            instrumenterBuilder = instrumenterBuilder.addAttributesExtractor(extractor);
+        }
+
+        Instrumenter<Interceptor.Chain, Response> instrumenter = instrumenterBuilder.build();
+
         CONNECTION_ERROR_INTERCEPTOR = new ConnectionErrorSpanInterceptor(instrumenter);
         TRACING_INTERCEPTOR = new TracingInterceptor(instrumenter, openTelemetry.getPropagators());
     }


### PR DESCRIPTION
- Added attribute extractors for both the auto-http instrumentations - `Okhttp3` and `HttpURLConnection`
- Added null check to prevent null pointer exception if `instrumenter = null `in `HttpURL` code

Tested both the extractors in my own sample app. 
