### PR TITLE
Use instrumentation api to get version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
           fi
           # otel instrumentation version comes in through alpha bom
           inst_version=$(./gradlew --console=plain android-agent:dependencies | \
-                        grep 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom ' | \
+                        grep 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-api ' | \
                         sed -e "s/.* -> //" | sed -e "s/ .*//" | \
                         sort | head -1)
           # otel-java core libs are transient deps thru instrumentation boms


### PR DESCRIPTION
When doing the last release, I noticed that the release notes didn't contain the instrumentation version. I think this broke when we switched to using the alpha bom, so let's just use the version of the instrumentation api. Tested locally.