### PR TITLE
Replace old Roboletric runner with the recommend AndroidJUnit4 one

### DIFF
--- a/common/src/test/java/io/opentelemetry/android/common/internal/features/networkattributes/CurrentNetworkAttributesExtractorTest.java
+++ b/common/src/test/java/io/opentelemetry/android/common/internal/features/networkattributes/CurrentNetworkAttributesExtractorTest.java
@@ -14,16 +14,16 @@ import static io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes.NE
 import static org.assertj.core.api.Assertions.entry;
 
 import android.os.Build;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.opentelemetry.android.common.internal.features.networkattributes.data.Carrier;
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork;
 import io.opentelemetry.android.common.internal.features.networkattributes.data.NetworkState;
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-@RunWith(RobolectricTestRunner.class)
+@RunWith(AndroidJUnit4.class)
 public class CurrentNetworkAttributesExtractorTest {
 
     final CurrentNetworkAttributesExtractor underTest = new CurrentNetworkAttributesExtractor();

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickActivityCallbackTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickActivityCallbackTest.kt
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.compose.click
 
 import android.app.Activity
 import android.view.Window
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -14,9 +15,8 @@ import io.mockk.verify
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 internal class ComposeClickActivityCallbackTest {
     lateinit var composeClickActivityCallback: ComposeClickActivityCallback
 

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGeneratorTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGeneratorTest.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsModifier
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -41,9 +42,8 @@ import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_NA
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 internal class ComposeClickEventGeneratorTest {
     private lateinit var openTelemetryRule: OpenTelemetryRule
 

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsModifier
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -51,9 +52,8 @@ import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_NA
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 internal class ComposeInstrumentationTest {
     private lateinit var openTelemetryRule: OpenTelemetryRule
 

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeTapTargetDetectorTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeTapTargetDetectorTest.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.semantics.SemanticsConfiguration
 import androidx.compose.ui.semantics.SemanticsModifier
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -30,9 +31,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 internal class ComposeTapTargetDetectorTest {
     lateinit var composeTapTargetDetector: ComposeTapTargetDetector
 

--- a/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentationTest.kt
+++ b/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentationTest.kt
@@ -7,6 +7,7 @@ package io.opentelemetry.android.instrumentation.network
 
 import android.app.Application
 import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -33,11 +34,10 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @Config(sdk = [Build.VERSION_CODES.P])
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 @ExtendWith(MockKExtension::class)
 class NetworkChangeInstrumentationTest {
     private lateinit var otelTesting: OpenTelemetryRule

--- a/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderListenerTest.java
+++ b/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderListenerTest.java
@@ -24,6 +24,7 @@ import android.content.ComponentName;
 import android.os.Build;
 import android.os.Handler;
 import android.view.FrameMetrics;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
@@ -44,10 +45,9 @@ import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-@RunWith(RobolectricTestRunner.class)
+@RunWith(AndroidJUnit4.class)
 @Config(sdk = Build.VERSION_CODES.N)
 public class SlowRenderListenerTest {
 

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
@@ -13,6 +13,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.Window
 import android.view.Window.Callback
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
@@ -37,9 +38,8 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 @ExtendWith(MockKExtension::class)
 class ViewClickInstrumentationTest {
     private lateinit var openTelemetryRule: OpenTelemetryRule

--- a/instrumentation/volley/library/src/test/java/io/opentelemetry/android/instrumentation/volley/TracingHurlStackExceptionTest.java
+++ b/instrumentation/volley/library/src/test/java/io/opentelemetry/android/instrumentation/volley/TracingHurlStackExceptionTest.java
@@ -9,6 +9,7 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.asser
 import static io.opentelemetry.semconv.ExceptionAttributes.*;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.android.volley.Request;
 import com.android.volley.toolbox.HurlStack;
 import com.android.volley.toolbox.RequestFuture;
@@ -22,9 +23,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
-@RunWith(RobolectricTestRunner.class)
+@RunWith(AndroidJUnit4.class)
 public class TracingHurlStackExceptionTest {
 
     @Rule public OpenTelemetryRule otelTesting = OpenTelemetryRule.create();

--- a/instrumentation/volley/library/src/test/java/io/opentelemetry/android/instrumentation/volley/TracingHurlStackTest.java
+++ b/instrumentation/volley/library/src/test/java/io/opentelemetry/android/instrumentation/volley/TracingHurlStackTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Fail.fail;
 
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.Request;
 import com.android.volley.Response;
@@ -44,9 +45,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
-@RunWith(RobolectricTestRunner.class)
+@RunWith(AndroidJUnit4.class)
 public class TracingHurlStackTest {
 
     @Rule public OpenTelemetryRule otelTesting = OpenTelemetryRule.create();

--- a/instrumentation/volley/library/src/test/java/io/opentelemetry/android/instrumentation/volley/VolleyHttpClientAttributesGetterTest.java
+++ b/instrumentation/volley/library/src/test/java/io/opentelemetry/android/instrumentation/volley/VolleyHttpClientAttributesGetterTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import com.android.volley.Header;
 import com.android.volley.Request;
 import com.android.volley.toolbox.HttpResponse;
@@ -19,9 +20,8 @@ import java.util.List;
 import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
-@RunWith(RobolectricTestRunner.class)
+@RunWith(AndroidJUnit4.class)
 public class VolleyHttpClientAttributesGetterTest {
 
     @Test

--- a/services/src/test/java/io/opentelemetry/android/internal/services/ServicesTest.kt
+++ b/services/src/test/java/io/opentelemetry/android/internal/services/ServicesTest.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.android.internal.services
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockk
@@ -17,9 +18,8 @@ import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTra
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class ServicesTest {
     @Test
     fun `Verify that services are created lazily`() {

--- a/services/src/test/java/io/opentelemetry/android/internal/services/network/CurrentNetworkProviderTest.kt
+++ b/services/src/test/java/io/opentelemetry/android/internal/services/network/CurrentNetworkProviderTest.kt
@@ -10,6 +10,7 @@ import android.net.ConnectivityManager.NetworkCallback
 import android.net.Network
 import android.net.NetworkRequest
 import android.os.Build
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -22,11 +23,10 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mockito
-import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import java.util.concurrent.atomic.AtomicInteger
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 @Config(
     maxSdk = Build.VERSION_CODES.S,
 )

--- a/services/src/test/java/io/opentelemetry/android/internal/services/network/detector/NetworkDetectorTest.java
+++ b/services/src/test/java/io/opentelemetry/android/internal/services/network/detector/NetworkDetectorTest.java
@@ -10,12 +10,12 @@ import static org.junit.Assert.assertTrue;
 import android.content.Context;
 import android.os.Build;
 import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-@RunWith(RobolectricTestRunner.class)
+@RunWith(AndroidJUnit4.class)
 public class NetworkDetectorTest {
 
     @Test

--- a/services/src/test/java/io/opentelemetry/android/internal/services/network/detector/PostApi28NetworkDetectorTest.java
+++ b/services/src/test/java/io/opentelemetry/android/internal/services/network/detector/PostApi28NetworkDetectorTest.java
@@ -17,6 +17,7 @@ import android.net.Network;
 import android.net.NetworkCapabilities;
 import android.os.Build;
 import android.telephony.TelephonyManager;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.opentelemetry.android.common.internal.features.networkattributes.data.Carrier;
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork;
 import io.opentelemetry.android.common.internal.features.networkattributes.data.NetworkState;
@@ -26,10 +27,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-@RunWith(RobolectricTestRunner.class)
+@RunWith(AndroidJUnit4.class)
 @Config(sdk = Build.VERSION_CODES.P)
 public class PostApi28NetworkDetectorTest {
 

--- a/services/src/test/java/io/opentelemetry/android/internal/services/network/detector/SimpleNetworkDetectorTest.java
+++ b/services/src/test/java/io/opentelemetry/android/internal/services/network/detector/SimpleNetworkDetectorTest.java
@@ -13,17 +13,17 @@ import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Build;
 import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork;
 import io.opentelemetry.android.common.internal.features.networkattributes.data.NetworkState;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowNetworkInfo;
 
-@RunWith(RobolectricTestRunner.class)
+@RunWith(AndroidJUnit4.class)
 @Config(sdk = Build.VERSION_CODES.P)
 public class SimpleNetworkDetectorTest {
     @Test

--- a/services/src/test/java/io/opentelemetry/android/internal/services/periodicwork/PeriodicRunnableTest.kt
+++ b/services/src/test/java/io/opentelemetry/android/internal/services/periodicwork/PeriodicRunnableTest.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.android.internal.services.periodicwork
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
@@ -15,9 +16,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class PeriodicRunnableTest {
     private lateinit var periodicWork: PeriodicWork
     private lateinit var testSystemTime: TestSystemTime

--- a/services/src/test/java/io/opentelemetry/android/internal/services/periodicwork/PeriodicWorkTest.kt
+++ b/services/src/test/java/io/opentelemetry/android/internal/services/periodicwork/PeriodicWorkTest.kt
@@ -5,16 +5,16 @@
 
 package io.opentelemetry.android.internal.services.periodicwork
 
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import org.robolectric.shadows.ShadowLooper
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-@RunWith(RobolectricTestRunner::class)
+@RunWith(AndroidJUnit4::class)
 class PeriodicWorkTest {
     companion object {
         private const val DELAY_BETWEEN_EXECUTIONS_IN_SECONDS = 10L


### PR DESCRIPTION
Replace the deprecated test runner with one that is recommended for running Robolectric tests