### PR TITLE
Relax fragment dependency

### DIFF
--- a/instrumentation/activity/build.gradle.kts
+++ b/instrumentation/activity/build.gradle.kts
@@ -23,7 +23,8 @@ dependencies {
     implementation(project(":common"))
     implementation(libs.opentelemetry.sdk)
     implementation(libs.androidx.core)
-    implementation(libs.androidx.navigation.fragment)
+    compileOnly(libs.androidx.navigation.fragment)
     implementation(libs.opentelemetry.instrumentation.api)
+    testImplementation(libs.androidx.navigation.fragment)
     testImplementation(libs.robolectric)
 }

--- a/instrumentation/common-api/build.gradle.kts
+++ b/instrumentation/common-api/build.gradle.kts
@@ -17,7 +17,8 @@ dependencies {
     implementation(project(":common"))
     api(platform(libs.opentelemetry.platform.alpha))
     api(libs.opentelemetry.api)
-    implementation(libs.androidx.navigation.fragment)
+    compileOnly(libs.androidx.navigation.fragment)
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.instrumentation.api)
+    testImplementation(libs.androidx.navigation.fragment)
 }

--- a/instrumentation/volley/library/build.gradle.kts
+++ b/instrumentation/volley/library/build.gradle.kts
@@ -33,7 +33,7 @@ android {
 }
 
 dependencies {
-    implementation(libs.androidx.navigation.fragment)
+    compileOnly(libs.androidx.navigation.fragment)
     implementation(libs.opentelemetry.instrumentation.api)
     implementation(libs.opentelemetry.semconv.incubating)
     compileOnly(libs.volley)

--- a/services/build.gradle.kts
+++ b/services/build.gradle.kts
@@ -17,10 +17,11 @@ dependencies {
     implementation(project(":common"))
 
     implementation(libs.androidx.core)
-    implementation(libs.androidx.navigation.fragment)
+    compileOnly(libs.androidx.navigation.fragment)
     implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.preference.ktx)
 
+    testImplementation(libs.androidx.navigation.fragment)
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.robolectric)
 }


### PR DESCRIPTION
This changes the dependency on navigation-fragment to compileOnly for all modules except fragment intsrumentation.

This should prevent a transitive dependency for users who do not use fragments, and doesn't force a newer version on users who might use an older version.

I tried the demo app, and it came up just fine. I believe that this is because the demo-app uses the agent, and the agent includes fragment instrumentation, so it picks up the transitive dependency as normal. It's a little worrying to have references to Fragment classes with a mere `compileOnly()`, so we should figure out what our end state should look like.