### PR TITLE
Bump compileSdk to 36

### DIFF
--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -13,7 +13,7 @@ localProperties.load(FileInputStream(rootProject.file("local.properties")))
 
 android {
     namespace = "io.opentelemetry.android.demo"
-    compileSdk = 35
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "io.opentelemetry.android.demo"

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,6 +22,6 @@ org.gradle.configuration-cache.parallel=true
 android.useAndroidX=true
 
 android.minSdk=21
-android.compileSdk=35
+android.compileSdk=36
 version=0.14.0
 group=io.opentelemetry.android


### PR DESCRIPTION
## Goal

Bumps the compileSdk to the latest version. I scanned the [release notes](https://developer.android.com/about/versions/16/features) and don't see anything that would prevent an upgrade. I also ran the example app & checks locally and everything passed.