### PR TITLE
Remove fragments dependency from Volley module

### DIFF
--- a/instrumentation/volley/library/build.gradle.kts
+++ b/instrumentation/volley/library/build.gradle.kts
@@ -33,7 +33,6 @@ android {
 }
 
 dependencies {
-    implementation(libs.androidx.navigation.fragment)
     implementation(libs.opentelemetry.instrumentation.api)
     implementation(libs.opentelemetry.semconv.incubating)
     compileOnly(libs.volley)


### PR DESCRIPTION
This dependency is not required for the Volley module so I'm removing it.