### PR TITLE
Temporarily ignore snapshots repo for link checking

### DIFF
--- a/.github/scripts/markdown-link-check-config.json
+++ b/.github/scripts/markdown-link-check-config.json
@@ -10,6 +10,9 @@
     },
     {
       "pattern": "^https://maven-badges.sml.io/maven-central/io.opentelemetry.android/.*$"
+    },
+    {
+      "pattern": "^https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/.*$"
     }
   ]
 }


### PR DESCRIPTION
We can remove this once things calm back down. Right now, builds fail due to this link check.