### PR TITLE
Add bom description

### DIFF
--- a/opentelemetry-android-bom/build.gradle.kts
+++ b/opentelemetry-android-bom/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     id("otel.publish-conventions")
 }
 
+description = "OpenTelemetry Android Bill of Materials"
+
 dependencies {
     constraints {
         rootProject.subprojects.forEach { subproject ->


### PR DESCRIPTION
The lack of description was causing the pom validation to [fail during the release](https://github.com/open-telemetry/opentelemetry-android/actions/runs/13724646433/job/38388065005). This should fix that.