### PR TITLE
Use semantic conventions in click instrumentation

### DIFF
--- a/instrumentation/view-click/build.gradle.kts
+++ b/instrumentation/view-click/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
     api(project(":instrumentation:android-instrumentation"))
 
     implementation(libs.opentelemetry.instrumentation.apiSemconv)
+    implementation(libs.opentelemetry.semconv.incubating)
     implementation(libs.opentelemetry.api.incubator)
 
     testImplementation(project(":test-common"))

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
@@ -11,13 +11,13 @@ import android.view.ViewGroup
 import android.view.Window
 import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_CLICK_EVENT_NAME
 import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_CLICK_EVENT_NAME
-import io.opentelemetry.android.instrumentation.view.click.internal.viewIdAttr
-import io.opentelemetry.android.instrumentation.view.click.internal.viewNameAttr
-import io.opentelemetry.android.instrumentation.view.click.internal.xCoordinateAttr
-import io.opentelemetry.android.instrumentation.view.click.internal.yCoordinateAttr
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder
 import io.opentelemetry.api.incubator.logs.ExtendedLogger
+import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_X
+import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_Y
+import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_ID
+import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_NAME
 import java.lang.ref.WeakReference
 import java.util.LinkedList
 
@@ -38,8 +38,8 @@ class ViewClickEventGenerator(
         windowRef?.get()?.let { window ->
             if (motionEvent != null && motionEvent.actionMasked == MotionEvent.ACTION_UP) {
                 createEvent(APP_SCREEN_CLICK_EVENT_NAME)
-                    .setAttribute(yCoordinateAttr, motionEvent.y.toLong())
-                    .setAttribute(xCoordinateAttr, motionEvent.x.toLong())
+                    .setAttribute(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong())
+                    .setAttribute(APP_SCREEN_COORDINATE_X, motionEvent.x.toLong())
                     .emit()
 
                 findTargetForTap(window.decorView, motionEvent.x, motionEvent.y)?.let { view ->
@@ -67,11 +67,11 @@ class ViewClickEventGenerator(
 
     private fun createViewAttributes(view: View): Attributes {
         val builder = Attributes.builder()
-        builder.put(viewNameAttr, viewToName(view))
-        builder.put(viewIdAttr, view.id.toLong())
+        builder.put(APP_WIDGET_NAME, viewToName(view))
+        builder.put(APP_WIDGET_ID, view.id.toString())
 
-        builder.put(xCoordinateAttr, view.x.toLong())
-        builder.put(yCoordinateAttr, view.y.toLong())
+        builder.put(APP_SCREEN_COORDINATE_X, view.x.toLong())
+        builder.put(APP_SCREEN_COORDINATE_Y, view.y.toLong())
         return builder.build()
     }
 

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/internal/ViewUtils.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/internal/ViewUtils.kt
@@ -5,14 +5,5 @@
 
 package io.opentelemetry.android.instrumentation.view.click.internal
 
-import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.api.common.AttributeKey.longKey
-import io.opentelemetry.api.common.AttributeKey.stringKey
-
 const val APP_SCREEN_CLICK_EVENT_NAME = "app.screen.click"
 const val VIEW_CLICK_EVENT_NAME = "event.app.widget.click"
-val viewNameAttr: AttributeKey<String> = stringKey("app.widget.name")
-
-val xCoordinateAttr: AttributeKey<Long> = longKey("app.screen.coordinate.x")
-val yCoordinateAttr: AttributeKey<Long> = longKey("app.screen.coordinate.y")
-val viewIdAttr: AttributeKey<Long> = longKey("app.widget.id")

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
@@ -118,7 +118,7 @@ class ViewClickInstrumentationTest {
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(APP_SCREEN_COORDINATE_X, mockView.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_X, mockView.y.toLong()),
+                equalTo(APP_SCREEN_COORDINATE_Y, mockView.y.toLong()),
                 equalTo(APP_WIDGET_ID, mockView.id.toString()),
                 equalTo(APP_WIDGET_NAME, "10012"),
             )

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
@@ -24,15 +24,15 @@ import io.mockk.verify
 import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_CLICK_EVENT_NAME
 import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_CLICK_EVENT_NAME
-import io.opentelemetry.android.instrumentation.view.click.internal.viewIdAttr
-import io.opentelemetry.android.instrumentation.view.click.internal.viewNameAttr
-import io.opentelemetry.android.instrumentation.view.click.internal.xCoordinateAttr
-import io.opentelemetry.android.instrumentation.view.click.internal.yCoordinateAttr
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.sdk.logs.data.internal.ExtendedLogRecordData
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
+import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_X
+import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_Y
+import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_ID
+import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_NAME
 import org.junit.Before
 import org.junit.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -109,18 +109,18 @@ class ViewClickInstrumentationTest {
         assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(xCoordinateAttr, motionEvent.x.toLong()),
-                equalTo(yCoordinateAttr, motionEvent.y.toLong()),
+                equalTo(APP_SCREEN_COORDINATE_X, motionEvent.x.toLong()),
+                equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
             )
 
         event = events[1] as ExtendedLogRecordData
         assertThat(event)
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(xCoordinateAttr, mockView.x.toLong()),
-                equalTo(yCoordinateAttr, mockView.y.toLong()),
-                equalTo(viewIdAttr, mockView.id),
-                equalTo(viewNameAttr, "10012"),
+                equalTo(APP_SCREEN_COORDINATE_X, mockView.x.toLong()),
+                equalTo(APP_SCREEN_COORDINATE_X, mockView.y.toLong()),
+                equalTo(APP_WIDGET_ID, mockView.id.toString()),
+                equalTo(APP_WIDGET_NAME, "10012"),
             )
     }
 
@@ -176,18 +176,18 @@ class ViewClickInstrumentationTest {
         assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(xCoordinateAttr, motionEvent.x.toLong()),
-                equalTo(yCoordinateAttr, motionEvent.y.toLong()),
+                equalTo(APP_SCREEN_COORDINATE_X, motionEvent.x.toLong()),
+                equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
             )
 
         event = events[1] as ExtendedLogRecordData
         assertThat(event)
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(xCoordinateAttr, mockView.x.toLong()),
-                equalTo(yCoordinateAttr, mockView.y.toLong()),
-                equalTo(viewIdAttr, mockView.id),
-                equalTo(viewNameAttr, "10012"),
+                equalTo(APP_SCREEN_COORDINATE_X, mockView.x.toLong()),
+                equalTo(APP_SCREEN_COORDINATE_Y, mockView.y.toLong()),
+                equalTo(APP_WIDGET_ID, mockView.id.toString()),
+                equalTo(APP_WIDGET_NAME, "10012"),
             )
     }
 
@@ -243,8 +243,8 @@ class ViewClickInstrumentationTest {
         assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(xCoordinateAttr, motionEvent.x.toLong()),
-                equalTo(yCoordinateAttr, motionEvent.y.toLong()),
+                equalTo(APP_SCREEN_COORDINATE_X, motionEvent.x.toLong()),
+                equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
             )
     }
 


### PR DESCRIPTION
We don't want to duplicate these constants now that they are available in the incubating semconv.