### PR TITLE
Migrate network change event from zero-duration span to event

### DIFF
--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OtelRumConfigExtensions.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OtelRumConfigExtensions.kt
@@ -16,9 +16,11 @@ import io.opentelemetry.android.instrumentation.crash.CrashReporterInstrumentati
 import io.opentelemetry.android.instrumentation.fragment.FragmentLifecycleInstrumentation
 import io.opentelemetry.android.instrumentation.network.NetworkChangeInstrumentation
 import io.opentelemetry.android.instrumentation.slowrendering.SlowRenderingInstrumentation
+import io.opentelemetry.api.common.AttributesBuilder
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor
 import java.time.Duration
+import java.util.function.BiConsumer
 
 /**
  * Convenience functions to allow configuring the default instrumentations through the [OtelRumConfig] object, for example:
@@ -73,7 +75,7 @@ fun OtelRumConfig.addCrashAttributesExtractor(extractor: AttributesExtractor<Cra
     return this
 }
 
-fun OtelRumConfig.addNetworkChangeAttributesExtractor(extractor: AttributesExtractor<CurrentNetwork, Void>): OtelRumConfig {
+fun OtelRumConfig.addNetworkChangeAttributesExtractor(extractor: BiConsumer<AttributesBuilder, CurrentNetwork>): OtelRumConfig {
     AndroidInstrumentationLoader
         .getInstrumentation(NetworkChangeInstrumentation::class.java)
         ?.addAttributesExtractor(extractor)

--- a/core/src/main/java/io/opentelemetry/android/internal/features/networkattrs/NetworkAttributesLogRecordAppender.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/features/networkattrs/NetworkAttributesLogRecordAppender.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.internal.features.networkattrs
+
+import io.opentelemetry.android.common.internal.features.networkattributes.CurrentNetworkAttributesExtractor
+import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.logs.LogRecordProcessor
+import io.opentelemetry.sdk.logs.ReadWriteLogRecord
+
+class NetworkAttributesLogRecordAppender(
+    private val currentNetworkProvider: CurrentNetworkProvider,
+    private val networkAttributesExtractor: CurrentNetworkAttributesExtractor = CurrentNetworkAttributesExtractor(),
+) : LogRecordProcessor {
+    constructor(networkProvider: CurrentNetworkProvider) : this(networkProvider, CurrentNetworkAttributesExtractor())
+
+    override fun onEmit(
+        context: Context,
+        logRecord: ReadWriteLogRecord,
+    ) {
+        val currentNetwork = currentNetworkProvider.currentNetwork
+        logRecord.setAllAttributes(networkAttributesExtractor.extract(currentNetwork))
+    }
+}

--- a/instrumentation/network/README.md
+++ b/instrumentation/network/README.md
@@ -18,9 +18,9 @@ This instrumentation produces the following telemetry:
 
 ### Network Change
 
-* Type: Span
+* Type: Event
 * Name: `network.change`
-* Description: This zero-duration span is started and ended when a network change is detected.
+* Description: This event is emitted when a network change is detected.
 * Attributes:
     * `network.status`: One of `lost` or `available`.
     * `network.connection.type` (semconv) one of `cell`, `wifi`, `wired`, `unavailable`, `unknown`, `vpn`.

--- a/instrumentation/network/build.gradle.kts
+++ b/instrumentation/network/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation(libs.androidx.core)
     implementation(libs.opentelemetry.semconv.incubating)
     implementation(libs.opentelemetry.sdk)
+    implementation(libs.opentelemetry.sdk.extension.incubator)
     implementation(libs.opentelemetry.instrumentation.api)
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.test.core)

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentation.java
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentation.java
@@ -11,26 +11,29 @@ import io.opentelemetry.android.common.internal.features.networkattributes.data.
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
 import io.opentelemetry.android.instrumentation.InstallationContext;
 import io.opentelemetry.android.internal.services.Services;
-import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
+import io.opentelemetry.api.common.AttributesBuilder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.BiConsumer;
 
 /** Generates telemetry for when the network status changes. */
 @AutoService(AndroidInstrumentation.class)
 public final class NetworkChangeInstrumentation implements AndroidInstrumentation {
 
-    final List<AttributesExtractor<CurrentNetwork, Void>> additionalExtractors = new ArrayList<>();
+    final List<BiConsumer<AttributesBuilder, CurrentNetwork>> additionalExtractors =
+            new ArrayList<>();
 
-    /** Adds an {@link AttributesExtractor} that will extract additional attributes. */
+    /** Adds a {@link BiConsumer} that can add Attributes about the current network. */
     public NetworkChangeInstrumentation addAttributesExtractor(
-            AttributesExtractor<CurrentNetwork, Void> extractor) {
+            BiConsumer<AttributesBuilder, CurrentNetwork> extractor) {
         additionalExtractors.add(extractor);
         return this;
     }
 
     @Override
     public void install(@NonNull InstallationContext ctx) {
+        additionalExtractors.add(new NetworkChangeAttributesExtractor());
         Services services = Services.get(ctx.getApplication());
         NetworkChangeMonitor networkChangeMonitor =
                 new NetworkChangeMonitor(

--- a/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeMonitorTest.java
+++ b/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeMonitorTest.java
@@ -25,8 +25,9 @@ import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle;
 import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateListener;
 import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider;
 import io.opentelemetry.android.internal.services.network.NetworkChangeListener;
+import io.opentelemetry.sdk.logs.data.LogRecordData;
+import io.opentelemetry.sdk.logs.data.internal.ExtendedLogRecordData;
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
-import io.opentelemetry.sdk.trace.data.SpanData;
 import java.util.Collections;
 import java.util.List;
 import org.junit.After;
@@ -76,10 +77,11 @@ public class NetworkChangeMonitorTest {
 
         listener.onNetworkChange(CurrentNetwork.builder(NetworkState.TRANSPORT_WIFI).build());
 
-        List<SpanData> spans = otelTesting.getSpans();
-        assertEquals(1, spans.size());
-        assertThat(spans.get(0))
-                .hasName("network.change")
+        List<LogRecordData> logs = otelTesting.getLogRecords();
+        assertEquals(1, logs.size());
+        ExtendedLogRecordData log = (ExtendedLogRecordData) logs.get(0);
+        assertThat(log.getEventName()).isEqualTo("network.change");
+        assertThat(log)
                 .hasAttributesSatisfyingExactly(
                         equalTo(NetworkApplicationListener.NETWORK_STATUS_KEY, "available"),
                         equalTo(NETWORK_CONNECTION_TYPE, "wifi"));
@@ -101,10 +103,11 @@ public class NetworkChangeMonitorTest {
 
         listener.onNetworkChange(network);
 
-        List<SpanData> spans = otelTesting.getSpans();
-        assertEquals(1, spans.size());
-        assertThat(spans.get(0))
-                .hasName("network.change")
+        List<LogRecordData> logs = otelTesting.getLogRecords();
+        assertEquals(1, logs.size());
+        ExtendedLogRecordData log = (ExtendedLogRecordData) logs.get(0);
+        assertThat(log.getEventName()).isEqualTo("network.change");
+        assertThat(log)
                 .hasAttributesSatisfyingExactly(
                         equalTo(NetworkApplicationListener.NETWORK_STATUS_KEY, "available"),
                         equalTo(NETWORK_CONNECTION_TYPE, "cell"),
@@ -125,10 +128,11 @@ public class NetworkChangeMonitorTest {
 
         listener.onNetworkChange(CurrentNetwork.builder(NetworkState.NO_NETWORK_AVAILABLE).build());
 
-        List<SpanData> spans = otelTesting.getSpans();
-        assertEquals(1, spans.size());
-        assertThat(spans.get(0))
-                .hasName("network.change")
+        List<LogRecordData> events = otelTesting.getLogRecords();
+        assertEquals(1, events.size());
+        ExtendedLogRecordData log = (ExtendedLogRecordData) events.get(0);
+        assertThat(log.getEventName()).isEqualTo("network.change");
+        assertThat(log)
                 .hasAttributesSatisfyingExactly(
                         equalTo(NetworkApplicationListener.NETWORK_STATUS_KEY, "lost"),
                         equalTo(NETWORK_CONNECTION_TYPE, "unavailable"));
@@ -167,6 +171,6 @@ public class NetworkChangeMonitorTest {
                 otelTesting.getOpenTelemetry(),
                 appLifecycle,
                 currentNetworkProvider,
-                Collections.emptyList());
+                Collections.singletonList(new NetworkChangeAttributesExtractor()));
     }
 }


### PR DESCRIPTION
The network change event is currently a zero-duration span. We want to migrate these to actual OpenTelemetry log-based events. This does that work, and also introduces a (global) `LogRecordProcessor` named `NetworkAttributesLogRecordAppender` that (when configured) always appends the global log attributes to all logs/events (similar to the NetworkAttributesSpanAppender).