### PR TITLE
These modules fail to publish, due to missing platform dependency.

### DIFF
--- a/android-agent/build.gradle.kts
+++ b/android-agent/build.gradle.kts
@@ -9,6 +9,7 @@ android {
 
 dependencies {
     api(project(":core"))
+    api(platform(libs.opentelemetry.platform.alpha))
     api(libs.opentelemetry.instrumentation.api)
     implementation(project(":common"))
     implementation(project(":session"))

--- a/instrumentation/okhttp3-websocket/library/build.gradle.kts
+++ b/instrumentation/okhttp3-websocket/library/build.gradle.kts
@@ -14,6 +14,7 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha))
     api(project(":instrumentation:android-instrumentation"))
     compileOnly(libs.okhttp)
     api(libs.opentelemetry.instrumentation.okhttp)

--- a/instrumentation/sessions/build.gradle.kts
+++ b/instrumentation/sessions/build.gradle.kts
@@ -14,6 +14,7 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha))
     api(project(":instrumentation:android-instrumentation"))
     implementation(libs.opentelemetry.api.incubator)
     implementation(libs.opentelemetry.sdk)


### PR DESCRIPTION
Sonatype failed the 0.12.0 release, due to validation of 3 modules:

<img width="939" alt="image" src="https://github.com/user-attachments/assets/9b166711-7ab8-470d-93c3-e8b089fb4f4c" />

If this works, I'll cherry pick this back into main for the next release.