### PR TITLE
Factor out and make session timeouts more explicit.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### ⚠️⚠️ Breaking changes
+
+- Remove `setSessionTimeout()` on `OtelRumConfig` in favor of new `setSessionConfig()`.([#xxx](https://github.com/open-telemetry/opentelemetry-android/pull/xxx))
+
 ## Version 0.10.0 (2025-03-06)
 
 - This version builds on opentelemetry-java-instrumentation

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRum.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRum.java
@@ -8,6 +8,7 @@ package io.opentelemetry.android;
 import android.app.Application;
 import io.opentelemetry.android.config.OtelRumConfig;
 import io.opentelemetry.android.internal.services.Services;
+import io.opentelemetry.android.session.SessionConfig;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.logs.SdkLoggerProvider;

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRum.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRum.java
@@ -8,7 +8,9 @@ package io.opentelemetry.android;
 import android.app.Application;
 import io.opentelemetry.android.config.OtelRumConfig;
 import io.opentelemetry.android.internal.services.Services;
-import io.opentelemetry.android.session.SessionConfig;
+import io.opentelemetry.android.internal.session.SessionIdTimeoutHandler;
+import io.opentelemetry.android.internal.session.SessionManagerImpl;
+import io.opentelemetry.android.session.SessionManager;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.logs.SdkLoggerProvider;
@@ -65,8 +67,17 @@ public interface OpenTelemetryRum {
     static SdkPreconfiguredRumBuilder builder(
             Application application, OpenTelemetrySdk openTelemetrySdk, OtelRumConfig config) {
 
+        SessionIdTimeoutHandler timeoutHandler =
+                new SessionIdTimeoutHandler(config.getSessionConfig());
+        SessionManager sessionManager =
+                SessionManagerImpl.create(timeoutHandler, config.getSessionConfig());
         return new SdkPreconfiguredRumBuilder(
-                application, openTelemetrySdk, config, Services.get(application));
+                application,
+                openTelemetrySdk,
+                timeoutHandler,
+                sessionManager,
+                config,
+                Services.get(application));
     }
 
     /** Returns a no-op implementation of {@link OpenTelemetryRum}. */

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -37,6 +37,7 @@ import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
 import io.opentelemetry.android.internal.services.periodicwork.PeriodicWork;
 import io.opentelemetry.android.internal.session.SessionIdTimeoutHandler;
 import io.opentelemetry.android.internal.session.SessionManagerImpl;
+import io.opentelemetry.android.session.SessionConfig;
 import io.opentelemetry.android.session.SessionManager;
 import io.opentelemetry.android.session.SessionProvider;
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
@@ -117,8 +118,9 @@ public final class OpenTelemetryRumBuilder {
     }
 
     public static OpenTelemetryRumBuilder create(Application application, OtelRumConfig config) {
-        return new OpenTelemetryRumBuilder(
-                application, config, new SessionIdTimeoutHandler(config.getSessionTimeout()));
+        SessionConfig sessionConfig = config.getSessionConfig();
+        SessionIdTimeoutHandler timeoutHandler = new SessionIdTimeoutHandler(sessionConfig);
+        return new OpenTelemetryRumBuilder(application, config, timeoutHandler);
     }
 
     OpenTelemetryRumBuilder(
@@ -320,8 +322,7 @@ public final class OpenTelemetryRumBuilder {
                 new BufferDelegatingMetricExporter();
 
         if (sessionManager == null) {
-            sessionManager =
-                    SessionManagerImpl.create(timeoutHandler, config.getSessionTimeout().toNanos());
+            sessionManager = SessionManagerImpl.create(timeoutHandler, config.getSessionConfig());
         }
 
         OpenTelemetrySdk sdk =

--- a/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
@@ -13,21 +13,54 @@ import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.internal.services.Services
 import io.opentelemetry.android.internal.session.SessionIdTimeoutHandler
 import io.opentelemetry.android.internal.session.SessionManagerImpl
+import io.opentelemetry.android.session.SessionConfig
 import io.opentelemetry.android.session.SessionManager
 import io.opentelemetry.sdk.OpenTelemetrySdk
 
 class SdkPreconfiguredRumBuilder
-    @JvmOverloads
     internal constructor(
         private val application: Application,
         private val sdk: OpenTelemetrySdk,
-        private val timeoutHandler: SessionIdTimeoutHandler = SessionIdTimeoutHandler(),
-        private val sessionManager: SessionManager = SessionManagerImpl(timeoutHandler = timeoutHandler),
+        private val timeoutHandler: SessionIdTimeoutHandler,
+        private val sessionManager: SessionManager,
         private val config: OtelRumConfig,
         private val services: Services,
     ) {
         private val instrumentations = mutableListOf<AndroidInstrumentation>()
         private val appLifecycleService by lazy { services.appLifecycle }
+
+        constructor(
+            app: Application,
+            sdk: OpenTelemetrySdk,
+            sessionConfig: SessionConfig,
+            discoverInstrumentations: Boolean,
+            services: Services,
+        ) :
+            this(
+                app,
+                sdk,
+                sessionConfig,
+                SessionIdTimeoutHandler(sessionConfig),
+                discoverInstrumentations,
+                services,
+            )
+
+        internal constructor(
+            app: Application,
+            sdk: OpenTelemetrySdk,
+            sessionConfig: SessionConfig,
+            timeoutHandler: SessionIdTimeoutHandler,
+            discoverInstrumentations: Boolean,
+            services: Services,
+        ) :
+            this(
+                app,
+                sdk,
+                timeoutHandler,
+                SessionManagerImpl(timeoutHandler = timeoutHandler, maxSessionLifetime = sessionConfig.maxLifetime),
+                discoverInstrumentations,
+                services,
+            )
 
         /**
          * Adds an instrumentation to be applied as a part of the [build] method call.

--- a/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
@@ -12,12 +12,11 @@ import io.opentelemetry.android.instrumentation.AndroidInstrumentationLoader
 import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.internal.services.Services
 import io.opentelemetry.android.internal.session.SessionIdTimeoutHandler
-import io.opentelemetry.android.internal.session.SessionManagerImpl
-import io.opentelemetry.android.session.SessionConfig
 import io.opentelemetry.android.session.SessionManager
 import io.opentelemetry.sdk.OpenTelemetrySdk
 
 class SdkPreconfiguredRumBuilder
+    @JvmOverloads
     internal constructor(
         private val application: Application,
         private val sdk: OpenTelemetrySdk,
@@ -28,39 +27,6 @@ class SdkPreconfiguredRumBuilder
     ) {
         private val instrumentations = mutableListOf<AndroidInstrumentation>()
         private val appLifecycleService by lazy { services.appLifecycle }
-
-        constructor(
-            app: Application,
-            sdk: OpenTelemetrySdk,
-            sessionConfig: SessionConfig,
-            discoverInstrumentations: Boolean,
-            services: Services,
-        ) :
-            this(
-                app,
-                sdk,
-                sessionConfig,
-                SessionIdTimeoutHandler(sessionConfig),
-                discoverInstrumentations,
-                services,
-            )
-
-        internal constructor(
-            app: Application,
-            sdk: OpenTelemetrySdk,
-            sessionConfig: SessionConfig,
-            timeoutHandler: SessionIdTimeoutHandler,
-            discoverInstrumentations: Boolean,
-            services: Services,
-        ) :
-            this(
-                app,
-                sdk,
-                timeoutHandler,
-                SessionManagerImpl(timeoutHandler = timeoutHandler, maxSessionLifetime = sessionConfig.maxLifetime),
-                discoverInstrumentations,
-                services,
-            )
 
         /**
          * Adds an instrumentation to be applied as a part of the [build] method call.

--- a/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
+++ b/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
@@ -8,6 +8,7 @@ package io.opentelemetry.android.config;
 import io.opentelemetry.android.ScreenAttributesSpanProcessor;
 import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig;
 import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider;
+import io.opentelemetry.android.session.SessionConfig;
 import io.opentelemetry.api.common.Attributes;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -27,7 +28,7 @@ public class OtelRumConfig {
     private boolean includeScreenAttributes = true;
     private boolean discoverInstrumentations = true;
     private DiskBufferingConfig diskBufferingConfig = DiskBufferingConfig.create();
-    private Duration sessionTimeout = Duration.ofMinutes(15);
+    private SessionConfig sessionConfig = SessionConfig.withDefaults();
     private final List<String> suppressedInstrumentations = new ArrayList<>();
 
     /**
@@ -132,15 +133,20 @@ public class OtelRumConfig {
         return this;
     }
 
-    /** Call this method to set session timeout in minutes */
-    public OtelRumConfig setSessionTimeout(Duration sessionTimeout) {
-        this.sessionTimeout = sessionTimeout;
+    /**
+     * Sets the session configuration, which includes inactivity timeout and maximum lifetime
+     * durations.
+     *
+     * @return this
+     */
+    public OtelRumConfig setSessionConfig(SessionConfig sessionConfig) {
+        this.sessionConfig = sessionConfig;
         return this;
     }
 
-    /** Call this method to retrieve session timeout */
-    public Duration getSessionTimeout() {
-        return sessionTimeout;
+    /** Call this method to retrieve the session config */
+    public SessionConfig getSessionConfig() {
+        return sessionConfig;
     }
 
     /**

--- a/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
+++ b/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
@@ -10,7 +10,6 @@ import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig;
 import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider;
 import io.opentelemetry.android.session.SessionConfig;
 import io.opentelemetry.api.common.Attributes;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;

--- a/core/src/test/java/io/opentelemetry/android/internal/session/SessionIdTimeoutHandlerTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/session/SessionIdTimeoutHandlerTest.kt
@@ -5,20 +5,21 @@
 
 package io.opentelemetry.android.internal.session
 
-import io.opentelemetry.android.internal.session.SessionIdTimeoutHandler.Companion.DEFAULT_SESSION_TIMEOUT
+import io.opentelemetry.android.session.SessionConfig
 import io.opentelemetry.sdk.testing.time.TestClock
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.time.Duration
 import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.nanoseconds
 
 class SessionIdTimeoutHandlerTest {
     @Test
     fun shouldNeverTimeOutInForeground() {
         val clock: TestClock = TestClock.create()
         val timeoutHandler =
-            SessionIdTimeoutHandler(clock, DEFAULT_SESSION_TIMEOUT)
+            SessionIdTimeoutHandler(clock, SessionConfig.withDefaults().backgroundInactivityTimeout)
 
         assertFalse(timeoutHandler.hasTimedOut())
         timeoutHandler.bump()
@@ -32,7 +33,7 @@ class SessionIdTimeoutHandlerTest {
     fun shouldApply15MinutesTimeoutToAppsInBackground() {
         val clock: TestClock = TestClock.create()
         val timeoutHandler =
-            SessionIdTimeoutHandler(clock, DEFAULT_SESSION_TIMEOUT)
+            SessionIdTimeoutHandler(clock, SessionConfig.withDefaults().backgroundInactivityTimeout)
 
         timeoutHandler.onApplicationBackgrounded()
         timeoutHandler.bump()
@@ -64,7 +65,7 @@ class SessionIdTimeoutHandlerTest {
     fun shouldApplyTimeoutToFirstSpanAfterAppBeingMovedToForeground() {
         val clock: TestClock = TestClock.create()
         val timeoutHandler =
-            SessionIdTimeoutHandler(clock, DEFAULT_SESSION_TIMEOUT)
+            SessionIdTimeoutHandler(clock, SessionConfig.withDefaults().backgroundInactivityTimeout)
 
         timeoutHandler.onApplicationBackgrounded()
         timeoutHandler.bump()
@@ -84,7 +85,7 @@ class SessionIdTimeoutHandlerTest {
     fun shouldApplyCustomTimeoutToFirstSpanAfterAppBeingMovedToForeground() {
         val clock: TestClock = TestClock.create()
         val timeoutHandler =
-            SessionIdTimeoutHandler(clock, Duration.ofNanos(5))
+            SessionIdTimeoutHandler(clock, 5.nanoseconds)
 
         timeoutHandler.onApplicationBackgrounded()
         timeoutHandler.bump()

--- a/core/src/test/java/io/opentelemetry/android/internal/session/SessionManagerImplTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/session/SessionManagerImplTest.kt
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
+import kotlin.time.Duration.Companion.hours
 
 internal class SessionManagerImplTest {
     @MockK
@@ -40,6 +41,7 @@ internal class SessionManagerImplTest {
             SessionManagerImpl(
                 TestClock.create(),
                 timeoutHandler = timeoutHandler,
+                maxSessionLifetime = 4.hours,
             )
         val sessionId = sessionManager.getSessionId()
         assertThat(sessionId).isNotNull()
@@ -54,6 +56,7 @@ internal class SessionManagerImplTest {
             SessionManagerImpl(
                 clock,
                 timeoutHandler = timeoutHandler,
+                maxSessionLifetime = 4.hours,
             )
         val value = sessionManager.getSessionId()
         assertThat(value).isEqualTo(sessionManager.getSessionId())
@@ -82,6 +85,7 @@ internal class SessionManagerImplTest {
             SessionManagerImpl(
                 clock,
                 timeoutHandler = timeoutHandler,
+                maxSessionLifetime = 4.hours,
             )
         sessionManager.addObserver(observer)
 
@@ -121,7 +125,7 @@ internal class SessionManagerImplTest {
 
     @Test
     fun shouldCreateNewSessionIdAfterTimeout() {
-        val sessionId = SessionManagerImpl(timeoutHandler = timeoutHandler)
+        val sessionId = SessionManagerImpl(timeoutHandler = timeoutHandler, maxSessionLifetime = 4.hours)
 
         val value = sessionId.getSessionId()
         verify { timeoutHandler.bump() }

--- a/session/src/main/kotlin/io/opentelemetry/android/session/SessionConfig.kt
+++ b/session/src/main/kotlin/io/opentelemetry/android/session/SessionConfig.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.session
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+data class SessionConfig(
+    val backgroundInactivityTimeout: Duration = 15.minutes,
+    val maxLifetime: Duration = 4.hours,
+) {
+    companion object {
+        @JvmStatic
+        fun withDefaults(): SessionConfig = SessionConfig()
+    }
+}


### PR DESCRIPTION
Relates to #860.  See the thread over there for additional details.

Basically, we have always intended to have two session "timeouts" -- one that is a maximum absolute lifespan (4 hour default) and a background inactivity timeout (15 minute default). Somewhere along the way, these two values were blended, and the same timeout value was ultimately used for both.

The purpose of this PR is to once again separate these two times, and to make their names and usages more explicit.