### PR TITLE
 Adding item to cart fix

### DIFF
--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/products/ProductDetails.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/products/ProductDetails.kt
@@ -134,8 +134,8 @@ fun AddToCartButton(
                 if (product.id == "HQTGWGPNH4") {
                     onSlowRenderChange(true)
                 }
-                cartViewModel.addProduct(product, quantity)
             }
+            cartViewModel.addProduct(product, quantity)
         },
         modifier = Modifier
             .fillMaxWidth()


### PR DESCRIPTION
Fixes #940 - took a line that adds an item to cart out of `else` for item being National Park Foundation Explorascope. 