### PR TITLE
Remove runtime dep on androidx fragment navigiation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,11 +13,13 @@ kotlin = "2.1.20"
 androidPlugin = "8.9.1"
 junitKtx = "1.2.1"
 autoService = "1.1.1"
+androidx-navigation = "2.7.7"
 
 [libraries]
 opentelemetry-platform-alpha = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetry-instrumentation-alpha" }
 opentelemetry-platform = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom" }
-androidx-navigation-fragment = "androidx.navigation:navigation-fragment:2.7.7"
+androidx-navigation-fragment = { group = "androidx.navigation", name = "navigation-fragment", version.ref = "androidx-navigation"}
+androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navigation-runtime-ktx", version.ref = "androidx-navigation" }
 androidx-core = "androidx.core:core:1.16.0"
 androidx-annotation = "androidx.annotation:annotation:1.9.1"
 androidx-lifecycle-process = "androidx.lifecycle:lifecycle-process:2.8.7"

--- a/services/build.gradle.kts
+++ b/services/build.gradle.kts
@@ -17,10 +17,11 @@ dependencies {
     implementation(project(":common"))
 
     implementation(libs.androidx.core)
-    implementation(libs.androidx.navigation.fragment)
+    implementation(libs.androidx.navigation.runtime.ktx)
     implementation(libs.androidx.lifecycle.process)
     implementation(libs.androidx.preference.ktx)
 
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.robolectric)
+    testImplementation(libs.androidx.navigation.fragment)
 }

--- a/services/src/main/java/io/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTracker.kt
+++ b/services/src/main/java/io/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTracker.kt
@@ -10,7 +10,7 @@ import android.app.Application
 import android.os.Build
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
-import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.NavHost
 import io.opentelemetry.android.internal.services.visiblescreen.activities.Pre29VisibleScreenLifecycleBinding
 import io.opentelemetry.android.internal.services.visiblescreen.activities.VisibleScreenLifecycleBinding
 import io.opentelemetry.android.internal.services.visiblescreen.fragments.RumFragmentActivityRegisterer
@@ -92,8 +92,8 @@ class VisibleScreenTracker internal constructor(
     }
 
     fun fragmentResumed(fragment: Fragment) {
-        // skip the NavHostFragment since it's never really "visible" by itself.
-        if (fragment is NavHostFragment) {
+        // skip the Fragment if it's a NavHost since it's never really "visible" by itself.
+        if (fragment is NavHost) {
             return
         }
 
@@ -104,8 +104,8 @@ class VisibleScreenTracker internal constructor(
     }
 
     fun fragmentPaused(fragment: Fragment) {
-        // skip the NavHostFragment since it's never really "visible" by itself.
-        if (fragment is NavHostFragment) {
+        // skip the Fragment if it's a NavHost since it's never really "visible" by itself.
+        if (fragment is NavHost) {
             return
         }
         if (fragment is DialogFragment) {


### PR DESCRIPTION
Remove runtime dependency by looking at whether the fragment is a `NavHost`, which is not part of the `navigation-fragment` package. We are still depending on AndroidX's Navigation API because that's what the logic checks. Further decoupling will require the implementation to not know about the concept of `NavHost`, which will be trickier to do and out of scope for what I'm trying to achieve, i.e. remove the dep to the fragments navigation package only.