### PR TITLE
Improve build speed by altering gradle.properties

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           java-version: 17
 
       - name: Build and publish artifacts
-        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -Pfinal=true
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -Pfinal=true --no-build-cache --no-configuration-cache --no-parallel
         env:
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,12 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096M -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4096M"
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.problems=fail
+org.gradle.configuration-cache.parallel=true
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
## Goal

This PR attempts to improve the build speed and overall build performance of the project by adopting Gradle's [suggested practices](https://docs.gradle.org/current/userguide/performance.html). This is loosely based on the performance tweaks we've adopted at Embrace over the last couple of years. Changes include:

1. Increasing the maximum heap size of the build
2. Various tweaks to JVM options for Gradle and the Gradle daemon that allow it to obtain more memory, if required
3. Enables parallel execution, which allows unrelated Gradle tasks to run in parallel rather than sequentially
4. Enables build caching
5. Enables configuration caching, which can drastically reduce the time required for the configuration phase of the build
6. Enables parallel storing of the configuration cache

Not all gradle plugins/build scripts are compatible with Gradle's configuration cache as the ecosystem has been moving over. The build has been configured to fail if known problems are detected.

## Testing

I used the following command on my local machine:
`./gradlew assembleRelease check --no-configuration-cache --no-build-cache --rerun-tasks --scan`

A baseline took 6m39s, and with the changeset this took 5m19s. I would expect more performance gains than this in practice given that the benchmarking command disabled configuration/build cache & ran all tasks from scratch.

## Future work

The demo-app could have the same settings applied as it's a separate Gradle project. Or, we could consider combining it into one Gradle project so that it's not necessary to run two gradle builds sequentially.
