### PR TITLE
Remove old/outdated explicit build tools version

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -6,8 +6,6 @@ plugins {
 android {
     namespace = "io.opentelemetry.android"
 
-    buildToolsVersion = "34.0.0"
-
     defaultConfig {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")

--- a/instrumentation/volley/library/build.gradle.kts
+++ b/instrumentation/volley/library/build.gradle.kts
@@ -7,8 +7,6 @@ plugins {
 android {
     namespace = "io.opentelemetry.android.volley"
 
-    buildToolsVersion = "34.0.0"
-
     defaultConfig {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")


### PR DESCRIPTION
The presence of these lines is causing a build warning:

<img width="874" alt="image" src="https://github.com/user-attachments/assets/ff6d260b-18c6-419c-9237-b88e7ac6ce6b" />

Seems like removing them with AGP 8.9.0 should be safe.