### PR TITLE
README minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Some of the additional features provided include:
 * Android [Fragment lifecycle monitoring](./instrumentation/fragment)
 * Access to the OpenTelemetry APIs for manual instrumentation
 * Helpers to redact any span from export, or change span attributes before export
-* Slow / frozen render detection
+* [Slow / frozen render detection](./instrumentation/slowrendering)
 * Offline buffering of telemetry via storage
 
 Note: Use of these features is not yet well documented.

--- a/instrumentation/slowrendering/README.md
+++ b/instrumentation/slowrendering/README.md
@@ -37,4 +37,4 @@ Generated when rendering takes more than 700ms.
   one render duration longer than 700ms.
 * Attributes:
     * `count` - the number of slow renders
-    * `activityName` - the name of the activity for which the slow render was detected
+    * `activity.name` - the name of the activity for which the slow render was detected

--- a/instrumentation/slowrendering/README.md
+++ b/instrumentation/slowrendering/README.md
@@ -25,7 +25,7 @@ Generated when rendering takes more than 16ms.
   one render duration longer than 16ms.
 * Attributes:
   * `count` - the number of slow renders
-  * `activityName` - the name of the activity for which the slow render was detected
+  * `activity.name` - the name of the activity for which the slow render was detected
 
 ### Frozen Renders
 


### PR DESCRIPTION
Changed `activityName` to `activity.name` in the slowrendering instrumentation readme (this one was dot separated from the start) and linked it in the main readme.