### PR TITLE
Add event attribute extractor

### DIFF
--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
@@ -18,6 +18,7 @@ import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.instrumentation.AndroidInstrumentationLoader
 import io.opentelemetry.android.instrumentation.activity.ActivityLifecycleInstrumentation
 import io.opentelemetry.android.instrumentation.anr.AnrInstrumentation
+import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor
 import io.opentelemetry.android.instrumentation.common.ScreenNameExtractor
 import io.opentelemetry.android.instrumentation.crash.CrashDetails
 import io.opentelemetry.android.instrumentation.crash.CrashReporterInstrumentation
@@ -81,7 +82,7 @@ object OpenTelemetryRumInitializer {
         activityNameExtractor: ScreenNameExtractor? = null,
         fragmentTracerCustomizer: ((Tracer) -> Tracer)? = null,
         fragmentNameExtractor: ScreenNameExtractor? = null,
-        anrAttributesExtractors: List<AttributesExtractor<Array<StackTraceElement>, Void>> = emptyList(),
+        anrAttributesExtractors: List<EventAttributesExtractor<Array<StackTraceElement>>> = emptyList(),
         crashAttributesExtractors: List<AttributesExtractor<CrashDetails, Void>> = emptyList(),
         networkChangeAttributesExtractors: List<NetworkAttributesExtractor> = emptyList(),
         slowRenderingDetectionPollInterval: Duration? = null,
@@ -135,7 +136,7 @@ object OpenTelemetryRumInitializer {
         activityNameExtractor: ScreenNameExtractor?,
         fragmentTracerCustomizer: ((Tracer) -> Tracer)?,
         fragmentNameExtractor: ScreenNameExtractor?,
-        anrAttributesExtractors: List<AttributesExtractor<Array<StackTraceElement>, Void>>,
+        anrAttributesExtractors: List<EventAttributesExtractor<Array<StackTraceElement>>>,
         crashAttributesExtractors: List<AttributesExtractor<CrashDetails, Void>>,
         networkChangeAttributesExtractors: List<NetworkAttributesExtractor>,
         slowRenderingDetectionPollInterval: Duration?,

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
@@ -32,7 +32,6 @@ import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
-import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor
 import java.time.Duration
 
 object OpenTelemetryRumInitializer {
@@ -83,7 +82,7 @@ object OpenTelemetryRumInitializer {
         fragmentTracerCustomizer: ((Tracer) -> Tracer)? = null,
         fragmentNameExtractor: ScreenNameExtractor? = null,
         anrAttributesExtractors: List<EventAttributesExtractor<Array<StackTraceElement>>> = emptyList(),
-        crashAttributesExtractors: List<AttributesExtractor<CrashDetails, Void>> = emptyList(),
+        crashAttributesExtractors: List<EventAttributesExtractor<CrashDetails>> = emptyList(),
         networkChangeAttributesExtractors: List<NetworkAttributesExtractor> = emptyList(),
         slowRenderingDetectionPollInterval: Duration? = null,
     ): OpenTelemetryRum {
@@ -137,7 +136,7 @@ object OpenTelemetryRumInitializer {
         fragmentTracerCustomizer: ((Tracer) -> Tracer)?,
         fragmentNameExtractor: ScreenNameExtractor?,
         anrAttributesExtractors: List<EventAttributesExtractor<Array<StackTraceElement>>>,
-        crashAttributesExtractors: List<AttributesExtractor<CrashDetails, Void>>,
+        crashAttributesExtractors: List<EventAttributesExtractor<CrashDetails>>,
         networkChangeAttributesExtractors: List<NetworkAttributesExtractor>,
         slowRenderingDetectionPollInterval: Duration?,
     ) {

--- a/instrumentation/anr/build.gradle.kts
+++ b/instrumentation/anr/build.gradle.kts
@@ -20,6 +20,7 @@ android {
 dependencies {
     api(project(":instrumentation:android-instrumentation"))
     implementation(project(":services"))
+    implementation(project(":instrumentation:common-api"))
     api(platform(libs.opentelemetry.platform.alpha))
     api(libs.opentelemetry.api)
     implementation(libs.androidx.core)

--- a/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrDetector.java
+++ b/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrDetector.java
@@ -7,6 +7,8 @@ package io.opentelemetry.android.instrumentation.anr;
 
 import android.os.Handler;
 import android.os.Looper;
+
+import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor;
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.logs.Logger;
@@ -16,14 +18,14 @@ import java.util.concurrent.ScheduledExecutorService;
 
 /** Entrypoint for installing the ANR (application not responding) detection instrumentation. */
 public final class AnrDetector {
-    private final List<AttributesExtractor<StackTraceElement[], Void>> additionalExtractors;
+    private final List<EventAttributesExtractor<StackTraceElement[]>> additionalExtractors;
     private final Looper mainLooper;
     private final ScheduledExecutorService scheduler;
     private final AppLifecycle appLifecycle;
     private final OpenTelemetry openTelemetry;
 
     AnrDetector(
-            List<AttributesExtractor<StackTraceElement[], Void>> additionalExtractors,
+            List<EventAttributesExtractor<StackTraceElement[]>> additionalExtractors,
             Looper mainLooper,
             ScheduledExecutorService scheduler,
             AppLifecycle appLifecycle,

--- a/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrDetector.java
+++ b/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrDetector.java
@@ -7,12 +7,10 @@ package io.opentelemetry.android.instrumentation.anr;
 
 import android.os.Handler;
 import android.os.Looper;
-
 import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor;
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.logs.Logger;
-import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 

--- a/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrInstrumentation.java
+++ b/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrInstrumentation.java
@@ -10,6 +10,7 @@ import androidx.annotation.NonNull;
 import com.google.auto.service.AutoService;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
 import io.opentelemetry.android.instrumentation.InstallationContext;
+import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor;
 import io.opentelemetry.android.internal.services.Services;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.util.ArrayList;
@@ -22,14 +23,14 @@ import java.util.concurrent.ScheduledExecutorService;
 public final class AnrInstrumentation implements AndroidInstrumentation {
 
     public static final String INSTRUMENTATION_NAME = "anr";
-    final List<AttributesExtractor<StackTraceElement[], Void>> additionalExtractors =
+    final List<EventAttributesExtractor<StackTraceElement[]>> additionalExtractors =
             new ArrayList<>();
     Looper mainLooper = Looper.getMainLooper();
     ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
     /** Adds an {@link AttributesExtractor} that will extract additional attributes. */
     public AnrInstrumentation addAttributesExtractor(
-            AttributesExtractor<StackTraceElement[], Void> extractor) {
+            EventAttributesExtractor<StackTraceElement[]> extractor) {
         additionalExtractors.add(extractor);
         return this;
     }

--- a/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrInstrumentation.java
+++ b/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrInstrumentation.java
@@ -12,7 +12,6 @@ import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
 import io.opentelemetry.android.instrumentation.InstallationContext;
 import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor;
 import io.opentelemetry.android.internal.services.Services;
-import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -28,7 +27,7 @@ public final class AnrInstrumentation implements AndroidInstrumentation {
     Looper mainLooper = Looper.getMainLooper();
     ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
-    /** Adds an {@link AttributesExtractor} that will extract additional attributes. */
+    /** Adds an {@link EventAttributesExtractor} that will extract additional attributes. */
     public AnrInstrumentation addAttributesExtractor(
             EventAttributesExtractor<StackTraceElement[]> extractor) {
         additionalExtractors.add(extractor);

--- a/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrWatcher.kt
+++ b/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrWatcher.kt
@@ -11,7 +11,6 @@ import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.context.Context
-import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor
 import io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME

--- a/instrumentation/anr/src/test/java/io/opentelemetry/android/instrumentation/anr/AnrDetectorTest.java
+++ b/instrumentation/anr/src/test/java/io/opentelemetry/android/instrumentation/anr/AnrDetectorTest.java
@@ -6,15 +6,16 @@
 package io.opentelemetry.android.instrumentation.anr;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
-import static io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor.constant;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.os.Looper;
+import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor;
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle;
 import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import java.util.Collections;
 import java.util.concurrent.ScheduledExecutorService;
@@ -36,9 +37,11 @@ class AnrDetectorTest {
         when(mainLooper.getThread()).thenReturn(new Thread());
         OpenTelemetry openTelemetry = OpenTelemetrySdk.builder().build();
 
+        EventAttributesExtractor<StackTraceElement[]> extractor =
+                (parentContext, o) -> Attributes.of(stringKey("test.key"), "abc");
         AnrDetector anrDetector =
                 new AnrDetector(
-                        Collections.singletonList(constant(stringKey("test.key"), "abc")),
+                        Collections.singletonList(extractor),
                         mainLooper,
                         scheduler,
                         appLifecycle,

--- a/instrumentation/common-api/src/main/java/io/opentelemetry/android/instrumentation/common/EventAttributesExtractor.kt
+++ b/instrumentation/common-api/src/main/java/io/opentelemetry/android/instrumentation/common/EventAttributesExtractor.kt
@@ -1,0 +1,16 @@
+package io.opentelemetry.android.instrumentation.common
+
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.context.Context
+
+/**
+ * Extractor of point-in-time attributes. Whereas the AttributesExtractor in the
+ * upstream instrumentation api is targeted at tracing/spans (onStart, onEnd),
+ * this extractor operates purely on the parentContext and a generic SUBJECT
+ * at a point in time. The resulting Attributes will all be added to the event
+ * that is being generated.
+ */
+interface EventAttributesExtractor<SUBJECT> {
+
+    fun extract(parentContext: Context, subject: SUBJECT): Attributes
+}

--- a/instrumentation/common-api/src/main/java/io/opentelemetry/android/instrumentation/common/EventAttributesExtractor.kt
+++ b/instrumentation/common-api/src/main/java/io/opentelemetry/android/instrumentation/common/EventAttributesExtractor.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.android.instrumentation.common
 
 import io.opentelemetry.api.common.Attributes
@@ -11,6 +16,8 @@ import io.opentelemetry.context.Context
  * that is being generated.
  */
 interface EventAttributesExtractor<SUBJECT> {
-
-    fun extract(parentContext: Context, subject: SUBJECT): Attributes
+    fun extract(
+        parentContext: Context,
+        subject: SUBJECT,
+    ): Attributes
 }

--- a/instrumentation/crash/build.gradle.kts
+++ b/instrumentation/crash/build.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     implementation(project(":common"))
     implementation(project(":services"))
     implementation(project(":session"))
+    implementation(project(":instrumentation:common-api"))
     api(platform(libs.opentelemetry.platform.alpha))
     api(libs.opentelemetry.api)
     implementation(libs.androidx.core)

--- a/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporterInstrumentation.java
+++ b/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporterInstrumentation.java
@@ -7,9 +7,9 @@ package io.opentelemetry.android.instrumentation.crash;
 
 import androidx.annotation.NonNull;
 import com.google.auto.service.AutoService;
-import io.opentelemetry.android.common.RuntimeDetailsExtractor;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
 import io.opentelemetry.android.instrumentation.InstallationContext;
+import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor;
 import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import java.util.ArrayList;
@@ -19,11 +19,11 @@ import java.util.List;
 @AutoService(AndroidInstrumentation.class)
 public final class CrashReporterInstrumentation implements AndroidInstrumentation {
     private static final String INSTRUMENTATION_NAME = "crash";
-    private final List<AttributesExtractor<CrashDetails, Void>> additionalExtractors =
+    private final List<EventAttributesExtractor<CrashDetails>> additionalExtractors =
             new ArrayList<>();
 
     /** Adds an {@link AttributesExtractor} that will extract additional attributes. */
-    public void addAttributesExtractor(AttributesExtractor<CrashDetails, Void> extractor) {
+    public void addAttributesExtractor(EventAttributesExtractor<CrashDetails> extractor) {
         additionalExtractors.add(extractor);
     }
 

--- a/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporterInstrumentation.java
+++ b/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporterInstrumentation.java
@@ -10,7 +10,6 @@ import com.google.auto.service.AutoService;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
 import io.opentelemetry.android.instrumentation.InstallationContext;
 import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor;
-import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +21,7 @@ public final class CrashReporterInstrumentation implements AndroidInstrumentatio
     private final List<EventAttributesExtractor<CrashDetails>> additionalExtractors =
             new ArrayList<>();
 
-    /** Adds an {@link AttributesExtractor} that will extract additional attributes. */
+    /** Adds an {@link EventAttributesExtractor} that will extract additional attributes. */
     public void addAttributesExtractor(EventAttributesExtractor<CrashDetails> extractor) {
         additionalExtractors.add(extractor);
     }

--- a/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/RuntimeDetailsExtractor.java
+++ b/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/RuntimeDetailsExtractor.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.android.common;
+package io.opentelemetry.android.instrumentation.crash;
 
 import static io.opentelemetry.android.common.RumConstants.BATTERY_PERCENT_KEY;
 import static io.opentelemetry.android.common.RumConstants.HEAP_FREE_KEY;
@@ -15,13 +15,14 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.BatteryManager;
 import androidx.annotation.Nullable;
+import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor;
+import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.common.AttributesBuilder;
-import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor;
 import java.io.File;
 
 /** Represents details about the runtime environment at a time */
 public final class RuntimeDetailsExtractor<RQ, RS> extends BroadcastReceiver
-        implements AttributesExtractor<RQ, RS> {
+        implements EventAttributesExtractor<RQ> {
 
     private @Nullable volatile Double batteryPercent = null;
     private final File filesDir;
@@ -46,10 +47,8 @@ public final class RuntimeDetailsExtractor<RQ, RS> extends BroadcastReceiver
     }
 
     @Override
-    public void onStart(
-            AttributesBuilder attributes,
-            io.opentelemetry.context.Context parentContext,
-            RQ request) {
+    public Attributes extract(io.opentelemetry.context.Context parentContext, RQ request) {
+        AttributesBuilder attributes = Attributes.builder();
         attributes.put(STORAGE_SPACE_FREE_KEY, getCurrentStorageFreeSpaceInBytes());
         attributes.put(HEAP_FREE_KEY, getCurrentFreeHeapInBytes());
 
@@ -57,15 +56,8 @@ public final class RuntimeDetailsExtractor<RQ, RS> extends BroadcastReceiver
         if (currentBatteryPercent != null) {
             attributes.put(BATTERY_PERCENT_KEY, currentBatteryPercent);
         }
+        return attributes.build();
     }
-
-    @Override
-    public void onEnd(
-            AttributesBuilder attributes,
-            io.opentelemetry.context.Context context,
-            RQ request,
-            RS response,
-            Throwable error) {}
 
     private long getCurrentStorageFreeSpaceInBytes() {
         return filesDir.getFreeSpace();

--- a/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReporterTest.java
+++ b/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReporterTest.java
@@ -6,12 +6,12 @@
 package io.opentelemetry.android.instrumentation.crash;
 
 import static io.opentelemetry.api.common.AttributeKey.stringKey;
-import static io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor.constant;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.opentelemetry.android.instrumentation.InstallationContext;
+import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor;
 import io.opentelemetry.android.session.SessionProvider;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
@@ -60,7 +60,9 @@ public class CrashReporterTest {
     @Test
     public void integrationTest() throws InterruptedException {
         CrashReporterInstrumentation instrumentation = new CrashReporterInstrumentation();
-        instrumentation.addAttributesExtractor(constant(stringKey("test.key"), "abc"));
+        EventAttributesExtractor<CrashDetails> extractor =
+                (parentContext, o) -> Attributes.of(stringKey("test.key"), "abc");
+        instrumentation.addAttributesExtractor(extractor);
         InstallationContext ctx =
                 new InstallationContext(
                         RuntimeEnvironment.getApplication(),

--- a/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/RuntimeDetailsExtractorTest.java
+++ b/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/RuntimeDetailsExtractorTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.android.common;
+package io.opentelemetry.android.instrumentation.crash;
 
 import static io.opentelemetry.android.common.RumConstants.BATTERY_PERCENT_KEY;
 import static io.opentelemetry.android.common.RumConstants.HEAP_FREE_KEY;
@@ -43,7 +43,7 @@ class RuntimeDetailsExtractorTest {
         details.onReceive(context, intent);
 
         AttributesBuilder attributes = Attributes.builder();
-        details.onStart(attributes, root(), null);
+        attributes.putAll(details.extract(root(), null));
         assertThat(attributes.build())
                 .hasSize(3)
                 .containsEntry(STORAGE_SPACE_FREE_KEY, 4200L)


### PR DESCRIPTION
So the design of the `AttributesExtractor` class is tightly tied in with how the instrumentation api is designed, which is focused squarely on tracing and making spans. As a result, the `AttributesExtractor` has `onStart()` and `onEnd()` methods which don't really line up with point-in-time eventing. This leads to clumsy implementations that have a `Void` generic type and an empty/useless `onEnd()`. The `onStart()` api itself is also kinda gross, because it expects/requires implementations to just cause side effects on the `AttributesBuilder` that is passed to it (presumably for optimization/performance reasons?).

This introduces a new interface called `EventAttributesExtractor` that takes the parent context and a "subject" and produces `Attributes`. Callers/users of the `EventAttributesExtractor` can then take the resulting attributes and add those to the event being emitted.