### PR TITLE
feat: add session-based sampling ratio support

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -545,6 +545,13 @@ public final class OpenTelemetryRumBuilder {
                 customizer : tracerProviderCustomizers) {
             tracerProviderBuilder = customizer.apply(tracerProviderBuilder, application);
         }
+
+        if (config.getSessionConfig().getRatio() != null) {
+            tracerProviderBuilder.setSampler(
+                    new SessionIdRatioBasedSampler(
+                            config.getSessionConfig().getRatio(), sessionProvider));
+        }
+
         return tracerProviderBuilder.build();
     }
 

--- a/core/src/main/java/io/opentelemetry/android/config/SessionConfig.kt
+++ b/core/src/main/java/io/opentelemetry/android/config/SessionConfig.kt
@@ -12,9 +12,20 @@ import kotlin.time.Duration.Companion.minutes
 data class SessionConfig(
     val backgroundInactivityTimeout: Duration = 15.minutes,
     val maxLifetime: Duration = 4.hours,
+    val ratio: Double? = null,
 ) {
+    constructor(
+        backgroundInactivityTimeout: Int = 15,
+        maxLifetime: Int = 4,
+        ratio: Double? = null,
+    ) : this(
+        backgroundInactivityTimeout = backgroundInactivityTimeout.minutes,
+        maxLifetime = maxLifetime.hours,
+        ratio = ratio,
+    )
+
     companion object {
         @JvmStatic
-        fun withDefaults(): SessionConfig = SessionConfig()
+        fun withDefaults(): SessionConfig = SessionConfig(15.minutes, 4.hours)
     }
 }


### PR DESCRIPTION
* Integrated SessionIdRatioBasedSampler in OpenTelemetryRumBuilder.
* Enhanced SessionConfig to support sampling ratio configuration.

Issue #841