### PR TITLE
Use setup-gradle GitHub action

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -16,6 +16,8 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+      - name: Setup Gradle build action
+        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
       - name: touch local props
         run: touch demo-app/local.properties
       - name: run gradle


### PR DESCRIPTION
## Goal

The [setup-gradle Github Action](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md) offers better build performance on CI. It caches build state such as gradle JARs and output from build tasks between jobs which therefore avoids starting the build from scratch each time. I didn't spot any alternative solution that was doing this already.

If this approach is accepted I can raise a separate changeset to do this for the other CI workflows.

## Testing

Relying on the CI job. I don't have permissions to retry the job to test the cache, which may be worth doing to get an idea of the speed improvements.


