### PR TITLE
Specify maxParallelForks for JVM tests

### DIFF
--- a/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
@@ -1,4 +1,5 @@
 import gradle.kotlin.dsl.accessors._d8282334f089ec6fbf714caba2b86dd9.kotlin
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
@@ -40,6 +41,13 @@ android {
             apiVersion.set(minKotlinVersion)
             languageVersion.set(minKotlinVersion)
             freeCompilerArgs.set(listOf("-Xjvm-default=all"))
+        }
+    }
+    testOptions {
+        unitTests {
+            all { test ->
+                test.maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2) + 1
+            }
         }
     }
 }


### PR DESCRIPTION
## Goal

Configuring [`maxParallelForks` for JVM tests](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.testing.Test.html#org.gradle.api.tasks.testing.Test:maxParallelForks) allows test classes to run in parallel. This can improve test execution times particularly if test cases are distributed across lots of different source files. Generally speaking this shouldn't cause problems unless tests are accessing shared objects/resources, which doesn't seem to be the case in this project.