### PR TITLE
Move Session Config up

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -37,7 +37,7 @@ import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
 import io.opentelemetry.android.internal.services.periodicwork.PeriodicWork;
 import io.opentelemetry.android.internal.session.SessionIdTimeoutHandler;
 import io.opentelemetry.android.internal.session.SessionManagerImpl;
-import io.opentelemetry.android.session.SessionConfig;
+import io.opentelemetry.android.config.SessionConfig;
 import io.opentelemetry.android.session.SessionManager;
 import io.opentelemetry.android.session.SessionProvider;
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;

--- a/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
+++ b/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
@@ -8,7 +8,6 @@ package io.opentelemetry.android.config;
 import io.opentelemetry.android.ScreenAttributesSpanProcessor;
 import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig;
 import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider;
-import io.opentelemetry.android.session.SessionConfig;
 import io.opentelemetry.api.common.Attributes;
 import java.util.ArrayList;
 import java.util.List;

--- a/core/src/main/java/io/opentelemetry/android/config/SessionConfig.kt
+++ b/core/src/main/java/io/opentelemetry/android/config/SessionConfig.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.android.session
+package io.opentelemetry.android.config
 
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours

--- a/core/src/main/java/io/opentelemetry/android/internal/session/SessionIdTimeoutHandler.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/session/SessionIdTimeoutHandler.kt
@@ -6,7 +6,7 @@
 package io.opentelemetry.android.internal.session
 
 import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateListener
-import io.opentelemetry.android.session.SessionConfig
+import io.opentelemetry.android.config.SessionConfig
 import io.opentelemetry.sdk.common.Clock
 import kotlin.time.Duration
 

--- a/core/src/main/java/io/opentelemetry/android/internal/session/SessionManagerImpl.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/session/SessionManagerImpl.kt
@@ -6,7 +6,7 @@
 package io.opentelemetry.android.internal.session
 
 import io.opentelemetry.android.session.Session
-import io.opentelemetry.android.session.SessionConfig
+import io.opentelemetry.android.config.SessionConfig
 import io.opentelemetry.android.session.SessionIdGenerator
 import io.opentelemetry.android.session.SessionManager
 import io.opentelemetry.android.session.SessionObserver

--- a/core/src/test/java/io/opentelemetry/android/internal/session/SessionIdTimeoutHandlerTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/session/SessionIdTimeoutHandlerTest.kt
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.android.internal.session
 
-import io.opentelemetry.android.session.SessionConfig
+import io.opentelemetry.android.config.SessionConfig
 import io.opentelemetry.sdk.testing.time.TestClock
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue


### PR DESCRIPTION
* When we are using opentelemetry-android in a app and want to configure the SessionConfig, it gives error. 
`Unresolved reference: SessionConfig`. 
* It looks like SessionConfig is declared inside `session/src/main/kotlin/io/opentelemetry/android/session/SessionConfig.kt`
* When `opentelemetry-android` is built, it doesn't expose the `sessionConfig` out for the child projects to use.
