### PR TITLE
Documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Some of the additional features provided include:
 * [Network change detection](./instrumentation/network/)
 * Android [Activity lifecycle instrumentation](./instrumentation/activity/)
 * Android [Fragment lifecycle monitoring](./instrumentation/fragment)
+* [View click instrumentation](./instrumentation/view-click/)
 * Access to the OpenTelemetry APIs for manual instrumentation
 * Helpers to redact any span from export, or change span attributes before export
 * [Slow / frozen render detection](./instrumentation/slowrendering)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/open-telemetry/opentelemetry-android/badge)](https://scorecard.dev/viewer/?uri=github.com/open-telemetry/opentelemetry-android)
 [![android api](https://img.shields.io/badge/Android_API-21-green.svg "Android min API 21")](VERSIONING.md)
 
-## Status: Experimental
+## Status: development
 
 * [About](#about)
 * [Getting Started](#getting-started)

--- a/instrumentation/activity/README.md
+++ b/instrumentation/activity/README.md
@@ -1,7 +1,7 @@
 
 # Activity Instrumentation
 
-Status: experimental
+Status: development
 
 The activity instrumentation helps to track the state of your application's
 Activity and the lifecycle. This instrumentation also currently measures

--- a/instrumentation/android-log/README.md
+++ b/instrumentation/android-log/README.md
@@ -1,7 +1,7 @@
 
 # Android Log Instrumentation
 
-Status: experimental
+Status: development
 
 The Android Log instrumentation transforms calls to `android.uti.Log.x` to emit
 OTEL log record.

--- a/instrumentation/anr/README.md
+++ b/instrumentation/anr/README.md
@@ -1,7 +1,7 @@
 
 # ANR (Application Not Responding) Instrumentation
 
-Status: experimental
+Status: development
 
 The ANR (Application Not Responding) instrumentation helps to detect
 when an application becomes unresponsive. This instrumentation functions

--- a/instrumentation/crash/README.md
+++ b/instrumentation/crash/README.md
@@ -1,7 +1,7 @@
 
 # Crash Instrumentation
 
-Status: experimental
+Status: development
 
 The crash instrumentation detects uncaught exceptions in the user
 application and reports these occurrences as telemetry.

--- a/instrumentation/fragment/README.md
+++ b/instrumentation/fragment/README.md
@@ -1,6 +1,6 @@
 # Fragment Instrumentation
 
-Status: experimental
+Status: development
 
 The fragment instrumentation helps to track the state of your application's Fragment lifecycle.
 

--- a/instrumentation/network/README.md
+++ b/instrumentation/network/README.md
@@ -1,7 +1,7 @@
 
 # Network Change Instrumentation
 
-Status: experimental
+Status: development
 
 Android applications are typically deployed on mobile devices. These mobile devices
 have the ability to move between networks, and sometimes a network change can

--- a/instrumentation/okhttp3/README.md
+++ b/instrumentation/okhttp3/README.md
@@ -1,6 +1,6 @@
 # Android Instrumentation for OkHttp version 3.0 and higher
 
-## Status: Experimental
+## Status: development
 
 Provides OpenTelemetry instrumentation for [okhttp3](https://square.github.io/okhttp/).
 

--- a/instrumentation/slowrendering/README.md
+++ b/instrumentation/slowrendering/README.md
@@ -1,7 +1,7 @@
 
 # Slow Rendering Instrumentation
 
-Status: experimental
+Status: development
 
 The OpenTelemetry slow rendering instrumentation for Android will detect when
 the application user interface is slow or frozen.

--- a/instrumentation/view-click/README.md
+++ b/instrumentation/view-click/README.md
@@ -1,0 +1,33 @@
+
+# View Click Instrumentation
+
+Status: development
+
+This instrumentation has the ability to generate events when the user
+performs click actions. A click is not differentiated from touch or other
+input pointer events.
+
+When an Activity becomes active, the instrumentation begins tracking
+its window by registering a callback that receives events. 
+
+This instrumentation is not currently enabled by default.
+
+## Telemetry
+
+Data produced by this instrumentation will have an instrumentation scope
+name of `io.opentelemetry.android.instrumentation.view.click`. 
+This instrumentation produces the following telemetry:
+
+### Network Change
+
+* Type: Event
+* Name: `app.screen.click`
+* Description: This event is emitted when the user taps or clicks on the screen.
+* See the [semantic convention definition](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/app/app.md#event-appscreenclick)
+  for more details.
+
+* Type: Event
+* Name: `event.app.widget.click`
+* Description: This event is emitted when the user taps on a view. Jetpack compose views are not currently supported.
+* See the [semantic convention definition](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/app/app.md#event-appwidgetclick)
+  for more details.

--- a/instrumentation/view-click/README.md
+++ b/instrumentation/view-click/README.md
@@ -8,14 +8,14 @@ performs click actions. A click is not differentiated from touch or other
 input pointer events.
 
 When an Activity becomes active, the instrumentation begins tracking
-its window by registering a callback that receives events. 
+its window by registering a callback that receives events.
 
 This instrumentation is not currently enabled by default.
 
 ## Telemetry
 
 Data produced by this instrumentation will have an instrumentation scope
-name of `io.opentelemetry.android.instrumentation.view.click`. 
+name of `io.opentelemetry.android.instrumentation.view.click`.
 This instrumentation produces the following telemetry:
 
 ### Network Change

--- a/instrumentation/volley/README.md
+++ b/instrumentation/volley/README.md
@@ -1,7 +1,7 @@
 
 # OpenTelemetry Android Volley Instrumentation
 
-> :construction: &nbsp;Status: Experimental
+> :construction: &nbsp;Status: development
 
 This directory contains OpenTelemetry instrumentation for the [Volley](https://google.github.io/volley/)
 HTTP client library. If you use the Volley HTTP client in your Android application, you can


### PR DESCRIPTION
This changes the "experimental" word over to "development", to better align with the spec/semconv repos.

It adds a `README.md` for the new view-click instrumentation as well. 