### PR TITLE
Add `DiskBufferingConfig.signalsBufferDir`

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfig.kt
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfig.kt
@@ -7,6 +7,7 @@ package io.opentelemetry.android.features.diskbuffering
 
 import android.util.Log
 import io.opentelemetry.android.common.RumConstants.OTEL_RUM_LOG_TAG
+import java.io.File
 import java.util.concurrent.TimeUnit
 
 const val DEFAULT_MAX_CACHE_SIZE: Int = 10 * 1024 * 1024
@@ -25,6 +26,11 @@ data class DiskBufferingConfig
         val maxFileAgeForReadMillis: Long = TimeUnit.HOURS.toMillis(DEFAULT_MAX_FILE_AGE_FOR_READ_MS),
         val maxCacheFileSize: Int = MAX_CACHE_FILE_SIZE,
         val debugEnabled: Boolean = false,
+        /**
+         * The directory where the SDK stores the buffered signals before they are exported. If
+         * `null`, a default directory inside the application's cache directory will be used.
+         */
+        val signalsBufferDir: File? = null,
     ) {
         companion object {
             /**
@@ -42,6 +48,7 @@ data class DiskBufferingConfig
                 maxFileAgeForReadMillis: Long = TimeUnit.HOURS.toMillis(18),
                 maxCacheFileSize: Int = MAX_CACHE_FILE_SIZE,
                 debugEnabled: Boolean = false,
+                signalsBufferDir: File? = null,
             ): DiskBufferingConfig {
                 var minRead = minFileAgeForReadMillis
                 if (minFileAgeForReadMillis <= maxFileAgeForWriteMillis) {
@@ -57,6 +64,7 @@ data class DiskBufferingConfig
                     maxFileAgeForReadMillis = maxFileAgeForReadMillis,
                     maxCacheFileSize = maxCacheFileSize,
                     debugEnabled = debugEnabled,
+                    signalsBufferDir = signalsBufferDir,
                 )
             }
         }

--- a/core/src/main/java/io/opentelemetry/android/internal/features/persistence/DiskManager.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/features/persistence/DiskManager.kt
@@ -19,7 +19,7 @@ internal class DiskManager(
     @get:Throws(IOException::class)
     val signalsBufferDir: File
         get() {
-            val dir = File(cacheStorage.cacheDir, "opentelemetry/signals")
+            val dir = diskBufferingConfig.signalsBufferDir ?: File(cacheStorage.cacheDir, "opentelemetry/signals")
             ensureExistingOrThrow(dir)
             return dir
         }

--- a/core/src/test/java/io/opentelemetry/android/internal/features/persistence/DiskManagerTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/features/persistence/DiskManagerTest.kt
@@ -39,10 +39,19 @@ internal class DiskManagerTest {
     }
 
     @Test
-    fun `provides the signal buffer dir`() {
+    fun `provides the default signal buffer dir if not overridden`() {
+        every { diskBufferingConfig.signalsBufferDir } returns null
         val expected = File(cacheDir, "opentelemetry/signals")
         assertThat(diskManager.signalsBufferDir).isEqualTo(expected)
         assertThat(expected.exists()).isTrue()
+    }
+
+    @Test
+    fun `provides the overridden signal buffer dir`() {
+        val customDir = File(cacheDir, "opentelemetry/custom")
+        every { diskBufferingConfig.signalsBufferDir } returns customDir
+        assertThat(diskManager.signalsBufferDir).isEqualTo(customDir)
+        assertThat(customDir.exists()).isTrue()
     }
 
     @Test


### PR DESCRIPTION
Fixes #859 by giving the flexibility to the SDK's users to choose a `signalsBufferDir` other than one used by default.