### PR TITLE
Release - Limit only to lines starting with a digit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           # otel instrumentation version comes in through alpha bom
           inst_version=$(./gradlew --console=plain android-agent:dependencies | \
                         grep 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-api ' | \
-                        sed -e "s/.* -> //" | sed -e "s/ .*//" | \
+                        sed -e "s/.* -> //" | sed -e "s/ .*//" | grep '^\d' | \
                         sort | head -1)
           # otel-java core libs are transient deps thru instrumentation boms
           sdk_version=$(./gradlew --console=plain android-agent:dependencies | \


### PR DESCRIPTION
One again, the release was unable to successfully detect the version of the instrumentation, and instead it threw garbage into the release page which I had to fix by hand. This was due to some extra lines getting hit, so let's just filter to lines starting with digits. Seems to #worksonmybox.