### PR TITLE
Fix v0.13.0 release

### DIFF
--- a/opentelemetry-android-bom/build.gradle.kts
+++ b/opentelemetry-android-bom/build.gradle.kts
@@ -9,8 +9,7 @@ javaPlatform.allowDependencies()
 
 dependencies {
     api(platform(libs.opentelemetry.platform.alpha))
-    api(platform(libs.opentelemetry.platform))
-    api(platform(libs.opentelemetry.core.bom))
+
     constraints {
         rootProject.subprojects.forEach { subproject ->
             if (subproject != project) {


### PR DESCRIPTION
So the versions of these two are determined by gradle transitively from the top `opentelemetry-instrumentation-bom-alpha`. Their inclusion here causes the sonatype release process to fail validation (because they don't have explicit versions)....so let's just remove them. They shouldn't be necessary anyway.

And much like last time, I'll cherry pick this into main after the release.