### PR TITLE
Update badge locations and don't fail link check for them

### DIFF
--- a/.github/scripts/markdown-link-check-config.json
+++ b/.github/scripts/markdown-link-check-config.json
@@ -7,6 +7,9 @@
   "ignorePatterns": [
     {
       "pattern": "^http://localhost:16686$"
+    },
+    {
+      "pattern": "^https://maven-badges.sml.io/maven-central/io.opentelemetry.android/.*$"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -85,6 +85,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 [ci-url]: https://github.com/open-telemetry/opentelemetry-android/actions?query=workflow%3Abuild+branch%3Amain
 
-[maven-image]: https://maven-badges.herokuapp.com/maven-central/io.opentelemetry.android/android-agent/badge.svg
+[maven-image]: https://maven-badges.sml.io/maven-central/io.opentelemetry.android/android-agent/badge.svg
 
-[maven-url]: https://maven-badges.herokuapp.com/maven-central/io.opentelemetry.android/android-agent
+[maven-url]: https://maven-badges.sml.io/maven-central/io.opentelemetry.android/android-agent


### PR DESCRIPTION
So we were failing the main branch build due to the markdown link checker failing on the badges:

<img width="791" alt="image" src="https://github.com/user-attachments/assets/e25602fa-797a-4533-b2c3-fe302d1489c5" />

Those URLs were always redirecting anyway, so let's replace them with the true/new URLs and prevent the link checker from failing on them (they're often a problem).