### PR TITLE
Removed angled brackets for morkdown to render correctly

### DIFF
--- a/instrumentation/activity/README.md
+++ b/instrumentation/activity/README.md
@@ -34,6 +34,6 @@ This instrumentation produces the following telemetry:
   `activityPreStopped` | `activityStopped` | `activityPostStopped` |
   `activityPreDestroyed` | `activityDestroyed` | `activityPostDestroyed` }
 * Attributes:
-  * `activity.name`:  <name of activity>
-  * `screen.name`:  <name of screen>
-  * `last.screen.name`:  <name of screen>, only when span contains the `activityPostResumed` event.
+  * `activity.name`:  name of activity
+  * `screen.name`:  name of screen
+  * `last.screen.name`:  name of screen, only when span contains the `activityPostResumed` event.

--- a/instrumentation/fragment/README.md
+++ b/instrumentation/fragment/README.md
@@ -19,6 +19,6 @@ This instrumentation produces the following telemetry:
   `fragmentStarted` | `fragmentResumed` | `fragmentPaused` | `fragmentStopped` |
   `fragmentViewDestroyed` | `fragmentDestroyed` | `fragmentDetached` }
 * Attributes:
-    * `fragment.name`:  <name of fragment>
-    * `screen.name`:  <name of screen>
-    * `last.screen.name`:  <name of screen>, when span contains the `fragmentResumed` event.
+    * `fragment.name`:  name of fragment
+    * `screen.name`:  name of screen
+    * `last.screen.name`:  name of screen, when span contains the `fragmentResumed` event.


### PR DESCRIPTION
Fixes #919 (I believe kubecon is over so I just did it)
Removed angle brackets in fragment and activity instrumentation READMEs for markdown to render correctly.
