### PR TITLE
Require kotlin 1.8+

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ plugins {
 }
 
 extra["java_version"] = JavaVersion.VERSION_1_8
-extra["kotlin_min_supported_version"] = KotlinVersion.KOTLIN_1_7
+extra["kotlin_min_supported_version"] = KotlinVersion.KOTLIN_1_8
 
 allprojects {
     repositories {


### PR DESCRIPTION
Kotlin 1.7 is now deprecated. Kotlin 1.8 came out more than 2 years ago, so this should be a reasonable upgrade.