### PR TITLE
Group patch PRs to lower thrash

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -108,6 +108,11 @@
     {
       "matchPackagePrefixes": ["com.gradle.develocity"],
       "groupName": "gradle develocity packages"
+    },
+    {
+      "groupName": "all patch versions",
+      "matchUpdateTypes": ["patch"],
+      "schedule": ["before 8am every weekday"]
     }
   ]
 }


### PR DESCRIPTION
Saw this in a couple of java repos and thought we might benefit from this occasionally. It groups patch release PRs to once daily.