### PR TITLE
Cherry pick from release #1054

### DIFF
--- a/android-agent/build.gradle.kts
+++ b/android-agent/build.gradle.kts
@@ -9,6 +9,7 @@ android {
 
 dependencies {
     api(project(":core"))
+    api(platform(libs.opentelemetry.platform.alpha))
     api(libs.opentelemetry.instrumentation.api)
     implementation(project(":common"))
     implementation(project(":session"))

--- a/instrumentation/okhttp3-websocket/library/build.gradle.kts
+++ b/instrumentation/okhttp3-websocket/library/build.gradle.kts
@@ -14,6 +14,7 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha))
     api(project(":instrumentation:android-instrumentation"))
     compileOnly(libs.okhttp)
     api(libs.opentelemetry.instrumentation.okhttp)

--- a/instrumentation/sessions/build.gradle.kts
+++ b/instrumentation/sessions/build.gradle.kts
@@ -14,6 +14,7 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha))
     api(project(":instrumentation:android-instrumentation"))
     implementation(libs.opentelemetry.api.incubator)
     implementation(libs.opentelemetry.sdk)


### PR DESCRIPTION
See the description and screenshot in #1054.

These modules fail to publish, due to missing platform dependency. This adds the platform dep and should fix this going forward. I think we should have a better way of doing this validation, before encountering it at release time... 🤔 