### PR TITLE
Update repos for sonatype central

### DIFF
--- a/.github/repository-settings.md
+++ b/.github/repository-settings.md
@@ -43,3 +43,6 @@ Same settings as above for `main`, except:
 * `GPG_PRIVATE_KEY` - stored in OpenTelemetry-Java 1Password
 * `SONATYPE_KEY` - owned by [@breedx-splk](https://github.com/breedx-splk)
 * `SONATYPE_USER` - owned by [@breedx-splk](https://github.com/breedx-splk)
+
+Note: `SONATYPE_KEY` and `SONATYPE_USER` were regenerated and replaced
+on June 6th, 2025 for the [Sonatype OSSRH migration](https://central.sonatype.org/news/20250326_ossrh_sunset/).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,9 +34,14 @@ subprojects {
     apply(plugin = "otel.spotless-conventions")
 }
 
-nexusPublishing.repositories {
-    sonatype {
-        username.set(System.getenv("SONATYPE_USER"))
-        password.set(System.getenv("SONATYPE_KEY"))
+nexusPublishing {
+    repositories {
+        // see https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+            username.set(System.getenv("SONATYPE_USER"))
+            password.set(System.getenv("SONATYPE_KEY"))
+        }
     }
 }


### PR DESCRIPTION
See this announcement: https://central.sonatype.org/news/20250326_ossrh_sunset/

and see this for the docs on this change https://github.com/gradle-nexus/publish-plugin?tab=readme-ov-file#publishing-to-maven-central-via-sonatype-central

A new user token has been generated and put into the GitHub secrets for this repo.