### PR TITLE
Session management updates

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -118,7 +118,7 @@ public final class OpenTelemetryRumBuilder {
         return new OpenTelemetryRumBuilder(
                 application,
                 config,
-                new SessionBackgroundTimeoutHandler(config.getSessionTimeout()));
+                new SessionBackgroundTimeoutHandler(config.getSessionBackgroundTimeout()));
     }
 
     OpenTelemetryRumBuilder(
@@ -323,7 +323,8 @@ public final class OpenTelemetryRumBuilder {
 
         if (sessionManager == null) {
             sessionManager =
-                    SessionManagerImpl.create(timeoutHandler, config.getSessionTimeout().toNanos());
+                    SessionManagerImpl.create(
+                            timeoutHandler, config.getSessionForegroundTimeout().toNanos());
         }
 
         OpenTelemetrySdk sdk =

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -33,7 +33,7 @@ import io.opentelemetry.android.internal.processors.SessionIdLogRecordAppender;
 import io.opentelemetry.android.internal.services.CacheStorage;
 import io.opentelemetry.android.internal.services.Services;
 import io.opentelemetry.android.internal.services.periodicwork.PeriodicWork;
-import io.opentelemetry.android.internal.session.SessionIdTimeoutHandler;
+import io.opentelemetry.android.internal.session.SessionBackgroundTimeoutHandler;
 import io.opentelemetry.android.internal.session.SessionManagerImpl;
 import io.opentelemetry.android.session.SessionManager;
 import io.opentelemetry.android.session.SessionProvider;
@@ -95,7 +95,7 @@ public final class OpenTelemetryRumBuilder {
     private final OtelRumConfig config;
     private final List<AndroidInstrumentation> instrumentations = new ArrayList<>();
     private final List<Consumer<OpenTelemetrySdk>> otelSdkReadyListeners = new ArrayList<>();
-    private final SessionIdTimeoutHandler timeoutHandler;
+    private final SessionBackgroundTimeoutHandler timeoutHandler;
     private Function<? super SpanExporter, ? extends SpanExporter> spanExporterCustomizer = a -> a;
     private Function<? super MetricExporter, ? extends MetricExporter> metricExporterCustomizer =
             a -> a;
@@ -116,11 +116,15 @@ public final class OpenTelemetryRumBuilder {
 
     public static OpenTelemetryRumBuilder create(Application application, OtelRumConfig config) {
         return new OpenTelemetryRumBuilder(
-                application, config, new SessionIdTimeoutHandler(config.getSessionTimeout()));
+                application,
+                config,
+                new SessionBackgroundTimeoutHandler(config.getSessionTimeout()));
     }
 
     OpenTelemetryRumBuilder(
-            Application application, OtelRumConfig config, SessionIdTimeoutHandler timeoutHandler) {
+            Application application,
+            OtelRumConfig config,
+            SessionBackgroundTimeoutHandler timeoutHandler) {
         this.application = application;
         this.timeoutHandler = timeoutHandler;
         this.resource = AndroidResource.createDefault(application);

--- a/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
@@ -10,7 +10,7 @@ import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.instrumentation.AndroidInstrumentationLoader
 import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.internal.services.Services
-import io.opentelemetry.android.internal.session.SessionIdTimeoutHandler
+import io.opentelemetry.android.internal.session.SessionBackgroundTimeoutHandler
 import io.opentelemetry.android.internal.session.SessionManagerImpl
 import io.opentelemetry.android.session.SessionManager
 import io.opentelemetry.sdk.OpenTelemetrySdk
@@ -20,7 +20,7 @@ class SdkPreconfiguredRumBuilder
     internal constructor(
         private val application: Application,
         private val sdk: OpenTelemetrySdk,
-        private val timeoutHandler: SessionIdTimeoutHandler = SessionIdTimeoutHandler(),
+        private val timeoutHandler: SessionBackgroundTimeoutHandler = SessionBackgroundTimeoutHandler(),
         private val sessionManager: SessionManager = SessionManagerImpl(timeoutHandler = timeoutHandler),
         private val discoverInstrumentations: Boolean,
         private val services: Services,

--- a/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
+++ b/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
@@ -25,7 +25,8 @@ public class OtelRumConfig {
     private boolean includeScreenAttributes = true;
     private boolean discoverInstrumentations = true;
     private DiskBufferingConfig diskBufferingConfig = DiskBufferingConfig.create();
-    private Duration sessionTimeout = Duration.ofMinutes(15);
+    private Duration sessionBackgroundTimeout = Duration.ofMinutes(15);
+    private Duration sessionForegroundTimeout = Duration.ofHours(4);
 
     /**
      * Configures the set of global attributes to emit with every span and event. Any existing
@@ -129,14 +130,25 @@ public class OtelRumConfig {
         return this;
     }
 
-    /** Call this method to set session timeout in minutes */
-    public OtelRumConfig setSessionTimeout(Duration sessionTimeout) {
-        this.sessionTimeout = sessionTimeout;
+    /** Call this method to set background session timeout */
+    public OtelRumConfig setSessionBackgroundTimeout(Duration sessionBackgroundTimeout) {
+        this.sessionBackgroundTimeout = sessionBackgroundTimeout;
         return this;
     }
 
-    /** Call this method to retrieve session timeout */
-    public Duration getSessionTimeout() {
-        return sessionTimeout;
+    /** Call this method to retrieve background session timeout */
+    public Duration getSessionBackgroundTimeout() {
+        return sessionBackgroundTimeout;
+    }
+
+    /** Call this method to set foreground session timeout */
+    public OtelRumConfig setSessionForegroundTimeout(Duration sessionForegroundTimeout) {
+        this.sessionForegroundTimeout = sessionForegroundTimeout;
+        return this;
+    }
+
+    /** Call this method to retrieve foreground session timeout */
+    public Duration getSessionForegroundTimeout() {
+        return sessionForegroundTimeout;
     }
 }

--- a/core/src/main/java/io/opentelemetry/android/internal/session/SessionBackgroundTimeoutHandler.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/session/SessionBackgroundTimeoutHandler.kt
@@ -23,7 +23,7 @@ import java.time.Duration
  * Consequently, when the app spent >15 minutes without any activity (spans) in the background,
  * after moving to the foreground the first span should trigger the sessionId timeout.
  */
-internal class SessionIdTimeoutHandler(
+internal class SessionBackgroundTimeoutHandler(
     private val clock: Clock,
     private val sessionTimeout: Duration,
 ) : ApplicationStateListener {

--- a/core/src/main/java/io/opentelemetry/android/internal/session/SessionManagerImpl.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/session/SessionManagerImpl.kt
@@ -26,6 +26,8 @@ internal class SessionManagerImpl(
     private val observers = synchronizedList(ArrayList<SessionObserver>())
 
     init {
+        // Initialize the first session when this class is first loaded from OpenTelemetryRumBuilder
+        getSessionId()
         sessionStorage.save(session)
     }
 

--- a/core/src/main/java/io/opentelemetry/android/internal/session/SessionManagerImpl.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/session/SessionManagerImpl.kt
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit
 internal class SessionManagerImpl(
     private val clock: Clock = Clock.getDefault(),
     private val sessionStorage: SessionStorage = SessionStorage.InMemory(),
-    private val timeoutHandler: SessionIdTimeoutHandler,
+    private val timeoutHandler: SessionBackgroundTimeoutHandler,
     private val idGenerator: SessionIdGenerator = SessionIdGenerator.DEFAULT,
     private val sessionLifetimeNanos: Long = TimeUnit.HOURS.toNanos(4),
 ) : SessionManager {
@@ -74,7 +74,7 @@ internal class SessionManagerImpl(
     companion object {
         @JvmStatic
         fun create(
-            timeoutHandler: SessionIdTimeoutHandler,
+            timeoutHandler: SessionBackgroundTimeoutHandler,
             sessionLifetimeNanos: Long,
         ): SessionManagerImpl =
             SessionManagerImpl(

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -42,7 +42,7 @@ import io.opentelemetry.android.internal.services.Services;
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle;
 import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateListener;
 import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTracker;
-import io.opentelemetry.android.internal.session.SessionIdTimeoutHandler;
+import io.opentelemetry.android.internal.session.SessionBackgroundTimeoutHandler;
 import io.opentelemetry.android.session.SessionManager;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder;
@@ -283,7 +283,7 @@ public class OpenTelemetryRumBuilderTest {
     public void shouldInstallInstrumentation() {
         Services services = createAndSetServiceManager();
         SessionManager sessionManager = mock();
-        SessionIdTimeoutHandler timeoutHandler = mock();
+        SessionBackgroundTimeoutHandler timeoutHandler = mock();
         AndroidInstrumentation localInstrumentation = mock();
         AndroidInstrumentation classpathInstrumentation = mock();
         AndroidInstrumentationLoaderImpl androidInstrumentationServices =
@@ -308,7 +308,7 @@ public class OpenTelemetryRumBuilderTest {
     public void shouldInstallInstrumentation_excludingClasspathImplsWhenRequestedInConfig() {
         Services services = createAndSetServiceManager();
         SessionManager sessionManager = mock();
-        SessionIdTimeoutHandler timeoutHandler = mock();
+        SessionBackgroundTimeoutHandler timeoutHandler = mock();
         AndroidInstrumentation localInstrumentation = mock();
         AndroidInstrumentation classpathInstrumentation = mock();
         AndroidInstrumentationLoaderImpl androidInstrumentationServices =

--- a/core/src/test/java/io/opentelemetry/android/internal/session/SessionIdTimeoutHandlerTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/session/SessionIdTimeoutHandlerTest.kt
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.android.internal.session
 
-import io.opentelemetry.android.internal.session.SessionIdTimeoutHandler.Companion.DEFAULT_SESSION_TIMEOUT
+import io.opentelemetry.android.internal.session.SessionBackgroundTimeoutHandler.Companion.DEFAULT_SESSION_TIMEOUT
 import io.opentelemetry.sdk.testing.time.TestClock
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -18,7 +18,7 @@ class SessionIdTimeoutHandlerTest {
     fun shouldNeverTimeOutInForeground() {
         val clock: TestClock = TestClock.create()
         val timeoutHandler =
-            SessionIdTimeoutHandler(clock, DEFAULT_SESSION_TIMEOUT)
+            SessionBackgroundTimeoutHandler(clock, DEFAULT_SESSION_TIMEOUT)
 
         assertFalse(timeoutHandler.hasTimedOut())
         timeoutHandler.bump()
@@ -32,7 +32,7 @@ class SessionIdTimeoutHandlerTest {
     fun shouldApply15MinutesTimeoutToAppsInBackground() {
         val clock: TestClock = TestClock.create()
         val timeoutHandler =
-            SessionIdTimeoutHandler(clock, DEFAULT_SESSION_TIMEOUT)
+            SessionBackgroundTimeoutHandler(clock, DEFAULT_SESSION_TIMEOUT)
 
         timeoutHandler.onApplicationBackgrounded()
         timeoutHandler.bump()
@@ -64,7 +64,7 @@ class SessionIdTimeoutHandlerTest {
     fun shouldApplyTimeoutToFirstSpanAfterAppBeingMovedToForeground() {
         val clock: TestClock = TestClock.create()
         val timeoutHandler =
-            SessionIdTimeoutHandler(clock, DEFAULT_SESSION_TIMEOUT)
+            SessionBackgroundTimeoutHandler(clock, DEFAULT_SESSION_TIMEOUT)
 
         timeoutHandler.onApplicationBackgrounded()
         timeoutHandler.bump()
@@ -84,7 +84,7 @@ class SessionIdTimeoutHandlerTest {
     fun shouldApplyCustomTimeoutToFirstSpanAfterAppBeingMovedToForeground() {
         val clock: TestClock = TestClock.create()
         val timeoutHandler =
-            SessionIdTimeoutHandler(clock, Duration.ofNanos(5))
+            SessionBackgroundTimeoutHandler(clock, Duration.ofNanos(5))
 
         timeoutHandler.onApplicationBackgrounded()
         timeoutHandler.bump()

--- a/core/src/test/java/io/opentelemetry/android/internal/session/SessionManagerImplTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/session/SessionManagerImplTest.kt
@@ -25,7 +25,7 @@ import java.util.regex.Pattern
 
 internal class SessionManagerImplTest {
     @MockK
-    lateinit var timeoutHandler: SessionIdTimeoutHandler
+    lateinit var timeoutHandler: SessionBackgroundTimeoutHandler
 
     @BeforeEach
     fun setUp() {

--- a/instrumentation/android-instrumentation/src/main/java/io/opentelemetry/android/instrumentation/InstallationContext.kt
+++ b/instrumentation/android-instrumentation/src/main/java/io/opentelemetry/android/instrumentation/InstallationContext.kt
@@ -9,8 +9,10 @@ import android.app.Application
 import io.opentelemetry.android.session.SessionManager
 import io.opentelemetry.api.OpenTelemetry
 
-data class InstallationContext(
-    val application: Application,
-    val openTelemetry: OpenTelemetry,
-    val sessionManager: SessionManager,
-)
+data class InstallationContext
+    @JvmOverloads
+    constructor(
+        val application: Application,
+        val openTelemetry: OpenTelemetry,
+        val sessionManager: SessionManager = SessionManager.NoOp(),
+    )

--- a/session/src/main/kotlin/io/opentelemetry/android/session/SessionManager.kt
+++ b/session/src/main/kotlin/io/opentelemetry/android/session/SessionManager.kt
@@ -12,4 +12,13 @@ package io.opentelemetry.android.session
  */
 interface SessionManager :
     SessionProvider,
-    SessionPublisher
+    SessionPublisher {
+    // No-Op SessionManager
+    class NoOp : SessionManager {
+        override fun getSessionId(): String = ""
+
+        override fun addObserver(observer: SessionObserver) {
+            // No-op implementation
+        }
+    }
+}


### PR DESCRIPTION
This PR covers the following:
- Starting the first session on application start (as soon as `ServiceManagerImpl` is loaded), resolving #781 
- Adding two separate `configs` for session `foreground` and `background` `timeout`, resolving #794 
- Adding a no-op session manager as default in `InstallationContext` API, interim resolution of #795 
- Renaming `SessionIdTimeoutHandler` to `SessionBackgroundTimeoutHandler`, part of #793 