### PR TITLE
Change okhttp3 dependency from compileOnly to implementation

### DIFF
--- a/instrumentation/okhttp3/agent/build.gradle.kts
+++ b/instrumentation/okhttp3/agent/build.gradle.kts
@@ -10,7 +10,7 @@ android {
 }
 
 dependencies {
-    compileOnly(libs.okhttp)
+    implementation(libs.okhttp)
     implementation(project(":instrumentation:okhttp3:library"))
     implementation(libs.byteBuddy)
 }


### PR DESCRIPTION
I tried @LikeTheSalad's suggestion on this issue - #944 and it works. Creating this quick PR to change it. 