### PR TITLE
Only run the assembleRelease target to verify the demo app compiles

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -22,7 +22,7 @@ jobs:
         run: ./gradlew check
       - name: build demo app
         working-directory: ./demo-app
-        run: ./gradlew check assemble
+        run: ./gradlew assembleRelease
 
   required-status-check:
     needs:


### PR DESCRIPTION
Reduce the scope of verification of the demo-app by only assembling the release version and bypass debug, lint, and other checks. Doing debug will be even faster but having it go through release and the APK optimizations (including desugaring) is a more comprehensive verification.