### PR TITLE
Alter FilteringSpanExporter to leverage common code from contrib

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -75,7 +75,7 @@ dependencies {
     implementation(libs.opentelemetry.instrumentation.api)
     implementation(libs.opentelemetry.semconv.incubating)
     implementation(libs.opentelemetry.diskBuffering)
-
+    implementation(libs.opentelemetry.processors)
     testImplementation(libs.opentelemetry.api.incubator)
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.awaitility)

--- a/core/src/main/java/io/opentelemetry/android/export/FilteringSpanExporter.java
+++ b/core/src/main/java/io/opentelemetry/android/export/FilteringSpanExporter.java
@@ -5,44 +5,12 @@
 
 package io.opentelemetry.android.export;
 
-import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
-import java.util.Collection;
-import java.util.List;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /** An exporter that will filter (not export) spans that fail a predicate. */
-public class FilteringSpanExporter implements SpanExporter {
-
-    private final SpanExporter delegate;
-
-    private final Predicate<SpanData> spanRejecter;
+public class FilteringSpanExporter {
 
     public static FilteringSpanExporterBuilder builder(SpanExporter delegate) {
         return new FilteringSpanExporterBuilder(delegate);
-    }
-
-    FilteringSpanExporter(SpanExporter delegate, Predicate<SpanData> spanRejecter) {
-        this.delegate = delegate;
-        this.spanRejecter = spanRejecter;
-    }
-
-    @Override
-    public CompletableResultCode export(Collection<SpanData> spans) {
-        List<SpanData> toExport =
-                spans.stream().filter(spanRejecter.negate()).collect(Collectors.toList());
-        return delegate.export(toExport);
-    }
-
-    @Override
-    public CompletableResultCode flush() {
-        return delegate.flush();
-    }
-
-    @Override
-    public CompletableResultCode shutdown() {
-        return delegate.shutdown();
     }
 }

--- a/core/src/main/java/io/opentelemetry/android/export/FilteringSpanExporterBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/export/FilteringSpanExporterBuilder.java
@@ -5,8 +5,11 @@
 
 package io.opentelemetry.android.export;
 
+import androidx.annotation.Nullable;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.contrib.interceptor.InterceptableSpanExporter;
+import io.opentelemetry.contrib.interceptor.api.Interceptor;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.util.Map;
@@ -16,6 +19,18 @@ public final class FilteringSpanExporterBuilder {
 
     private final SpanExporter delegate;
     private Predicate<SpanData> predicate = x -> false;
+    private final Interceptor<SpanData> interceptor = new Interceptor<SpanData>() {
+
+        @Nullable
+        @Override
+        public SpanData intercept(SpanData item) {
+            if (predicate.test(item)) {
+                return null;
+            } else {
+                return item;
+            }
+        }
+    };
 
     FilteringSpanExporterBuilder(SpanExporter spanExporter) {
         this.delegate = spanExporter;
@@ -90,6 +105,6 @@ public final class FilteringSpanExporterBuilder {
     }
 
     public SpanExporter build() {
-        return new FilteringSpanExporter(delegate, this.predicate);
+        return new InterceptableSpanExporter(delegate, interceptor);
     }
 }

--- a/core/src/main/java/io/opentelemetry/android/export/FilteringSpanExporterBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/export/FilteringSpanExporterBuilder.java
@@ -27,9 +27,8 @@ public final class FilteringSpanExporterBuilder {
                 public SpanData intercept(SpanData item) {
                     if (predicate.test(item)) {
                         return null;
-                    } else {
-                        return item;
-                    }
+                    } 
+                    return item;                   
                 }
             };
 

--- a/core/src/main/java/io/opentelemetry/android/export/FilteringSpanExporterBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/export/FilteringSpanExporterBuilder.java
@@ -27,8 +27,8 @@ public final class FilteringSpanExporterBuilder {
                 public SpanData intercept(SpanData item) {
                     if (predicate.test(item)) {
                         return null;
-                    } 
-                    return item;                   
+                    }
+                    return item;
                 }
             };
 

--- a/core/src/main/java/io/opentelemetry/android/export/FilteringSpanExporterBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/export/FilteringSpanExporterBuilder.java
@@ -19,18 +19,19 @@ public final class FilteringSpanExporterBuilder {
 
     private final SpanExporter delegate;
     private Predicate<SpanData> predicate = x -> false;
-    private final Interceptor<SpanData> interceptor = new Interceptor<SpanData>() {
+    private final Interceptor<SpanData> interceptor =
+            new Interceptor<SpanData>() {
 
-        @Nullable
-        @Override
-        public SpanData intercept(SpanData item) {
-            if (predicate.test(item)) {
-                return null;
-            } else {
-                return item;
-            }
-        }
-    };
+                @Nullable
+                @Override
+                public SpanData intercept(SpanData item) {
+                    if (predicate.test(item)) {
+                        return null;
+                    } else {
+                        return item;
+                    }
+                }
+            };
 
     FilteringSpanExporterBuilder(SpanExporter spanExporter) {
         this.delegate = spanExporter;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,7 +19,7 @@ compose = "1.5.4"
 [libraries]
 opentelemetry-platform-alpha = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetry-instrumentation-alpha" }
 opentelemetry-platform = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom" }
-androidx-navigation-fragment = { group = "androidx.navigation", name = "navigation-fragment", version.ref = "androidx-navigation"}
+androidx-navigation-fragment = { group = "androidx.navigation", name = "navigation-fragment", version.ref = "androidx-navigation" }
 androidx-navigation-runtime-ktx = { group = "androidx.navigation", name = "navigation-runtime-ktx", version.ref = "androidx-navigation" }
 androidx-core = "androidx.core:core:1.16.0"
 androidx-annotation = "androidx.annotation:annotation:1.9.1"
@@ -40,6 +40,7 @@ opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk" }
 opentelemetry-context = { module = "io.opentelemetry:opentelemetry-context" }
 opentelemetry-exporter-logging = { module = "io.opentelemetry:opentelemetry-exporter-logging" }
 opentelemetry-diskBuffering = { module = "io.opentelemetry.contrib:opentelemetry-disk-buffering", version.ref = "opentelemetry-contrib" }
+opentelemetry-processors = { module = "io.opentelemetry.contrib:opentelemetry-processors", version.ref = "opentelemetry-contrib" }
 opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp" }
 volley = "com.android.volley:volley:1.2.1"
 auto-service-annotations = { module = "com.google.auto.service:auto-service-annotations", version.ref = "autoService" }


### PR DESCRIPTION
Resolves https://github.com/open-telemetry/opentelemetry-android/issues/76

- Integrates processors from the Java Contrib module
- Refactors FilteringSpanExporterBuilder to utilize InterceptableSpanExporter provided by the contrib library