### PR TITLE
OpenTelemetryRum.shutdown() and instrumentation uninstall

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/NoopOpenTelemetryRum.java
+++ b/core/src/main/java/io/opentelemetry/android/NoopOpenTelemetryRum.java
@@ -25,4 +25,9 @@ enum NoopOpenTelemetryRum implements OpenTelemetryRum {
 
     @Override
     public void emitEvent(String eventName, String body, Attributes attributes) {}
+
+    @Override
+    public void shutdown() {
+        // nop
+    }
 }

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRum.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRum.java
@@ -15,12 +15,7 @@ import io.opentelemetry.sdk.logs.SdkLoggerProvider;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
 
-/**
- * Entrypoint for the OpenTelemetry Real User Monitoring library for Android.
- *
- * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
- * at any time.
- */
+/** Entrypoint for the OpenTelemetry Real User Monitoring library for Android. */
 public interface OpenTelemetryRum {
 
     /**
@@ -137,4 +132,10 @@ public interface OpenTelemetryRum {
      * @param attributes The attributes associated with the event, providing metadata.
      */
     void emitEvent(String eventName, String body, Attributes attributes);
+
+    /**
+     * Initiates orderly shutdown of this OpenTelemetryRum instance. After this method completes,
+     * the instance should be considered invalid and no longer used.
+     */
+    void shutdown();
 }

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -331,7 +331,13 @@ public final class OpenTelemetryRumBuilder {
         otelSdkReadyListeners.forEach(listener -> listener.accept(sdk));
 
         SdkPreconfiguredRumBuilder delegate =
-                new SdkPreconfiguredRumBuilder(application, sdk, sessionProvider, config);
+                new SdkPreconfiguredRumBuilder(application, sdk, sessionProvider, config)
+                        .setShutdownHook(
+                                () -> {
+                                    if (exportScheduleHandler != null) {
+                                        exportScheduleHandler.disable();
+                                    }
+                                });
 
         // AsyncTask is deprecated but the thread pool is still used all over the Android SDK
         // and it provides a way to get a background thread without having to create a new one.

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumImpl.kt
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumImpl.kt
@@ -14,6 +14,7 @@ import io.opentelemetry.sdk.OpenTelemetrySdk
 internal class OpenTelemetryRumImpl(
     private val openTelemetrySdk: OpenTelemetrySdk,
     private val sessionProvider: SessionProvider,
+    private val onShutdown: Runnable
 ) : OpenTelemetryRum {
     private val logger: ExtendedLogger =
         openTelemetrySdk.logsBridge
@@ -35,5 +36,9 @@ internal class OpenTelemetryRumImpl(
             .setBody(body)
             .setAllAttributes(attributes)
             .emit()
+    }
+
+    override fun shutdown() {
+        onShutdown.run()
     }
 }

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumImpl.kt
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumImpl.kt
@@ -14,7 +14,7 @@ import io.opentelemetry.sdk.OpenTelemetrySdk
 internal class OpenTelemetryRumImpl(
     private val openTelemetrySdk: OpenTelemetrySdk,
     private val sessionProvider: SessionProvider,
-    private val onShutdown: Runnable
+    private val onShutdown: Runnable,
 ) : OpenTelemetryRum {
     private val logger: ExtendedLogger =
         openTelemetrySdk.logsBridge

--- a/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
@@ -41,11 +41,17 @@ class SdkPreconfiguredRumBuilder internal constructor(
      * @return A new [OpenTelemetryRum] instance.
      */
     fun build(): OpenTelemetryRum {
-        val openTelemetryRum = OpenTelemetryRumImpl(sdk, sessionProvider)
+        val ctx = InstallationContext(application, sdk, sessionProvider)
+        val enabledInstrumentations = getEnabledInstrumentations()
+        val onShutdown = {
+            for (instrumentation in enabledInstrumentations) {
+                instrumentation.uninstall(ctx)
+            }
+        }
+        val openTelemetryRum = OpenTelemetryRumImpl(sdk, sessionProvider, onShutdown)
 
         // Install instrumentations
-        val ctx = InstallationContext(application, openTelemetryRum.openTelemetry, sessionProvider)
-        for (instrumentation in getEnabledInstrumentations()) {
+        for (instrumentation in enabledInstrumentations) {
             instrumentation.install(ctx)
         }
 

--- a/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
@@ -19,6 +19,7 @@ class SdkPreconfiguredRumBuilder internal constructor(
     private val sessionProvider: SessionProvider,
     private val config: OtelRumConfig,
 ) {
+    private var onShutdown: Runnable = Runnable {} // nop
     private val instrumentations = mutableListOf<AndroidInstrumentation>()
 
     /**
@@ -28,6 +29,15 @@ class SdkPreconfiguredRumBuilder internal constructor(
      */
     fun addInstrumentation(instrumentation: AndroidInstrumentation): SdkPreconfiguredRumBuilder {
         instrumentations.add(instrumentation)
+        return this
+    }
+
+    /**
+     * Call this to provide a shutdown hook that will be called when the OpenTelemetryRum
+     * instance is shut down.
+     */
+    fun setShutdownHook(onShutdown: Runnable): SdkPreconfiguredRumBuilder {
+        this.onShutdown = onShutdown
         return this
     }
 
@@ -48,6 +58,7 @@ class SdkPreconfiguredRumBuilder internal constructor(
                 instrumentation.uninstall(ctx)
             }
             sdk.shutdown()
+            onShutdown.run()
         }
         val openTelemetryRum = OpenTelemetryRumImpl(sdk, sessionProvider, onShutdown)
 

--- a/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
@@ -43,10 +43,11 @@ class SdkPreconfiguredRumBuilder internal constructor(
     fun build(): OpenTelemetryRum {
         val ctx = InstallationContext(application, sdk, sessionProvider)
         val enabledInstrumentations = getEnabledInstrumentations()
-        val onShutdown = {
+        val onShutdown: () -> Unit = {
             for (instrumentation in enabledInstrumentations) {
                 instrumentation.uninstall(ctx)
             }
+            sdk.shutdown()
         }
         val openTelemetryRum = OpenTelemetryRumImpl(sdk, sessionProvider, onShutdown)
 

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduleHandler.kt
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduleHandler.kt
@@ -20,4 +20,9 @@ class DefaultExportScheduleHandler(
             periodicWorkService.enqueue(exportScheduler)
         }
     }
+
+    override fun disable() {
+        super.disable()
+        exportScheduler.shutdown()
+    }
 }

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduler.kt
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduler.kt
@@ -16,6 +16,9 @@ import java.util.concurrent.TimeUnit
 class DefaultExportScheduler(
     periodicWorkProvider: () -> PeriodicWork,
 ) : PeriodicRunnable(periodicWorkProvider) {
+    @Volatile
+    private var isShutDown: Boolean = false
+
     companion object {
         private val DELAY_BEFORE_NEXT_EXPORT_IN_MILLIS = TimeUnit.SECONDS.toMillis(10)
     }
@@ -32,7 +35,11 @@ class DefaultExportScheduler(
         }
     }
 
-    override fun shouldStopRunning(): Boolean = SignalFromDiskExporter.get() == null
+    fun shutdown() {
+        isShutDown = true
+    }
+
+    override fun shouldStopRunning(): Boolean = isShutDown || (SignalFromDiskExporter.get() == null)
 
     override fun minimumDelayUntilNextRunInMillis(): Long = DELAY_BEFORE_NEXT_EXPORT_IN_MILLIS
 }

--- a/instrumentation/android-instrumentation/src/main/java/io/opentelemetry/android/instrumentation/AndroidInstrumentation.kt
+++ b/instrumentation/android-instrumentation/src/main/java/io/opentelemetry/android/instrumentation/AndroidInstrumentation.kt
@@ -31,6 +31,16 @@ interface AndroidInstrumentation {
     fun install(ctx: InstallationContext)
 
     /**
+     * This method can be called to uninstall the instrumentation. Implementations should remove all
+     * used resources and shut down cleanly.
+     *
+     * @param ctx The InstallationContext under which the instrumentation had been removed.
+     */
+    fun uninstall(ctx: InstallationContext) {
+        // NOP default implementation
+    }
+
+    /**
      * The canonical short name for this instrumentation.
      */
     val name: String

--- a/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentation.java
+++ b/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentation.java
@@ -5,14 +5,17 @@
 
 package io.opentelemetry.android.instrumentation.slowrendering;
 
+import static io.opentelemetry.android.common.RumConstants.OTEL_RUM_LOG_TAG;
+
 import android.os.Build;
 import android.util.Log;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.google.auto.service.AutoService;
-import io.opentelemetry.android.common.RumConstants;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
 import io.opentelemetry.android.instrumentation.InstallationContext;
 import java.time.Duration;
+import org.jetbrains.annotations.NotNull;
 
 /** Entrypoint for installing the slow rendering detection instrumentation. */
 @AutoService(AndroidInstrumentation.class)
@@ -20,6 +23,7 @@ public final class SlowRenderingInstrumentation implements AndroidInstrumentatio
 
     private static final String INSTRUMENTATION_NAME = "slowrendering";
     Duration slowRenderingDetectionPollInterval = Duration.ofSeconds(1);
+    @Nullable private volatile SlowRenderListener detector = null;
 
     /**
      * Configures the rate at which frame render durations are polled.
@@ -30,7 +34,7 @@ public final class SlowRenderingInstrumentation implements AndroidInstrumentatio
     public SlowRenderingInstrumentation setSlowRenderingDetectionPollInterval(Duration interval) {
         if (interval.toMillis() <= 0) {
             Log.e(
-                    RumConstants.OTEL_RUM_LOG_TAG,
+                    OTEL_RUM_LOG_TAG,
                     "Invalid slowRenderingDetectionPollInterval: "
                             + interval
                             + "; must be positive");
@@ -44,18 +48,37 @@ public final class SlowRenderingInstrumentation implements AndroidInstrumentatio
     public void install(@NonNull InstallationContext ctx) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             Log.w(
-                    RumConstants.OTEL_RUM_LOG_TAG,
+                    OTEL_RUM_LOG_TAG,
                     "Slow/frozen rendering detection is not supported on platforms older than Android N (SDK version 24).");
             return;
         }
+        if (detector != null) {
+            Log.w(
+                    OTEL_RUM_LOG_TAG,
+                    "SlowRenderingInstrumentation skipping installation (detector already installed)");
+            return;
+        }
 
-        SlowRenderListener detector =
+        detector =
                 new SlowRenderListener(
                         ctx.getOpenTelemetry().getTracer("io.opentelemetry.slow-rendering"),
                         slowRenderingDetectionPollInterval);
 
         ctx.getApplication().registerActivityLifecycleCallbacks(detector);
         detector.start();
+    }
+
+    @Override
+    public void uninstall(@NotNull InstallationContext ctx) {
+        if (detector == null) {
+            Log.w(
+                    OTEL_RUM_LOG_TAG,
+                    "SlowRenderingInstrumentation skipping uninstall (detector is null)");
+            return;
+        }
+        ctx.getApplication().unregisterActivityLifecycleCallbacks(detector);
+        detector.shutdown();
+        detector = null;
     }
 
     @NonNull

--- a/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderListenerTest.java
+++ b/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderListenerTest.java
@@ -31,6 +31,7 @@ import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -64,12 +65,14 @@ public class SlowRenderListenerTest {
 
     @Mock FrameMetrics frameMetrics;
     Tracer tracer;
+    ScheduledExecutorService executorService;
 
     @Captor ArgumentCaptor<SlowRenderListener.PerActivityListener> activityListenerCaptor;
 
     @Before
     public void setup() {
         tracer = otelTesting.getOpenTelemetry().getTracer("testTracer");
+        executorService = Executors.newSingleThreadScheduledExecutor();
         ComponentName componentName = new ComponentName("io.otel", "Komponent");
         when(activity.getComponentName()).thenReturn(componentName);
     }
@@ -77,7 +80,7 @@ public class SlowRenderListenerTest {
     @Test
     public void add() {
         SlowRenderListener testInstance =
-                new SlowRenderListener(tracer, null, frameMetricsHandler, Duration.ZERO);
+                new SlowRenderListener(tracer, executorService, frameMetricsHandler, Duration.ZERO);
 
         testInstance.onActivityResumed(activity);
 
@@ -90,7 +93,7 @@ public class SlowRenderListenerTest {
     @Test
     public void removeBeforeAddOk() {
         SlowRenderListener testInstance =
-                new SlowRenderListener(tracer, null, frameMetricsHandler, Duration.ZERO);
+                new SlowRenderListener(tracer, executorService, frameMetricsHandler, Duration.ZERO);
 
         testInstance.onActivityPaused(activity);
 
@@ -101,7 +104,7 @@ public class SlowRenderListenerTest {
     @Test
     public void addAndRemove() {
         SlowRenderListener testInstance =
-                new SlowRenderListener(tracer, null, frameMetricsHandler, Duration.ZERO);
+                new SlowRenderListener(tracer, executorService, frameMetricsHandler, Duration.ZERO);
 
         testInstance.onActivityResumed(activity);
         testInstance.onActivityPaused(activity);
@@ -118,7 +121,7 @@ public class SlowRenderListenerTest {
     @Test
     public void removeWithMetrics() {
         SlowRenderListener testInstance =
-                new SlowRenderListener(tracer, null, frameMetricsHandler, Duration.ZERO);
+                new SlowRenderListener(tracer, executorService, frameMetricsHandler, Duration.ZERO);
 
         testInstance.onActivityResumed(activity);
 


### PR DESCRIPTION
Related to #1071.

So this just starts the process of being able to uninstall instrumentation and shut down the sdk. It should not be considered a complete solution, because I only picked up a single instrumentation to see how it would feel to shut down. 

If we like this approach, I can create a tracking issue for the other instrumentations and we can knock those uninstalls out one-at-a-time.