### PR TITLE
Use event name for crash event (instead of attr)

### DIFF
--- a/instrumentation/crash/README.md
+++ b/instrumentation/crash/README.md
@@ -12,19 +12,15 @@ This instrumentation produces the following telemetry:
 
 ### Crash
 
-* Type: Event (*)
-* Name: `device.crash` (see note below)
+* Type: Event
+* Event Name: `device.crash`
 * Description: An event that is generated for exceptions not handled by user code.
 * Attributes:
-    * `event.name`: `device.crash` (see note below)
     * `exception.message` ([see semconv here](https://github.com/open-telemetry/semantic-conventions/blob/727700406f9e6cc3f4e4680a81c4c28f2eb71569/docs/attributes-registry/exception.md#exception-message))
     * `exception.stacktrace` ([see semconv here](https://github.com/open-telemetry/semantic-conventions/blob/727700406f9e6cc3f4e4680a81c4c28f2eb71569/docs/attributes-registry/exception.md#exception-stacktrace))
     * `exception.type` ([see semconv here](https://github.com/open-telemetry/semantic-conventions/blob/727700406f9e6cc3f4e4680a81c4c28f2eb71569/docs/attributes-registry/exception.md#exception-type))
     * `thread.id` ([see semconv here](https://github.com/open-telemetry/semantic-conventions/blob/727700406f9e6cc3f4e4680a81c4c28f2eb71569/docs/attributes-registry/thread.md#thread-id))
     * `thread.name` ([see semconv here](https://github.com/open-telemetry/semantic-conventions/blob/727700406f9e6cc3f4e4680a81c4c28f2eb71569/docs/attributes-registry/thread.md#thread-name))
-
-(*) Note: This event is currently a malformed LogRecord. It will use correct event fields
-    and semantics after the java sdk has these features available.
 
 Note: This instrumentation supports additional user-configurable `AttributeExtractors` that
 may set additional attributes from the given `CrashDetails` (`Thread` and `Throwable`).

--- a/instrumentation/crash/build.gradle.kts
+++ b/instrumentation/crash/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation(libs.androidx.core)
     implementation(libs.opentelemetry.semconv.incubating)
     implementation(libs.opentelemetry.sdk)
+    implementation(libs.opentelemetry.sdk.extension.incubator)
     implementation(libs.opentelemetry.instrumentation.api)
     testImplementation(libs.awaitility)
     testImplementation(libs.robolectric)

--- a/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.java
+++ b/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.java
@@ -8,12 +8,12 @@ package io.opentelemetry.android.instrumentation.crash;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE;
 import static io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE;
-import static io.opentelemetry.semconv.incubating.EventIncubatingAttributes.EVENT_NAME;
 import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID;
 import static io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME;
 
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder;
 import io.opentelemetry.api.logs.Logger;
 import io.opentelemetry.api.logs.LoggerProvider;
 import io.opentelemetry.context.Context;
@@ -59,9 +59,12 @@ public final class CrashReporter {
             extractor.onStart(attributesBuilder, Context.current(), crashDetails);
         }
 
-        // TODO: use emitEvent() when available, with event name from semantic conventions.
-        attributesBuilder.put(EVENT_NAME, "device.crash");
-        crashReporter.logRecordBuilder().setAllAttributes(attributesBuilder.build()).emit();
+        ExtendedLogRecordBuilder eventBuilder =
+                (ExtendedLogRecordBuilder) crashReporter.logRecordBuilder();
+        eventBuilder
+                .setEventName("device.crash")
+                .setAllAttributes(attributesBuilder.build())
+                .emit();
     }
 
     private String stackTraceToString(Throwable throwable) {

--- a/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReporterTest.java
+++ b/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReporterTest.java
@@ -17,6 +17,7 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.logs.SdkLoggerProvider;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.opentelemetry.sdk.logs.data.internal.ExtendedLogRecordData;
 import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions;
 import io.opentelemetry.sdk.testing.exporter.InMemoryLogRecordExporter;
@@ -81,7 +82,10 @@ public class CrashReporterTest {
         List<LogRecordData> logRecords = logRecordExporter.getFinishedLogRecordItems();
         assertThat(logRecords).hasSize(1);
 
-        Attributes crashAttributes = logRecords.get(0).getAttributes();
+        ExtendedLogRecordData logRecord = (ExtendedLogRecordData) logRecords.get(0);
+
+        assertThat(logRecord.getEventName()).isEqualTo("device.crash");
+        Attributes crashAttributes = logRecord.getAttributes();
         OpenTelemetryAssertions.assertThat(crashAttributes)
                 .containsEntry(ExceptionAttributes.EXCEPTION_MESSAGE, exceptionMessage)
                 .containsEntry(ExceptionAttributes.EXCEPTION_TYPE, "java.lang.RuntimeException")


### PR DESCRIPTION
During SIG review today, we noticed that the log record for crash still had the event name attribute set. This changes it to use the top-level event field on the LogRecord.