### PR TITLE
Exposing instrumentation api as agent api

### DIFF
--- a/android-agent/build.gradle.kts
+++ b/android-agent/build.gradle.kts
@@ -9,10 +9,10 @@ android {
 
 dependencies {
     api(project(":core"))
+    api(libs.opentelemetry.instrumentation.api)
     implementation(project(":common"))
     implementation(project(":session"))
     implementation(project(":services"))
-    implementation(libs.opentelemetry.instrumentation.api)
     implementation(libs.opentelemetry.exporter.otlp)
 
     // Default instrumentations:


### PR DESCRIPTION
This should address the issue mentioned [here](https://github.com/open-telemetry/opentelemetry-android/issues/998#issue-3124911408) about the `AttributesExtractor` type not being available at compile-time.