### PR TITLE
Allow empty global attributes from Supplier at startup

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
+++ b/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.java
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.android.config;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import io.opentelemetry.android.ScreenAttributesSpanProcessor;
 import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig;
 import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider;
@@ -19,7 +22,9 @@ import java.util.function.Supplier;
  * components.
  */
 public class OtelRumConfig {
-    private Supplier<Attributes> globalAttributesSupplier = Attributes::empty;
+
+    @Nullable
+    private Supplier<Attributes> globalAttributesSupplier = null;
     private boolean includeNetworkAttributes = true;
     private boolean generateSdkInitializationEvents = true;
     private boolean includeScreenAttributes = true;
@@ -31,7 +36,10 @@ public class OtelRumConfig {
      * Configures the set of global attributes to emit with every span and event. Any existing
      * configured attributes will be dropped. Default = none.
      */
-    public OtelRumConfig setGlobalAttributes(Attributes attributes) {
+    public OtelRumConfig setGlobalAttributes(@Nullable Attributes attributes) {
+        if(attributes == null || attributes.isEmpty()){
+            return this;
+        }
         return setGlobalAttributes(() -> attributes);
     }
 
@@ -41,12 +49,12 @@ public class OtelRumConfig {
     }
 
     public boolean hasGlobalAttributes() {
-        Attributes attributes = globalAttributesSupplier.get();
-        return attributes != null && !attributes.isEmpty();
+        return globalAttributesSupplier != null;
     }
 
+    @NonNull
     public Supplier<Attributes> getGlobalAttributesSupplier() {
-        return globalAttributesSupplier;
+        return globalAttributesSupplier == null ? Attributes::empty : globalAttributesSupplier;
     }
 
     /**

--- a/core/src/test/java/io/opentelemetry/android/config/OtelRumConfigTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/config/OtelRumConfigTest.kt
@@ -1,0 +1,74 @@
+package io.opentelemetry.android.config
+
+import io.opentelemetry.api.common.AttributeKey.stringKey
+import io.opentelemetry.api.common.Attributes
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.util.function.Supplier
+
+class OtelRumConfigTest {
+
+    @Test
+    fun `no global attributes by default`(){
+        val config = OtelRumConfig()
+        assertThat(config.hasGlobalAttributes()).isFalse()
+        assertThat(config.globalAttributesSupplier.get().isEmpty).isTrue()
+    }
+
+    @Test
+    fun `setting null Attributes does nothing`(){
+        val config = OtelRumConfig()
+        config.setGlobalAttributes(null as Attributes?)
+        assertThat(config.hasGlobalAttributes()).isFalse()
+        assertThat(config.globalAttributesSupplier.get().isEmpty).isTrue()
+    }
+
+    @Test
+    fun `setting empty Attributes does nothing`(){
+        val config = OtelRumConfig()
+        config.setGlobalAttributes(Attributes.empty())
+        assertThat(config.hasGlobalAttributes()).isFalse()
+        assertThat(config.globalAttributesSupplier.get().isEmpty).isTrue()
+    }
+
+    @Test
+    fun `can set some Attributes directly`(){
+        val config = OtelRumConfig()
+        config.setGlobalAttributes(Attributes.of(stringKey("foo"), "bar"))
+        assertThat(config.hasGlobalAttributes()).isTrue()
+        assertThat(config.globalAttributesSupplier.get().get(stringKey("foo"))).isEqualTo("bar")
+    }
+
+    @Test
+    fun `setting a null attribute supplier does nothing`(){
+        val config = OtelRumConfig()
+        config.setGlobalAttributes(null as Supplier<Attributes>?)
+        assertThat(config.hasGlobalAttributes()).isFalse()
+        assertThat(config.globalAttributesSupplier.get().isEmpty).isTrue()
+    }
+
+    @Test
+    fun `setting a Supplier that returns empty attributes is fine`(){
+        val config = OtelRumConfig()
+        config.setGlobalAttributes { Attributes.empty() }
+        assertThat(config.hasGlobalAttributes()).isTrue() // It might return some Attributes later
+        assertThat(config.globalAttributesSupplier.get().isEmpty).isTrue()
+    }
+
+    @Test
+    fun `setting a Supplier that returns null attributes is fine`(){
+        val config = OtelRumConfig()
+        config.setGlobalAttributes { null }
+        assertThat(config.hasGlobalAttributes()).isTrue() // It might return some Attributes later
+        assertThat(config.globalAttributesSupplier.get()).isNull()
+    }
+
+    @Test
+    fun `can supply global attributes with a supplier`(){
+        val config = OtelRumConfig()
+        config.setGlobalAttributes { Attributes.of(stringKey("foo"), "bar") }
+        assertThat(config.hasGlobalAttributes()).isTrue()
+        assertThat(config.globalAttributesSupplier.get().get(stringKey("foo"))).isEqualTo("bar")
+    }
+
+}

--- a/instrumentation/httpurlconnection/library/src/main/java/io/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlInstrumentation.java
+++ b/instrumentation/httpurlconnection/library/src/main/java/io/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlInstrumentation.java
@@ -137,7 +137,7 @@ public class HttpUrlInstrumentation implements AndroidInstrumentation {
     }
 
     @Override
-    public void install(@NotNull InstallationContext ctx) {
+    public void install(@NonNull InstallationContext ctx) {
         HttpUrlConnectionSingletons.configure(this, ctx.getOpenTelemetry());
     }
 

--- a/instrumentation/okhttp3/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/OkHttpInstrumentation.java
+++ b/instrumentation/okhttp3/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/OkHttpInstrumentation.java
@@ -139,7 +139,7 @@ public class OkHttpInstrumentation implements AndroidInstrumentation {
     }
 
     @Override
-    public void install(@NotNull InstallationContext ctx) {
+    public void install(@NonNull InstallationContext ctx) {
         OkHttp3Singletons.configure(this, ctx.getOpenTelemetry());
     }
 


### PR DESCRIPTION
Resolves #1094.

We need to allow the case where a user sets up a `Supplier<Attributes>` that returns empty during build time. This allows the `GlobalAttributesAppender` to be created with a `Supplier` that might later return attribute data. Without this, the wiring of the `GlobalAttributesAppender` is simply skipped.