### PR TITLE
Enable disk buffering by default in the demo app

### DIFF
--- a/demo-app/src/main/java/io/opentelemetry/android/demo/OtelDemoApplication.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/OtelDemoApplication.kt
@@ -38,7 +38,11 @@ class OtelDemoApplication : Application() {
 
         // 10.0.2.2 is apparently a special binding to the host running the emulator
         try {
-            rum = OpenTelemetryRumInitializer.initialize(this, "http://10.0.2.2:4318")
+            rum = OpenTelemetryRumInitializer.initialize(
+                application = this,
+                endpointBaseUrl = "http://10.0.2.2:4318",
+                rumConfig = config
+            )
             Log.d(TAG, "RUM session started: " + rum!!.rumSessionId)
         } catch (e: Exception) {
             Log.e(TAG, "Oh no!", e)


### PR DESCRIPTION
Re-enable disk buffering in the demo application by the the config object that was already created.