### PR TITLE
Setup binary compatibility validator

### DIFF
--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -1,0 +1,71 @@
+public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer {
+	public static final field INSTANCE Lio/opentelemetry/android/agent/OpenTelemetryRumInitializer;
+	public static final fun initialize (Landroid/app/Application;Ljava/lang/String;Ljava/util/Map;Lio/opentelemetry/android/agent/connectivity/EndpointConnectivity;Lio/opentelemetry/android/agent/connectivity/EndpointConnectivity;Lio/opentelemetry/android/agent/connectivity/EndpointConnectivity;Lio/opentelemetry/android/config/OtelRumConfig;Lio/opentelemetry/android/agent/session/SessionConfig;Lkotlin/jvm/functions/Function1;Lio/opentelemetry/android/instrumentation/common/ScreenNameExtractor;Lkotlin/jvm/functions/Function1;Lio/opentelemetry/android/instrumentation/common/ScreenNameExtractor;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/time/Duration;)Lio/opentelemetry/android/OpenTelemetryRum;
+	public static synthetic fun initialize$default (Landroid/app/Application;Ljava/lang/String;Ljava/util/Map;Lio/opentelemetry/android/agent/connectivity/EndpointConnectivity;Lio/opentelemetry/android/agent/connectivity/EndpointConnectivity;Lio/opentelemetry/android/agent/connectivity/EndpointConnectivity;Lio/opentelemetry/android/config/OtelRumConfig;Lio/opentelemetry/android/agent/session/SessionConfig;Lkotlin/jvm/functions/Function1;Lio/opentelemetry/android/instrumentation/common/ScreenNameExtractor;Lkotlin/jvm/functions/Function1;Lio/opentelemetry/android/instrumentation/common/ScreenNameExtractor;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/time/Duration;ILjava/lang/Object;)Lio/opentelemetry/android/OpenTelemetryRum;
+}
+
+public abstract interface class io/opentelemetry/android/agent/connectivity/EndpointConnectivity {
+	public abstract fun getHeaders ()Ljava/util/Map;
+	public abstract fun getUrl ()Ljava/lang/String;
+}
+
+public final class io/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity : io/opentelemetry/android/agent/connectivity/EndpointConnectivity {
+	public static final field Companion Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getHeaders ()Ljava/util/Map;
+	public fun getUrl ()Ljava/lang/String;
+}
+
+public final class io/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity$Companion {
+	public final fun forLogs (Ljava/lang/String;Ljava/util/Map;)Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity;
+	public static synthetic fun forLogs$default (Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity$Companion;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity;
+	public final fun forMetrics (Ljava/lang/String;Ljava/util/Map;)Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity;
+	public static synthetic fun forMetrics$default (Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity$Companion;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity;
+	public final fun forTraces (Ljava/lang/String;Ljava/util/Map;)Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity;
+	public static synthetic fun forTraces$default (Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity$Companion;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity;
+}
+
+public final class io/opentelemetry/android/agent/session/SessionConfig {
+	public static final field Companion Lio/opentelemetry/android/agent/session/SessionConfig$Companion;
+	public synthetic fun <init> (JJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UwyO8pc ()J
+	public final fun component2-UwyO8pc ()J
+	public final fun copy-QTBD994 (JJ)Lio/opentelemetry/android/agent/session/SessionConfig;
+	public static synthetic fun copy-QTBD994$default (Lio/opentelemetry/android/agent/session/SessionConfig;JJILjava/lang/Object;)Lio/opentelemetry/android/agent/session/SessionConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackgroundInactivityTimeout-UwyO8pc ()J
+	public final fun getMaxLifetime-UwyO8pc ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public static final fun withDefaults ()Lio/opentelemetry/android/agent/session/SessionConfig;
+}
+
+public final class io/opentelemetry/android/agent/session/SessionConfig$Companion {
+	public final fun withDefaults ()Lio/opentelemetry/android/agent/session/SessionConfig;
+}
+
+public abstract interface class io/opentelemetry/android/agent/session/SessionIdGenerator {
+	public abstract fun generateSessionId ()Ljava/lang/String;
+}
+
+public final class io/opentelemetry/android/agent/session/SessionIdGenerator$DEFAULT : io/opentelemetry/android/agent/session/SessionIdGenerator {
+	public static final field INSTANCE Lio/opentelemetry/android/agent/session/SessionIdGenerator$DEFAULT;
+	public fun generateSessionId ()Ljava/lang/String;
+}
+
+public abstract interface class io/opentelemetry/android/agent/session/SessionStorage {
+	public abstract fun get ()Lio/opentelemetry/android/session/Session;
+	public abstract fun save (Lio/opentelemetry/android/session/Session;)V
+}
+
+public final class io/opentelemetry/android/agent/session/SessionStorage$InMemory : io/opentelemetry/android/agent/session/SessionStorage {
+	public fun <init> ()V
+	public fun <init> (Lio/opentelemetry/android/session/Session;)V
+	public synthetic fun <init> (Lio/opentelemetry/android/session/Session;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun get ()Lio/opentelemetry/android/session/Session;
+	public final fun getSession ()Lio/opentelemetry/android/session/Session;
+	public fun save (Lio/opentelemetry/android/session/Session;)V
+	public final fun setSession (Lio/opentelemetry/android/session/Session;)V
+}
+

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,4 +24,5 @@ dependencies {
     implementation(libs.animalsniffer.plugin)
     implementation(libs.kotlin.plugin)
     implementation(libs.detekt.plugin)
+    implementation(libs.binary.compat.validator)
 }

--- a/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
@@ -1,4 +1,3 @@
-import gradle.kotlin.dsl.accessors._d8282334f089ec6fbf714caba2b86dd9.kotlin
 import io.gitlab.arturbosch.detekt.Detekt
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
@@ -10,6 +9,7 @@ plugins {
     id("kotlin-kapt")
     id("otel.animalsniffer-conventions")
     id("io.gitlab.arturbosch.detekt")
+    id("org.jetbrains.kotlinx.binary-compatibility-validator")
 }
 
 val javaVersion = rootProject.extra["java_version"] as JavaVersion
@@ -75,6 +75,10 @@ project.tasks.withType(Detekt::class.java).configureEach {
         xml.required.set(false)
     }
 }
+
+// disable kotlin's binary compat validator for unwanted modules
+val ignoredModules = listOf("test-common")
+apiValidation.validationDisabled = ignoredModules.contains(project.name)
 
 val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 dependencies {

--- a/common/api/common.api
+++ b/common/api/common.api
@@ -1,0 +1,102 @@
+public class io/opentelemetry/android/common/RumConstants {
+	public static final field APP_START_SPAN_NAME Ljava/lang/String;
+	public static final field BATTERY_PERCENT_KEY Lio/opentelemetry/api/common/AttributeKey;
+	public static final field HEAP_FREE_KEY Lio/opentelemetry/api/common/AttributeKey;
+	public static final field LAST_SCREEN_NAME_KEY Lio/opentelemetry/api/common/AttributeKey;
+	public static final field OTEL_RUM_LOG_TAG Ljava/lang/String;
+	public static final field RUM_SDK_VERSION Lio/opentelemetry/api/common/AttributeKey;
+	public static final field SCREEN_NAME_KEY Lio/opentelemetry/api/common/AttributeKey;
+	public static final field START_TYPE_KEY Lio/opentelemetry/api/common/AttributeKey;
+	public static final field STORAGE_SPACE_FREE_KEY Lio/opentelemetry/api/common/AttributeKey;
+}
+
+public final class io/opentelemetry/android/common/RumConstants$Events {
+	public static final field EVENT_SESSION_END Ljava/lang/String;
+	public static final field EVENT_SESSION_START Ljava/lang/String;
+	public static final field INIT_EVENT_ANR_MONITOR Ljava/lang/String;
+	public static final field INIT_EVENT_CONFIG Ljava/lang/String;
+	public static final field INIT_EVENT_CRASH_REPORTER Ljava/lang/String;
+	public static final field INIT_EVENT_JANK_MONITOR Ljava/lang/String;
+	public static final field INIT_EVENT_NET_MONITOR Ljava/lang/String;
+	public static final field INIT_EVENT_NET_PROVIDER Ljava/lang/String;
+	public static final field INIT_EVENT_SPAN_EXPORTER Ljava/lang/String;
+	public static final field INIT_EVENT_STARTED Ljava/lang/String;
+}
+
+public final class io/opentelemetry/android/common/internal/features/networkattributes/CurrentNetworkAttributesExtractor {
+	public fun <init> ()V
+	public fun extract (Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;)Lio/opentelemetry/api/common/Attributes;
+}
+
+public final class io/opentelemetry/android/common/internal/features/networkattributes/data/Carrier {
+	public fun <init> ()V
+	public fun <init> (I)V
+	public fun <init> (ILjava/lang/String;)V
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;)V
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/opentelemetry/android/common/internal/features/networkattributes/data/Carrier;
+	public static synthetic fun copy$default (Lio/opentelemetry/android/common/internal/features/networkattributes/data/Carrier;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/opentelemetry/android/common/internal/features/networkattributes/data/Carrier;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()I
+	public final fun getIsoCountryCode ()Ljava/lang/String;
+	public final fun getMobileCountryCode ()Ljava/lang/String;
+	public final fun getMobileNetworkCode ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork {
+	public static fun builder (Lio/opentelemetry/android/common/internal/features/networkattributes/data/NetworkState;)Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork$Builder;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getCarrierCountryCode ()Ljava/lang/String;
+	public fun getCarrierIsoCountryCode ()Ljava/lang/String;
+	public fun getCarrierName ()Ljava/lang/String;
+	public fun getCarrierNetworkCode ()Ljava/lang/String;
+	public fun getState ()Lio/opentelemetry/android/common/internal/features/networkattributes/data/NetworkState;
+	public fun getSubType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun isOnline ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public class io/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork$Builder {
+	public fun build ()Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;
+	public fun carrier (Lio/opentelemetry/android/common/internal/features/networkattributes/data/Carrier;)Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork$Builder;
+	public fun subType (Ljava/lang/String;)Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork$Builder;
+}
+
+public final class io/opentelemetry/android/common/internal/features/networkattributes/data/NetworkState : java/lang/Enum {
+	public static final field NO_NETWORK_AVAILABLE Lio/opentelemetry/android/common/internal/features/networkattributes/data/NetworkState;
+	public static final field TRANSPORT_CELLULAR Lio/opentelemetry/android/common/internal/features/networkattributes/data/NetworkState;
+	public static final field TRANSPORT_UNKNOWN Lio/opentelemetry/android/common/internal/features/networkattributes/data/NetworkState;
+	public static final field TRANSPORT_VPN Lio/opentelemetry/android/common/internal/features/networkattributes/data/NetworkState;
+	public static final field TRANSPORT_WIFI Lio/opentelemetry/android/common/internal/features/networkattributes/data/NetworkState;
+	public static final field TRANSPORT_WIRED Lio/opentelemetry/android/common/internal/features/networkattributes/data/NetworkState;
+	public fun getHumanName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lio/opentelemetry/android/common/internal/features/networkattributes/data/NetworkState;
+	public static fun values ()[Lio/opentelemetry/android/common/internal/features/networkattributes/data/NetworkState;
+}
+
+public abstract interface class io/opentelemetry/android/common/internal/tools/time/SystemTime {
+	public static final field Companion Lio/opentelemetry/android/common/internal/tools/time/SystemTime$Companion;
+	public abstract fun getCurrentTimeMillis ()J
+}
+
+public final class io/opentelemetry/android/common/internal/tools/time/SystemTime$Companion {
+	public final fun get ()Lio/opentelemetry/android/common/internal/tools/time/SystemTime;
+	public final fun setForTest (Lio/opentelemetry/android/common/internal/tools/time/SystemTime;)V
+}
+
+public final class io/opentelemetry/android/common/internal/tools/time/SystemTime$DefaultSystemTime : io/opentelemetry/android/common/internal/tools/time/SystemTime {
+	public fun <init> ()V
+	public fun getCurrentTimeMillis ()J
+}
+

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1,0 +1,249 @@
+public final class io/opentelemetry/android/AndroidResource {
+	public static final field INSTANCE Lio/opentelemetry/android/AndroidResource;
+	public static final fun createDefault (Landroid/app/Application;)Lio/opentelemetry/sdk/resources/Resource;
+}
+
+public final class io/opentelemetry/android/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public static final field OTEL_ANDROID_VERSION Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public abstract interface class io/opentelemetry/android/OpenTelemetryRum {
+	public static fun builder (Landroid/app/Application;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public static fun builder (Landroid/app/Application;Lio/opentelemetry/android/config/OtelRumConfig;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public static fun builder (Landroid/app/Application;Lio/opentelemetry/sdk/OpenTelemetrySdk;Lio/opentelemetry/android/config/OtelRumConfig;Lio/opentelemetry/android/session/SessionProvider;)Lio/opentelemetry/android/SdkPreconfiguredRumBuilder;
+	public fun emitEvent (Ljava/lang/String;)V
+	public fun emitEvent (Ljava/lang/String;Lio/opentelemetry/api/common/Attributes;)V
+	public fun emitEvent (Ljava/lang/String;Ljava/lang/String;)V
+	public abstract fun emitEvent (Ljava/lang/String;Ljava/lang/String;Lio/opentelemetry/api/common/Attributes;)V
+	public abstract fun getOpenTelemetry ()Lio/opentelemetry/api/OpenTelemetry;
+	public abstract fun getRumSessionId ()Ljava/lang/String;
+	public static fun noop ()Lio/opentelemetry/android/OpenTelemetryRum;
+	public abstract fun shutdown ()V
+}
+
+public final class io/opentelemetry/android/OpenTelemetryRumBuilder {
+	public fun addInstrumentation (Lio/opentelemetry/android/instrumentation/AndroidInstrumentation;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public fun addLogRecordExporterCustomizer (Ljava/util/function/Function;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public fun addLoggerProviderCustomizer (Ljava/util/function/BiFunction;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public fun addMeterProviderCustomizer (Ljava/util/function/BiFunction;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public fun addMetricExporterCustomizer (Ljava/util/function/Function;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public fun addOtelSdkReadyListener (Ljava/util/function/Consumer;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public fun addPropagatorCustomizer (Ljava/util/function/Function;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public fun addSpanExporterCustomizer (Ljava/util/function/Function;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public fun addTracerProviderCustomizer (Ljava/util/function/BiFunction;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public fun build ()Lio/opentelemetry/android/OpenTelemetryRum;
+	public static fun create (Landroid/app/Application;Lio/opentelemetry/android/config/OtelRumConfig;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public fun mergeResource (Lio/opentelemetry/sdk/resources/Resource;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public fun setExportScheduleHandler (Lio/opentelemetry/android/features/diskbuffering/scheduler/ExportScheduleHandler;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public fun setResource (Lio/opentelemetry/sdk/resources/Resource;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public fun setSessionProvider (Lio/opentelemetry/android/session/SessionProvider;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+}
+
+public final class io/opentelemetry/android/SdkPreconfiguredRumBuilder {
+	public final fun addInstrumentation (Lio/opentelemetry/android/instrumentation/AndroidInstrumentation;)Lio/opentelemetry/android/SdkPreconfiguredRumBuilder;
+	public final fun build ()Lio/opentelemetry/android/OpenTelemetryRum;
+	public final fun setShutdownHook (Ljava/lang/Runnable;)Lio/opentelemetry/android/SdkPreconfiguredRumBuilder;
+}
+
+public final class io/opentelemetry/android/SessionIdRatioBasedSampler : io/opentelemetry/sdk/trace/samplers/Sampler {
+	public fun <init> (DLio/opentelemetry/android/session/SessionProvider;)V
+	public fun getDescription ()Ljava/lang/String;
+	public fun shouldSample (Lio/opentelemetry/context/Context;Ljava/lang/String;Ljava/lang/String;Lio/opentelemetry/api/trace/SpanKind;Lio/opentelemetry/api/common/Attributes;Ljava/util/List;)Lio/opentelemetry/sdk/trace/samplers/SamplingResult;
+}
+
+public class io/opentelemetry/android/config/OtelRumConfig {
+	public fun <init> ()V
+	public fun disableInstrumentationDiscovery ()Lio/opentelemetry/android/config/OtelRumConfig;
+	public fun disableNetworkAttributes ()Lio/opentelemetry/android/config/OtelRumConfig;
+	public fun disableScreenAttributes ()Lio/opentelemetry/android/config/OtelRumConfig;
+	public fun disableSdkInitializationEvents ()Lio/opentelemetry/android/config/OtelRumConfig;
+	public fun getDiskBufferingConfig ()Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public fun getGlobalAttributesSupplier ()Ljava/util/function/Supplier;
+	public fun hasGlobalAttributes ()Z
+	public fun isSuppressed (Ljava/lang/String;)Z
+	public fun setDiskBufferingConfig (Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;)Lio/opentelemetry/android/config/OtelRumConfig;
+	public fun setGlobalAttributes (Lio/opentelemetry/api/common/Attributes;)Lio/opentelemetry/android/config/OtelRumConfig;
+	public fun setGlobalAttributes (Ljava/util/function/Supplier;)Lio/opentelemetry/android/config/OtelRumConfig;
+	public fun shouldDiscoverInstrumentations ()Z
+	public fun shouldGenerateSdkInitializationEvents ()Z
+	public fun shouldIncludeNetworkAttributes ()Z
+	public fun shouldIncludeScreenAttributes ()Z
+	public fun suppressInstrumentation (Ljava/lang/String;)Lio/opentelemetry/android/config/OtelRumConfig;
+}
+
+public class io/opentelemetry/android/export/AttributeModifyingSpanExporter : io/opentelemetry/sdk/trace/export/SpanExporter {
+	public fun <init> (Lio/opentelemetry/sdk/trace/export/SpanExporter;Ljava/util/Map;)V
+	public fun export (Ljava/util/Collection;)Lio/opentelemetry/sdk/common/CompletableResultCode;
+	public fun flush ()Lio/opentelemetry/sdk/common/CompletableResultCode;
+	public fun shutdown ()Lio/opentelemetry/sdk/common/CompletableResultCode;
+}
+
+public class io/opentelemetry/android/export/FilteringSpanExporter {
+	public fun <init> ()V
+	public static fun builder (Lio/opentelemetry/sdk/trace/export/SpanExporter;)Lio/opentelemetry/android/export/FilteringSpanExporterBuilder;
+}
+
+public final class io/opentelemetry/android/export/FilteringSpanExporterBuilder {
+	public fun build ()Lio/opentelemetry/sdk/trace/export/SpanExporter;
+	public fun rejectSpansNamed (Ljava/lang/String;)Lio/opentelemetry/android/export/FilteringSpanExporterBuilder;
+	public fun rejectSpansNamed (Ljava/util/function/Predicate;)Lio/opentelemetry/android/export/FilteringSpanExporterBuilder;
+	public fun rejectSpansWithAttributesMatching (Ljava/util/Map;)Lio/opentelemetry/android/export/FilteringSpanExporterBuilder;
+	public fun rejectSpansWithNameContaining (Ljava/lang/String;)Lio/opentelemetry/android/export/FilteringSpanExporterBuilder;
+	public fun rejecting (Ljava/util/function/Predicate;)Lio/opentelemetry/android/export/FilteringSpanExporterBuilder;
+}
+
+public final class io/opentelemetry/android/export/SpanDataModifier {
+	public fun build ()Lio/opentelemetry/sdk/trace/export/SpanExporter;
+	public static fun builder (Lio/opentelemetry/sdk/trace/export/SpanExporter;)Lio/opentelemetry/android/export/SpanDataModifier;
+	public fun rejectSpansByAttributeValue (Lio/opentelemetry/api/common/AttributeKey;Ljava/util/function/Predicate;)Lio/opentelemetry/android/export/SpanDataModifier;
+	public fun rejectSpansByName (Ljava/util/function/Predicate;)Lio/opentelemetry/android/export/SpanDataModifier;
+	public fun removeSpanAttribute (Lio/opentelemetry/api/common/AttributeKey;)Lio/opentelemetry/android/export/SpanDataModifier;
+	public fun removeSpanAttribute (Lio/opentelemetry/api/common/AttributeKey;Ljava/util/function/Predicate;)Lio/opentelemetry/android/export/SpanDataModifier;
+	public fun replaceSpanAttribute (Lio/opentelemetry/api/common/AttributeKey;Ljava/util/function/Function;)Lio/opentelemetry/android/export/SpanDataModifier;
+}
+
+public final class io/opentelemetry/android/features/diskbuffering/DiskBufferingConfig {
+	public static final field Companion Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig$Companion;
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public fun <init> (ZI)V
+	public fun <init> (ZIJ)V
+	public fun <init> (ZIJJ)V
+	public fun <init> (ZIJJJ)V
+	public fun <init> (ZIJJJI)V
+	public fun <init> (ZIJJJIZ)V
+	public fun <init> (ZIJJJIZLjava/io/File;)V
+	public synthetic fun <init> (ZIJJJIZLjava/io/File;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()I
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun component5 ()J
+	public final fun component6 ()I
+	public final fun component7 ()Z
+	public final fun component8 ()Ljava/io/File;
+	public final fun copy (ZIJJJIZLjava/io/File;)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public static synthetic fun copy$default (Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;ZIJJJIZLjava/io/File;ILjava/lang/Object;)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public static final fun create ()Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public static final fun create (Z)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public static final fun create (ZI)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public static final fun create (ZIJ)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public static final fun create (ZIJJ)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public static final fun create (ZIJJJ)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public static final fun create (ZIJJJI)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public static final fun create (ZIJJJIZ)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public static final fun create (ZIJJJIZLjava/io/File;)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDebugEnabled ()Z
+	public final fun getEnabled ()Z
+	public final fun getMaxCacheFileSize ()I
+	public final fun getMaxCacheSize ()I
+	public final fun getMaxFileAgeForReadMillis ()J
+	public final fun getMaxFileAgeForWriteMillis ()J
+	public final fun getMinFileAgeForReadMillis ()J
+	public final fun getSignalsBufferDir ()Ljava/io/File;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/opentelemetry/android/features/diskbuffering/DiskBufferingConfig$Companion {
+	public final fun create ()Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public final fun create (Z)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public final fun create (ZI)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public final fun create (ZIJ)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public final fun create (ZIJJ)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public final fun create (ZIJJJ)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public final fun create (ZIJJJI)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public final fun create (ZIJJJIZ)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public final fun create (ZIJJJIZLjava/io/File;)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public static synthetic fun create$default (Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig$Companion;ZIJJJIZLjava/io/File;ILjava/lang/Object;)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+}
+
+public final class io/opentelemetry/android/features/diskbuffering/DiskBufferingConfigKt {
+	public static final field DEFAULT_MAX_CACHE_SIZE I
+	public static final field DEFAULT_MAX_FILE_AGE_FOR_READ_MS J
+	public static final field DEFAULT_MAX_FILE_AGE_FOR_WRITE_MS J
+	public static final field DEFAULT_MIN_FILE_AGE_FOR_READ_MS J
+	public static final field MAX_CACHE_FILE_SIZE I
+}
+
+public final class io/opentelemetry/android/features/diskbuffering/SignalFromDiskExporter {
+	public static final field Companion Lio/opentelemetry/android/features/diskbuffering/SignalFromDiskExporter$Companion;
+	public fun <init> (Lio/opentelemetry/contrib/disk/buffering/SpanFromDiskExporter;Lio/opentelemetry/contrib/disk/buffering/MetricFromDiskExporter;Lio/opentelemetry/contrib/disk/buffering/LogRecordFromDiskExporter;)V
+	public final fun exportBatchOfEach ()Z
+	public final fun exportBatchOfLogs ()Z
+	public final fun exportBatchOfMetrics ()Z
+	public final fun exportBatchOfSpans ()Z
+	public static final fun get ()Lio/opentelemetry/android/features/diskbuffering/SignalFromDiskExporter;
+	public static final fun resetForTesting ()V
+	public static final fun set (Lio/opentelemetry/android/features/diskbuffering/SignalFromDiskExporter;)V
+}
+
+public final class io/opentelemetry/android/features/diskbuffering/SignalFromDiskExporter$Companion {
+	public final fun get ()Lio/opentelemetry/android/features/diskbuffering/SignalFromDiskExporter;
+	public final fun resetForTesting ()V
+	public final fun set (Lio/opentelemetry/android/features/diskbuffering/SignalFromDiskExporter;)V
+}
+
+public final class io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduleHandler : io/opentelemetry/android/features/diskbuffering/scheduler/ExportScheduleHandler {
+	public fun <init> (Lio/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduler;Lkotlin/jvm/functions/Function0;)V
+	public fun disable ()V
+	public fun enable ()V
+}
+
+public final class io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduler : io/opentelemetry/android/internal/services/periodicwork/PeriodicRunnable {
+	public static final field Companion Lio/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduler$Companion;
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public fun minimumDelayUntilNextRunInMillis ()J
+	public fun onRun ()V
+	public fun shouldStopRunning ()Z
+	public final fun shutdown ()V
+}
+
+public final class io/opentelemetry/android/features/diskbuffering/scheduler/DefaultExportScheduler$Companion {
+}
+
+public abstract interface class io/opentelemetry/android/features/diskbuffering/scheduler/ExportScheduleHandler {
+	public fun disable ()V
+	public abstract fun enable ()V
+}
+
+public final class io/opentelemetry/android/internal/features/networkattrs/NetworkAttributesLogRecordAppender : io/opentelemetry/sdk/logs/LogRecordProcessor {
+	public fun <init> (Lio/opentelemetry/android/internal/services/network/CurrentNetworkProvider;)V
+	public fun <init> (Lio/opentelemetry/android/internal/services/network/CurrentNetworkProvider;Lio/opentelemetry/android/common/internal/features/networkattributes/CurrentNetworkAttributesExtractor;)V
+	public synthetic fun <init> (Lio/opentelemetry/android/internal/services/network/CurrentNetworkProvider;Lio/opentelemetry/android/common/internal/features/networkattributes/CurrentNetworkAttributesExtractor;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun onEmit (Lio/opentelemetry/context/Context;Lio/opentelemetry/sdk/logs/ReadWriteLogRecord;)V
+}
+
+public abstract interface class io/opentelemetry/android/internal/initialization/InitializationEvents {
+	public static final field Companion Lio/opentelemetry/android/internal/initialization/InitializationEvents$Companion;
+	public abstract fun anrMonitorInitialized ()V
+	public abstract fun crashReportingInitialized ()V
+	public abstract fun currentNetworkProviderInitialized ()V
+	public static fun get ()Lio/opentelemetry/android/internal/initialization/InitializationEvents;
+	public abstract fun networkMonitorInitialized ()V
+	public abstract fun recordConfiguration (Lio/opentelemetry/android/config/OtelRumConfig;)V
+	public static fun resetForTest ()V
+	public abstract fun sdkInitializationStarted ()V
+	public static fun set (Lio/opentelemetry/android/internal/initialization/InitializationEvents;)V
+	public abstract fun slowRenderingDetectorInitialized ()V
+	public abstract fun spanExporterInitialized (Lio/opentelemetry/sdk/trace/export/SpanExporter;)V
+}
+
+public final class io/opentelemetry/android/internal/initialization/InitializationEvents$Companion {
+	public final fun get ()Lio/opentelemetry/android/internal/initialization/InitializationEvents;
+	public final fun getNO_OP ()Lio/opentelemetry/android/internal/initialization/InitializationEvents;
+	public final fun resetForTest ()V
+	public final fun set (Lio/opentelemetry/android/internal/initialization/InitializationEvents;)V
+}
+
+public final class io/opentelemetry/android/internal/processors/ScreenAttributesLogRecordProcessor : io/opentelemetry/sdk/logs/LogRecordProcessor {
+	public fun <init> (Lio/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTracker;)V
+	public final fun getVisibleScreenTracker ()Lio/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTracker;
+	public fun onEmit (Lio/opentelemetry/context/Context;Lio/opentelemetry/sdk/logs/ReadWriteLogRecord;)V
+}
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ autoService = "1.1.1"
 androidx-navigation = "2.7.7"
 compose = "1.5.4"
 detekt = "1.23.8"
+binaryCompatValidator = "0.18.1"
 
 [libraries]
 opentelemetry-platform-alpha = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetry-instrumentation-alpha" }
@@ -49,6 +50,7 @@ auto-service-annotations = { module = "com.google.auto.service:auto-service-anno
 auto-service-processor = { module = "com.google.auto.service:auto-service", version.ref = "autoService" }
 compose = { group = "androidx.compose.ui", name = "ui", version.ref = "compose" }
 detekt-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
+binary-compat-validator = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version.ref = "binaryCompatValidator" }
 
 #Test tools
 opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing" }

--- a/instrumentation/activity/api/activity.api
+++ b/instrumentation/activity/api/activity.api
@@ -1,0 +1,72 @@
+public final class io/opentelemetry/android/instrumentation/activity/ActivityCallbacks : io/opentelemetry/android/internal/services/visiblescreen/activities/DefaultingActivityLifecycleCallbacks {
+	public fun <init> (Lio/opentelemetry/android/instrumentation/activity/ActivityTracerCache;)V
+	public fun onActivityCreated (Landroid/app/Activity;Landroid/os/Bundle;)V
+	public fun onActivityDestroyed (Landroid/app/Activity;)V
+	public fun onActivityPaused (Landroid/app/Activity;)V
+	public fun onActivityPostCreated (Landroid/app/Activity;Landroid/os/Bundle;)V
+	public fun onActivityPostDestroyed (Landroid/app/Activity;)V
+	public fun onActivityPostPaused (Landroid/app/Activity;)V
+	public fun onActivityPostResumed (Landroid/app/Activity;)V
+	public fun onActivityPostStarted (Landroid/app/Activity;)V
+	public fun onActivityPostStopped (Landroid/app/Activity;)V
+	public fun onActivityPreCreated (Landroid/app/Activity;Landroid/os/Bundle;)V
+	public fun onActivityPreDestroyed (Landroid/app/Activity;)V
+	public fun onActivityPrePaused (Landroid/app/Activity;)V
+	public fun onActivityPreResumed (Landroid/app/Activity;)V
+	public fun onActivityPreStarted (Landroid/app/Activity;)V
+	public fun onActivityPreStopped (Landroid/app/Activity;)V
+	public fun onActivityResumed (Landroid/app/Activity;)V
+	public fun onActivityStarted (Landroid/app/Activity;)V
+	public fun onActivityStopped (Landroid/app/Activity;)V
+}
+
+public final class io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public fun <init> ()V
+	public fun getName ()Ljava/lang/String;
+	public fun install (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
+	public final fun setScreenNameExtractor (Lio/opentelemetry/android/instrumentation/common/ScreenNameExtractor;)V
+	public final fun setTracerCustomizer (Lkotlin/jvm/functions/Function1;)V
+}
+
+public class io/opentelemetry/android/instrumentation/activity/ActivityTracer {
+	public fun addEvent (Ljava/lang/String;)Lio/opentelemetry/android/instrumentation/activity/ActivityTracer;
+	public fun addPreviousScreenAttribute ()Lio/opentelemetry/android/instrumentation/activity/ActivityTracer;
+	public fun endActiveSpan ()V
+	public fun endSpanForActivityResumed ()V
+}
+
+public class io/opentelemetry/android/instrumentation/activity/ActivityTracerCache {
+	public fun <init> (Lio/opentelemetry/api/trace/Tracer;Lio/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTracker;Lio/opentelemetry/android/instrumentation/activity/startup/AppStartupTimer;Lio/opentelemetry/android/instrumentation/common/ScreenNameExtractor;)V
+	public fun addEvent (Landroid/app/Activity;Ljava/lang/String;)Lio/opentelemetry/android/instrumentation/activity/ActivityTracer;
+	public fun initiateRestartSpanIfNecessary (Landroid/app/Activity;)Lio/opentelemetry/android/instrumentation/activity/ActivityTracer;
+	public fun startActivityCreation (Landroid/app/Activity;)Lio/opentelemetry/android/instrumentation/activity/ActivityTracer;
+	public fun startSpanIfNoneInProgress (Landroid/app/Activity;Ljava/lang/String;)Lio/opentelemetry/android/instrumentation/activity/ActivityTracer;
+}
+
+public class io/opentelemetry/android/instrumentation/activity/Pre29ActivityCallbacks : io/opentelemetry/android/internal/services/visiblescreen/activities/DefaultingActivityLifecycleCallbacks {
+	public fun <init> (Lio/opentelemetry/android/instrumentation/activity/ActivityTracerCache;)V
+	public fun onActivityCreated (Landroid/app/Activity;Landroid/os/Bundle;)V
+	public fun onActivityDestroyed (Landroid/app/Activity;)V
+	public fun onActivityPaused (Landroid/app/Activity;)V
+	public fun onActivityResumed (Landroid/app/Activity;)V
+	public fun onActivityStarted (Landroid/app/Activity;)V
+	public fun onActivityStopped (Landroid/app/Activity;)V
+}
+
+public final class io/opentelemetry/android/instrumentation/activity/startup/AnchoredClock {
+	public static fun create (Lio/opentelemetry/sdk/common/Clock;)Lio/opentelemetry/android/instrumentation/activity/startup/AnchoredClock;
+	public fun now ()J
+}
+
+public class io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimer {
+	public fun <init> ()V
+	public fun clockNow ()J
+	public fun createLifecycleCallback ()Landroid/app/Application$ActivityLifecycleCallbacks;
+	public fun detectBackgroundStart (Landroid/os/Handler;)V
+	public fun end ()V
+	public fun getStartupSpan ()Lio/opentelemetry/api/trace/Span;
+	public fun runCompletionCallback ()V
+	public fun setCompletionCallback (Ljava/lang/Runnable;)V
+	public fun start (Lio/opentelemetry/api/trace/Tracer;)Lio/opentelemetry/api/trace/Span;
+}
+

--- a/instrumentation/android-instrumentation/api/android-instrumentation.api
+++ b/instrumentation/android-instrumentation/api/android-instrumentation.api
@@ -1,0 +1,43 @@
+public abstract interface class io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun install (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
+	public fun uninstall (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
+}
+
+public abstract interface class io/opentelemetry/android/instrumentation/AndroidInstrumentationLoader {
+	public static final field Companion Lio/opentelemetry/android/instrumentation/AndroidInstrumentationLoader$Companion;
+	public static fun get ()Lio/opentelemetry/android/instrumentation/AndroidInstrumentationLoader;
+	public abstract fun getAll ()Ljava/util/Collection;
+	public abstract fun getByType (Ljava/lang/Class;)Lio/opentelemetry/android/instrumentation/AndroidInstrumentation;
+	public static fun getInstrumentation (Ljava/lang/Class;)Lio/opentelemetry/android/instrumentation/AndroidInstrumentation;
+	public static fun resetForTest ()V
+}
+
+public final class io/opentelemetry/android/instrumentation/AndroidInstrumentationLoader$Companion {
+	public final fun get ()Lio/opentelemetry/android/instrumentation/AndroidInstrumentationLoader;
+	public final fun getInstrumentation (Ljava/lang/Class;)Lio/opentelemetry/android/instrumentation/AndroidInstrumentation;
+	public final fun resetForTest ()V
+}
+
+public final class io/opentelemetry/android/instrumentation/InstallationContext {
+	public fun <init> (Landroid/app/Application;Lio/opentelemetry/api/OpenTelemetry;Lio/opentelemetry/android/session/SessionProvider;)V
+	public final fun component1 ()Landroid/app/Application;
+	public final fun component2 ()Lio/opentelemetry/api/OpenTelemetry;
+	public final fun component3 ()Lio/opentelemetry/android/session/SessionProvider;
+	public final fun copy (Landroid/app/Application;Lio/opentelemetry/api/OpenTelemetry;Lio/opentelemetry/android/session/SessionProvider;)Lio/opentelemetry/android/instrumentation/InstallationContext;
+	public static synthetic fun copy$default (Lio/opentelemetry/android/instrumentation/InstallationContext;Landroid/app/Application;Lio/opentelemetry/api/OpenTelemetry;Lio/opentelemetry/android/session/SessionProvider;ILjava/lang/Object;)Lio/opentelemetry/android/instrumentation/InstallationContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApplication ()Landroid/app/Application;
+	public final fun getOpenTelemetry ()Lio/opentelemetry/api/OpenTelemetry;
+	public final fun getSessionProvider ()Lio/opentelemetry/android/session/SessionProvider;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/opentelemetry/android/instrumentation/internal/AndroidInstrumentationLoaderImpl : io/opentelemetry/android/instrumentation/AndroidInstrumentationLoader {
+	public fun <init> ()V
+	public fun getAll ()Ljava/util/Collection;
+	public fun getByType (Ljava/lang/Class;)Lio/opentelemetry/android/instrumentation/AndroidInstrumentation;
+	public final fun registerForTest (Lio/opentelemetry/android/instrumentation/AndroidInstrumentation;)V
+}
+

--- a/instrumentation/android-log/agent/api/agent.api
+++ b/instrumentation/android-log/agent/api/agent.api
@@ -1,0 +1,8 @@
+public class io/opentelemetry/instrumentation/agent/log/AndroidLogPlugin : net/bytebuddy/build/Plugin {
+	public fun <init> (Lnet/bytebuddy/build/AndroidDescriptor;)V
+	public fun apply (Lnet/bytebuddy/dynamic/DynamicType$Builder;Lnet/bytebuddy/description/type/TypeDescription;Lnet/bytebuddy/dynamic/ClassFileLocator;)Lnet/bytebuddy/dynamic/DynamicType$Builder;
+	public fun close ()V
+	public synthetic fun matches (Ljava/lang/Object;)Z
+	public fun matches (Lnet/bytebuddy/description/type/TypeDescription;)Z
+}
+

--- a/instrumentation/android-log/library/api/library.api
+++ b/instrumentation/android-log/library/api/library.api
@@ -1,0 +1,34 @@
+public class io/opentelemetry/instrumentation/library/log/AndroidLogInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public static final field INSTRUMENTATION_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun getName ()Ljava/lang/String;
+	public fun install (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
+}
+
+public class io/opentelemetry/instrumentation/library/log/AndroidLogSubstitutions {
+	public static field TAG_KEY Lio/opentelemetry/api/common/AttributeKey;
+	public fun <init> ()V
+	public static fun substitutionForDebug (Ljava/lang/String;Ljava/lang/String;)I
+	public static fun substitutionForDebug2 (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+	public static fun substitutionForError (Ljava/lang/String;Ljava/lang/String;)I
+	public static fun substitutionForError2 (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+	public static fun substitutionForInfo (Ljava/lang/String;Ljava/lang/String;)I
+	public static fun substitutionForInfo2 (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+	public static fun substitutionForVerbose (Ljava/lang/String;Ljava/lang/String;)I
+	public static fun substitutionForVerbose2 (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+	public static fun substitutionForWarn (Ljava/lang/String;Ljava/lang/String;)I
+	public static fun substitutionForWarn2 (Ljava/lang/String;Ljava/lang/Throwable;)I
+	public static fun substitutionForWarn3 (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+	public static fun substitutionForWtf (Ljava/lang/String;Ljava/lang/String;)I
+	public static fun substitutionForWtf2 (Ljava/lang/String;Ljava/lang/Throwable;)I
+	public static fun substitutionForWtf3 (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Throwable;)I
+}
+
+public final class io/opentelemetry/instrumentation/library/log/internal/LogRecordBuilderCreator {
+	public static final field INSTANCE Lio/opentelemetry/instrumentation/library/log/internal/LogRecordBuilderCreator;
+	public static final fun configure (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
+	public static final fun createLogRecordBuilder ()Lio/opentelemetry/api/incubator/logs/ExtendedLogRecordBuilder;
+	public static final fun getTypeName (Ljava/lang/Throwable;)Ljava/lang/String;
+	public static final fun printStacktrace (Ljava/lang/Throwable;)Ljava/lang/String;
+}
+

--- a/instrumentation/anr/api/anr.api
+++ b/instrumentation/anr/api/anr.api
@@ -1,0 +1,13 @@
+public final class io/opentelemetry/android/instrumentation/anr/AnrDetector {
+	public fun start ()V
+}
+
+public final class io/opentelemetry/android/instrumentation/anr/AnrInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public static final field INSTRUMENTATION_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun addAttributesExtractor (Lio/opentelemetry/android/instrumentation/common/EventAttributesExtractor;)Lio/opentelemetry/android/instrumentation/anr/AnrInstrumentation;
+	public fun getName ()Ljava/lang/String;
+	public fun install (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
+	public fun setMainLooper (Landroid/os/Looper;)Lio/opentelemetry/android/instrumentation/anr/AnrInstrumentation;
+}
+

--- a/instrumentation/common-api/api/common-api.api
+++ b/instrumentation/common-api/api/common-api.api
@@ -1,0 +1,27 @@
+public abstract interface annotation class io/opentelemetry/android/instrumentation/annotations/RumScreenName : java/lang/annotation/Annotation {
+	public abstract fun value ()Ljava/lang/String;
+}
+
+public class io/opentelemetry/android/instrumentation/common/ActiveSpan {
+	public fun <init> (Ljava/util/function/Supplier;)V
+	public fun addEvent (Ljava/lang/String;)V
+	public fun addPreviousScreenAttribute (Ljava/lang/String;)V
+	public fun endActiveSpan ()V
+	public fun spanInProgress ()Z
+	public fun startSpan (Ljava/util/function/Supplier;)V
+}
+
+public final class io/opentelemetry/android/instrumentation/common/Constants {
+	public static final field INSTANCE Lio/opentelemetry/android/instrumentation/common/Constants;
+	public static final field INSTRUMENTATION_SCOPE Ljava/lang/String;
+}
+
+public abstract interface class io/opentelemetry/android/instrumentation/common/EventAttributesExtractor {
+	public abstract fun extract (Lio/opentelemetry/context/Context;Ljava/lang/Object;)Lio/opentelemetry/api/common/Attributes;
+}
+
+public abstract interface class io/opentelemetry/android/instrumentation/common/ScreenNameExtractor {
+	public static final field DEFAULT Lio/opentelemetry/android/instrumentation/common/ScreenNameExtractor;
+	public abstract fun extract (Ljava/lang/Object;)Ljava/lang/String;
+}
+

--- a/instrumentation/compose/click/api/click.api
+++ b/instrumentation/compose/click/api/click.api
@@ -1,0 +1,11 @@
+public final class io/opentelemetry/instrumentation/compose/click/ComposeClickInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public fun <init> ()V
+	public fun getName ()Ljava/lang/String;
+	public fun install (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
+}
+
+public final class io/opentelemetry/instrumentation/compose/click/ComposeLayoutNodeUtilKt {
+	public static final field APP_SCREEN_CLICK_EVENT_NAME Ljava/lang/String;
+	public static final field VIEW_CLICK_EVENT_NAME Ljava/lang/String;
+}
+

--- a/instrumentation/crash/api/crash.api
+++ b/instrumentation/crash/api/crash.api
@@ -1,0 +1,26 @@
+public final class io/opentelemetry/android/instrumentation/crash/CrashDetails {
+	public static fun create (Ljava/lang/Thread;Ljava/lang/Throwable;)Lio/opentelemetry/android/instrumentation/crash/CrashDetails;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getCause ()Ljava/lang/Throwable;
+	public fun getThread ()Ljava/lang/Thread;
+	public fun hashCode ()I
+}
+
+public final class io/opentelemetry/android/instrumentation/crash/CrashReporter {
+	public fun <init> (Ljava/util/List;)V
+	public fun install (Lio/opentelemetry/sdk/OpenTelemetrySdk;)V
+}
+
+public final class io/opentelemetry/android/instrumentation/crash/CrashReporterInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public fun <init> ()V
+	public fun addAttributesExtractor (Lio/opentelemetry/android/instrumentation/common/EventAttributesExtractor;)V
+	public fun getName ()Ljava/lang/String;
+	public fun install (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
+}
+
+public final class io/opentelemetry/android/instrumentation/crash/RuntimeDetailsExtractor : android/content/BroadcastReceiver, io/opentelemetry/android/instrumentation/common/EventAttributesExtractor {
+	public static fun create (Landroid/content/Context;)Lio/opentelemetry/android/instrumentation/crash/RuntimeDetailsExtractor;
+	public fun extract (Lio/opentelemetry/context/Context;Ljava/lang/Object;)Lio/opentelemetry/api/common/Attributes;
+	public fun onReceive (Landroid/content/Context;Landroid/content/Intent;)V
+}
+

--- a/instrumentation/fragment/api/fragment.api
+++ b/instrumentation/fragment/api/fragment.api
@@ -1,0 +1,25 @@
+public final class io/opentelemetry/android/instrumentation/fragment/FragmentLifecycleInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public fun <init> ()V
+	public fun getName ()Ljava/lang/String;
+	public fun install (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
+	public final fun setScreenNameExtractor (Lio/opentelemetry/android/instrumentation/common/ScreenNameExtractor;)V
+	public final fun setTracerCustomizer (Lkotlin/jvm/functions/Function1;)V
+}
+
+public class io/opentelemetry/android/instrumentation/fragment/RumFragmentLifecycleCallbacks : androidx/fragment/app/FragmentManager$FragmentLifecycleCallbacks {
+	public fun <init> (Lio/opentelemetry/api/trace/Tracer;Ljava/util/function/Supplier;Lio/opentelemetry/android/instrumentation/common/ScreenNameExtractor;)V
+	public fun onFragmentAttached (Landroidx/fragment/app/FragmentManager;Landroidx/fragment/app/Fragment;Landroid/content/Context;)V
+	public fun onFragmentCreated (Landroidx/fragment/app/FragmentManager;Landroidx/fragment/app/Fragment;Landroid/os/Bundle;)V
+	public fun onFragmentDestroyed (Landroidx/fragment/app/FragmentManager;Landroidx/fragment/app/Fragment;)V
+	public fun onFragmentDetached (Landroidx/fragment/app/FragmentManager;Landroidx/fragment/app/Fragment;)V
+	public fun onFragmentPaused (Landroidx/fragment/app/FragmentManager;Landroidx/fragment/app/Fragment;)V
+	public fun onFragmentPreAttached (Landroidx/fragment/app/FragmentManager;Landroidx/fragment/app/Fragment;Landroid/content/Context;)V
+	public fun onFragmentPreCreated (Landroidx/fragment/app/FragmentManager;Landroidx/fragment/app/Fragment;Landroid/os/Bundle;)V
+	public fun onFragmentResumed (Landroidx/fragment/app/FragmentManager;Landroidx/fragment/app/Fragment;)V
+	public fun onFragmentSaveInstanceState (Landroidx/fragment/app/FragmentManager;Landroidx/fragment/app/Fragment;Landroid/os/Bundle;)V
+	public fun onFragmentStarted (Landroidx/fragment/app/FragmentManager;Landroidx/fragment/app/Fragment;)V
+	public fun onFragmentStopped (Landroidx/fragment/app/FragmentManager;Landroidx/fragment/app/Fragment;)V
+	public fun onFragmentViewCreated (Landroidx/fragment/app/FragmentManager;Landroidx/fragment/app/Fragment;Landroid/view/View;Landroid/os/Bundle;)V
+	public fun onFragmentViewDestroyed (Landroidx/fragment/app/FragmentManager;Landroidx/fragment/app/Fragment;)V
+}
+

--- a/instrumentation/httpurlconnection/agent/api/agent.api
+++ b/instrumentation/httpurlconnection/agent/api/agent.api
@@ -1,0 +1,8 @@
+public class io/opentelemetry/instrumentation/agent/httpurlconnection/HttpUrlConnectionPlugin : net/bytebuddy/build/Plugin {
+	public fun <init> (Lnet/bytebuddy/build/AndroidDescriptor;)V
+	public fun apply (Lnet/bytebuddy/dynamic/DynamicType$Builder;Lnet/bytebuddy/description/type/TypeDescription;Lnet/bytebuddy/dynamic/ClassFileLocator;)Lnet/bytebuddy/dynamic/DynamicType$Builder;
+	public fun close ()V
+	public synthetic fun matches (Ljava/lang/Object;)Z
+	public fun matches (Lnet/bytebuddy/description/type/TypeDescription;)Z
+}
+

--- a/instrumentation/httpurlconnection/library/api/library.api
+++ b/instrumentation/httpurlconnection/library/api/library.api
@@ -1,0 +1,89 @@
+public class io/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public fun <init> ()V
+	public fun addAttributesExtractor (Lio/opentelemetry/instrumentation/api/instrumenter/AttributesExtractor;)V
+	public fun emitExperimentalHttpClientMetrics ()Z
+	public fun getAdditionalExtractors ()Ljava/util/List;
+	public fun getCapturedRequestHeaders ()Ljava/util/List;
+	public fun getCapturedResponseHeaders ()Ljava/util/List;
+	public fun getKnownMethods ()Ljava/util/Set;
+	public fun getName ()Ljava/lang/String;
+	public fun getReportIdleConnectionInterval ()J
+	public fun getReportIdleConnectionRunnable ()Ljava/lang/Runnable;
+	public fun install (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
+	public fun newPeerServiceResolver ()Lio/opentelemetry/instrumentation/api/incubator/semconv/net/PeerServiceResolver;
+	public fun setCapturedRequestHeaders (Ljava/util/List;)V
+	public fun setCapturedResponseHeaders (Ljava/util/List;)V
+	public fun setConnectionInactivityTimeoutMs (J)V
+	public fun setConnectionInactivityTimeoutMsForTesting (J)V
+	public fun setEmitExperimentalHttpClientMetrics (Z)V
+	public fun setKnownMethods (Ljava/util/Set;)V
+	public fun setPeerServiceMapping (Ljava/util/Map;)V
+}
+
+public class io/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlReplacements {
+	public static final field UNKNOWN_RESPONSE_CODE I
+	public fun <init> ()V
+	public static fun replacementForConnect (Ljava/net/URLConnection;)V
+	public static fun replacementForContent (Ljava/net/URLConnection;)Ljava/lang/Object;
+	public static fun replacementForContent (Ljava/net/URLConnection;[Ljava/lang/Class;)Ljava/lang/Object;
+	public static fun replacementForContentEncoding (Ljava/net/URLConnection;)Ljava/lang/String;
+	public static fun replacementForContentLength (Ljava/net/URLConnection;)I
+	public static fun replacementForContentLengthLong (Ljava/net/URLConnection;)J
+	public static fun replacementForContentType (Ljava/net/URLConnection;)Ljava/lang/String;
+	public static fun replacementForDate (Ljava/net/URLConnection;)J
+	public static fun replacementForDisconnect (Ljava/net/HttpURLConnection;)V
+	public static fun replacementForErrorStream (Ljava/net/HttpURLConnection;)Ljava/io/InputStream;
+	public static fun replacementForExpiration (Ljava/net/URLConnection;)J
+	public static fun replacementForHeaderField (Ljava/net/URLConnection;I)Ljava/lang/String;
+	public static fun replacementForHeaderField (Ljava/net/URLConnection;Ljava/lang/String;)Ljava/lang/String;
+	public static fun replacementForHeaderFieldDate (Ljava/net/URLConnection;Ljava/lang/String;J)J
+	public static fun replacementForHeaderFieldInt (Ljava/net/URLConnection;Ljava/lang/String;I)I
+	public static fun replacementForHeaderFieldKey (Ljava/net/URLConnection;I)Ljava/lang/String;
+	public static fun replacementForHeaderFieldLong (Ljava/net/URLConnection;Ljava/lang/String;J)J
+	public static fun replacementForHeaderFields (Ljava/net/URLConnection;)Ljava/util/Map;
+	public static fun replacementForHttpHeaderField (Ljava/net/HttpURLConnection;I)Ljava/lang/String;
+	public static fun replacementForHttpHeaderFieldDate (Ljava/net/HttpURLConnection;Ljava/lang/String;J)J
+	public static fun replacementForHttpHeaderFieldKey (Ljava/net/HttpURLConnection;I)Ljava/lang/String;
+	public static fun replacementForInputStream (Ljava/net/URLConnection;)Ljava/io/InputStream;
+	public static fun replacementForLastModified (Ljava/net/URLConnection;)J
+	public static fun replacementForOutputStream (Ljava/net/URLConnection;)Ljava/io/OutputStream;
+	public static fun replacementForResponseCode (Ljava/net/URLConnection;)I
+	public static fun replacementForResponseMessage (Ljava/net/URLConnection;)Ljava/lang/String;
+}
+
+public final class io/opentelemetry/instrumentation/library/httpurlconnection/internal/HttpUrlConnectionSingletons {
+	public static fun configure (Lio/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlInstrumentation;Lio/opentelemetry/api/OpenTelemetry;)V
+	public static fun instrumenter ()Lio/opentelemetry/instrumentation/api/instrumenter/Instrumenter;
+	public static fun openTelemetryInstance ()Lio/opentelemetry/api/OpenTelemetry;
+}
+
+public class io/opentelemetry/instrumentation/library/httpurlconnection/internal/HttpUrlHttpAttributesGetter : io/opentelemetry/instrumentation/api/semconv/http/HttpClientAttributesGetter {
+	public fun <init> ()V
+	public synthetic fun getHttpRequestHeader (Ljava/lang/Object;Ljava/lang/String;)Ljava/util/List;
+	public fun getHttpRequestHeader (Ljava/net/URLConnection;Ljava/lang/String;)Ljava/util/List;
+	public synthetic fun getHttpRequestMethod (Ljava/lang/Object;)Ljava/lang/String;
+	public fun getHttpRequestMethod (Ljava/net/URLConnection;)Ljava/lang/String;
+	public synthetic fun getHttpResponseHeader (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/String;)Ljava/util/List;
+	public fun getHttpResponseHeader (Ljava/net/URLConnection;Ljava/lang/Integer;Ljava/lang/String;)Ljava/util/List;
+	public synthetic fun getHttpResponseStatusCode (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Throwable;)Ljava/lang/Integer;
+	public fun getHttpResponseStatusCode (Ljava/net/URLConnection;Ljava/lang/Integer;Ljava/lang/Throwable;)Ljava/lang/Integer;
+	public synthetic fun getNetworkProtocolName (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/String;
+	public fun getNetworkProtocolName (Ljava/net/URLConnection;Ljava/lang/Integer;)Ljava/lang/String;
+	public synthetic fun getNetworkProtocolVersion (Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/String;
+	public fun getNetworkProtocolVersion (Ljava/net/URLConnection;Ljava/lang/Integer;)Ljava/lang/String;
+	public synthetic fun getServerAddress (Ljava/lang/Object;)Ljava/lang/String;
+	public fun getServerAddress (Ljava/net/URLConnection;)Ljava/lang/String;
+	public synthetic fun getServerPort (Ljava/lang/Object;)Ljava/lang/Integer;
+	public fun getServerPort (Ljava/net/URLConnection;)Ljava/lang/Integer;
+	public synthetic fun getUrlFull (Ljava/lang/Object;)Ljava/lang/String;
+	public fun getUrlFull (Ljava/net/URLConnection;)Ljava/lang/String;
+}
+
+public final class io/opentelemetry/instrumentation/library/httpurlconnection/internal/RequestPropertySetter : java/lang/Enum, io/opentelemetry/context/propagation/TextMapSetter {
+	public static final field INSTANCE Lio/opentelemetry/instrumentation/library/httpurlconnection/internal/RequestPropertySetter;
+	public synthetic fun set (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;)V
+	public fun set (Ljava/net/URLConnection;Ljava/lang/String;Ljava/lang/String;)V
+	public static fun valueOf (Ljava/lang/String;)Lio/opentelemetry/instrumentation/library/httpurlconnection/internal/RequestPropertySetter;
+	public static fun values ()[Lio/opentelemetry/instrumentation/library/httpurlconnection/internal/RequestPropertySetter;
+}
+

--- a/instrumentation/network/api/network.api
+++ b/instrumentation/network/api/network.api
@@ -1,0 +1,14 @@
+public final class io/opentelemetry/android/instrumentation/network/NetworkApplicationListenerKt {
+	public static final fun getNETWORK_STATUS_KEY ()Lio/opentelemetry/api/common/AttributeKey;
+}
+
+public abstract interface class io/opentelemetry/android/instrumentation/network/NetworkAttributesExtractor : kotlin/jvm/functions/Function2 {
+}
+
+public final class io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public fun <init> ()V
+	public final fun addAttributesExtractor (Lio/opentelemetry/android/instrumentation/network/NetworkAttributesExtractor;)Lio/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentation;
+	public fun getName ()Ljava/lang/String;
+	public fun install (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
+}
+

--- a/instrumentation/okhttp3-websocket/agent/api/agent.api
+++ b/instrumentation/okhttp3-websocket/agent/api/agent.api
@@ -1,0 +1,13 @@
+public class io/opentelemetry/instrumentation/agent/okhttp/v3_0/websocket/OkHttpClientWebsocketAdvice {
+	public fun <init> ()V
+	public static fun enter (Lokhttp3/WebSocketListener;)V
+}
+
+public class io/opentelemetry/instrumentation/agent/okhttp/v3_0/websocket/OkHttpClientWebsocketPlugin : net/bytebuddy/build/Plugin {
+	public fun <init> ()V
+	public fun apply (Lnet/bytebuddy/dynamic/DynamicType$Builder;Lnet/bytebuddy/description/type/TypeDescription;Lnet/bytebuddy/dynamic/ClassFileLocator;)Lnet/bytebuddy/dynamic/DynamicType$Builder;
+	public fun close ()V
+	public synthetic fun matches (Ljava/lang/Object;)Z
+	public fun matches (Lnet/bytebuddy/description/type/TypeDescription;)Z
+}
+

--- a/instrumentation/okhttp3-websocket/library/api/library.api
+++ b/instrumentation/okhttp3-websocket/library/api/library.api
@@ -1,0 +1,26 @@
+public class io/opentelemetry/instrumentation/library/okhttp/v3_0/websocket/internal/OkHttpWebsocketInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public static final field INSTRUMENTATION_NAME Ljava/lang/String;
+	public fun <init> ()V
+	public fun getName ()Ljava/lang/String;
+	public fun install (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
+}
+
+public class io/opentelemetry/instrumentation/library/okhttp/v3_0/websocket/internal/WebsocketAttributes {
+	public static field MESSAGE_SIZE Lio/opentelemetry/api/common/AttributeKey;
+	public static field MESSAGE_TYPE Lio/opentelemetry/api/common/AttributeKey;
+}
+
+public final class io/opentelemetry/instrumentation/library/okhttp/v3_0/websocket/internal/WebsocketEventGenerator {
+	public static fun configure (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
+	public static fun generateEvent (Ljava/lang/String;Lio/opentelemetry/api/common/Attributes;)V
+}
+
+public class io/opentelemetry/instrumentation/library/okhttp/v3_0/websocket/internal/WebsocketListenerWrapper : okhttp3/WebSocketListener {
+	public fun <init> (Lokhttp3/WebSocketListener;)V
+	public fun onClosed (Lokhttp3/WebSocket;ILjava/lang/String;)V
+	public fun onFailure (Lokhttp3/WebSocket;Ljava/lang/Throwable;Lokhttp3/Response;)V
+	public fun onMessage (Lokhttp3/WebSocket;Ljava/lang/String;)V
+	public fun onMessage (Lokhttp3/WebSocket;Lokio/ByteString;)V
+	public fun onOpen (Lokhttp3/WebSocket;Lokhttp3/Response;)V
+}
+

--- a/instrumentation/okhttp3/agent/api/agent.api
+++ b/instrumentation/okhttp3/agent/api/agent.api
@@ -1,0 +1,26 @@
+public class io/opentelemetry/instrumentation/agent/okhttp/v3_0/OkHttpClientAdvice {
+	public fun <init> ()V
+	public static fun enter (Lokhttp3/OkHttpClient$Builder;)V
+}
+
+public class io/opentelemetry/instrumentation/agent/okhttp/v3_0/OkHttpClientPlugin : net/bytebuddy/build/Plugin {
+	public fun <init> ()V
+	public fun apply (Lnet/bytebuddy/dynamic/DynamicType$Builder;Lnet/bytebuddy/description/type/TypeDescription;Lnet/bytebuddy/dynamic/ClassFileLocator;)Lnet/bytebuddy/dynamic/DynamicType$Builder;
+	public fun close ()V
+	public synthetic fun matches (Ljava/lang/Object;)Z
+	public fun matches (Lnet/bytebuddy/description/type/TypeDescription;)Z
+}
+
+public class io/opentelemetry/instrumentation/agent/okhttp/v3_0/callback/OkHttpCallbackAdvice {
+	public fun <init> ()V
+	public static fun enter (Lokhttp3/Call;Lokhttp3/Callback;)V
+}
+
+public class io/opentelemetry/instrumentation/agent/okhttp/v3_0/callback/OkHttpCallbackPlugin : net/bytebuddy/build/Plugin {
+	public fun <init> ()V
+	public fun apply (Lnet/bytebuddy/dynamic/DynamicType$Builder;Lnet/bytebuddy/description/type/TypeDescription;Lnet/bytebuddy/dynamic/ClassFileLocator;)Lnet/bytebuddy/dynamic/DynamicType$Builder;
+	public fun close ()V
+	public synthetic fun matches (Ljava/lang/Object;)Z
+	public fun matches (Lnet/bytebuddy/description/type/TypeDescription;)Z
+}
+

--- a/instrumentation/okhttp3/library/api/library.api
+++ b/instrumentation/okhttp3/library/api/library.api
@@ -1,0 +1,38 @@
+public class io/opentelemetry/instrumentation/library/okhttp/v3_0/OkHttpInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public fun <init> ()V
+	public fun addAttributesExtractor (Lio/opentelemetry/instrumentation/api/instrumenter/AttributesExtractor;)V
+	public fun emitExperimentalHttpClientTelemetry ()Z
+	public fun getAdditionalExtractors ()Ljava/util/List;
+	public fun getCapturedRequestHeaders ()Ljava/util/List;
+	public fun getCapturedResponseHeaders ()Ljava/util/List;
+	public fun getKnownMethods ()Ljava/util/Set;
+	public fun getName ()Ljava/lang/String;
+	public fun install (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
+	public fun newPeerServiceResolver ()Lio/opentelemetry/instrumentation/api/incubator/semconv/net/PeerServiceResolver;
+	public fun setCapturedRequestHeaders (Ljava/util/List;)V
+	public fun setCapturedResponseHeaders (Ljava/util/List;)V
+	public fun setEmitExperimentalHttpClientTelemetry (Z)V
+	public fun setKnownMethods (Ljava/util/Set;)V
+	public fun setPeerServiceMapping (Ljava/util/Map;)V
+}
+
+public final class io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttp3Singletons {
+	public static final field CALLBACK_CONTEXT_INTERCEPTOR Lokhttp3/Interceptor;
+	public static field CONNECTION_ERROR_INTERCEPTOR Lokhttp3/Interceptor;
+	public static final field RESEND_COUNT_CONTEXT_INTERCEPTOR Lokhttp3/Interceptor;
+	public static field TRACING_INTERCEPTOR Lokhttp3/Interceptor;
+	public static fun configure (Lio/opentelemetry/instrumentation/library/okhttp/v3_0/OkHttpInstrumentation;Lio/opentelemetry/api/OpenTelemetry;)V
+}
+
+public final class io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/OkHttpCallbackAdviceHelper {
+	public fun <init> ()V
+	public static fun propagateContext (Lokhttp3/Call;)Z
+	public static fun tryRecoverPropagatedContextFromCallback (Lokhttp3/Request;)Lio/opentelemetry/context/Context;
+}
+
+public final class io/opentelemetry/instrumentation/library/okhttp/v3_0/internal/TracingCallback : okhttp3/Callback {
+	public fun <init> (Lokhttp3/Callback;Lio/opentelemetry/context/Context;)V
+	public fun onFailure (Lokhttp3/Call;Ljava/io/IOException;)V
+	public fun onResponse (Lokhttp3/Call;Lokhttp3/Response;)V
+}
+

--- a/instrumentation/sessions/api/sessions.api
+++ b/instrumentation/sessions/api/sessions.api
@@ -1,0 +1,6 @@
+public final class io/opentelemetry/android/instrumentation/sessions/SessionInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public fun <init> ()V
+	public fun getName ()Ljava/lang/String;
+	public fun install (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
+}
+

--- a/instrumentation/slowrendering/api/slowrendering.api
+++ b/instrumentation/slowrendering/api/slowrendering.api
@@ -1,0 +1,8 @@
+public final class io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public fun <init> ()V
+	public fun getName ()Ljava/lang/String;
+	public fun install (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
+	public fun setSlowRenderingDetectionPollInterval (Ljava/time/Duration;)Lio/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentation;
+	public fun uninstall (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
+}
+

--- a/instrumentation/startup/api/startup.api
+++ b/instrumentation/startup/api/startup.api
@@ -1,0 +1,20 @@
+public final class io/opentelemetry/android/instrumentation/startup/SdkInitializationEvents : io/opentelemetry/android/internal/initialization/InitializationEvents {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/function/Supplier;)V
+	public synthetic fun <init> (Ljava/util/function/Supplier;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun anrMonitorInitialized ()V
+	public fun crashReportingInitialized ()V
+	public fun currentNetworkProviderInitialized ()V
+	public fun networkMonitorInitialized ()V
+	public fun recordConfiguration (Lio/opentelemetry/android/config/OtelRumConfig;)V
+	public fun sdkInitializationStarted ()V
+	public fun slowRenderingDetectorInitialized ()V
+	public fun spanExporterInitialized (Lio/opentelemetry/sdk/trace/export/SpanExporter;)V
+}
+
+public final class io/opentelemetry/android/instrumentation/startup/StartupInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public fun <init> ()V
+	public fun getName ()Ljava/lang/String;
+	public fun install (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
+}
+

--- a/instrumentation/view-click/api/view-click.api
+++ b/instrumentation/view-click/api/view-click.api
@@ -1,0 +1,52 @@
+public final class io/opentelemetry/android/instrumentation/view/click/ViewClickActivityCallback : io/opentelemetry/android/internal/services/visiblescreen/activities/DefaultingActivityLifecycleCallbacks {
+	public fun <init> (Lio/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator;)V
+	public fun onActivityPaused (Landroid/app/Activity;)V
+	public fun onActivityResumed (Landroid/app/Activity;)V
+}
+
+public final class io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator {
+	public fun <init> (Lio/opentelemetry/api/incubator/logs/ExtendedLogger;)V
+	public final fun generateClick (Landroid/view/MotionEvent;)V
+	public final fun startTracking (Landroid/view/Window;)V
+	public final fun stopTracking ()V
+}
+
+public final class io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public fun <init> ()V
+	public fun getName ()Ljava/lang/String;
+	public fun install (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
+}
+
+public final class io/opentelemetry/android/instrumentation/view/click/WindowCallbackWrapper : android/view/Window$Callback {
+	public fun <init> (Landroid/view/Window$Callback;Lio/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator;)V
+	public fun dispatchGenericMotionEvent (Landroid/view/MotionEvent;)Z
+	public fun dispatchKeyEvent (Landroid/view/KeyEvent;)Z
+	public fun dispatchKeyShortcutEvent (Landroid/view/KeyEvent;)Z
+	public fun dispatchPopulateAccessibilityEvent (Landroid/view/accessibility/AccessibilityEvent;)Z
+	public fun dispatchTouchEvent (Landroid/view/MotionEvent;)Z
+	public fun dispatchTrackballEvent (Landroid/view/MotionEvent;)Z
+	public fun onActionModeFinished (Landroid/view/ActionMode;)V
+	public fun onActionModeStarted (Landroid/view/ActionMode;)V
+	public fun onAttachedToWindow ()V
+	public fun onContentChanged ()V
+	public fun onCreatePanelMenu (ILandroid/view/Menu;)Z
+	public fun onCreatePanelView (I)Landroid/view/View;
+	public fun onDetachedFromWindow ()V
+	public fun onMenuItemSelected (ILandroid/view/MenuItem;)Z
+	public fun onMenuOpened (ILandroid/view/Menu;)Z
+	public fun onPanelClosed (ILandroid/view/Menu;)V
+	public fun onPreparePanel (ILandroid/view/View;Landroid/view/Menu;)Z
+	public fun onSearchRequested ()Z
+	public fun onSearchRequested (Landroid/view/SearchEvent;)Z
+	public fun onWindowAttributesChanged (Landroid/view/WindowManager$LayoutParams;)V
+	public fun onWindowFocusChanged (Z)V
+	public fun onWindowStartingActionMode (Landroid/view/ActionMode$Callback;)Landroid/view/ActionMode;
+	public fun onWindowStartingActionMode (Landroid/view/ActionMode$Callback;I)Landroid/view/ActionMode;
+	public final fun unwrap ()Landroid/view/Window$Callback;
+}
+
+public final class io/opentelemetry/android/instrumentation/view/click/internal/ViewUtilsKt {
+	public static final field APP_SCREEN_CLICK_EVENT_NAME Ljava/lang/String;
+	public static final field VIEW_CLICK_EVENT_NAME Ljava/lang/String;
+}
+

--- a/instrumentation/volley/library/api/library.api
+++ b/instrumentation/volley/library/api/library.api
@@ -1,0 +1,20 @@
+public final class io/opentelemetry/android/instrumentation/volley/RequestWrapper {
+	public fun getAdditionalHeaders ()Ljava/util/Map;
+	public fun getRequest ()Lcom/android/volley/Request;
+}
+
+public final class io/opentelemetry/android/instrumentation/volley/VolleyTracing {
+	public static fun builder (Lio/opentelemetry/api/OpenTelemetry;)Lio/opentelemetry/android/instrumentation/volley/VolleyTracingBuilder;
+	public static fun create (Lio/opentelemetry/api/OpenTelemetry;)Lio/opentelemetry/android/instrumentation/volley/VolleyTracing;
+	public fun newHurlStack ()Lcom/android/volley/toolbox/HurlStack;
+	public fun newHurlStack (Lcom/android/volley/toolbox/HurlStack$UrlRewriter;)Lcom/android/volley/toolbox/HurlStack;
+	public fun newHurlStack (Lcom/android/volley/toolbox/HurlStack$UrlRewriter;Ljavax/net/ssl/SSLSocketFactory;)Lcom/android/volley/toolbox/HurlStack;
+}
+
+public final class io/opentelemetry/android/instrumentation/volley/VolleyTracingBuilder {
+	public fun addAttributesExtractor (Lio/opentelemetry/instrumentation/api/instrumenter/AttributesExtractor;)Lio/opentelemetry/android/instrumentation/volley/VolleyTracingBuilder;
+	public fun build ()Lio/opentelemetry/android/instrumentation/volley/VolleyTracing;
+	public fun setCapturedRequestHeaders (Ljava/util/List;)Lio/opentelemetry/android/instrumentation/volley/VolleyTracingBuilder;
+	public fun setCapturedResponseHeaders (Ljava/util/List;)Lio/opentelemetry/android/instrumentation/volley/VolleyTracingBuilder;
+}
+

--- a/services/api/services.api
+++ b/services/api/services.api
@@ -1,0 +1,122 @@
+public class io/opentelemetry/android/internal/services/CacheStorage {
+	public fun <init> (Landroid/content/Context;)V
+	public fun getCacheDir ()Ljava/io/File;
+}
+
+public final class io/opentelemetry/android/internal/services/Preferences {
+	public final fun retrieveInt (Ljava/lang/String;I)I
+	public final fun store (Ljava/lang/String;I)V
+}
+
+public final class io/opentelemetry/android/internal/services/Services {
+	public static final field Companion Lio/opentelemetry/android/internal/services/Services$Companion;
+	public static final fun get (Landroid/app/Application;)Lio/opentelemetry/android/internal/services/Services;
+	public final fun getAppLifecycle ()Lio/opentelemetry/android/internal/services/applifecycle/AppLifecycle;
+	public final fun getCacheStorage ()Lio/opentelemetry/android/internal/services/CacheStorage;
+	public final fun getCurrentNetworkProvider ()Lio/opentelemetry/android/internal/services/network/CurrentNetworkProvider;
+	public final fun getPeriodicWork ()Lio/opentelemetry/android/internal/services/periodicwork/PeriodicWork;
+	public final fun getPreferences ()Lio/opentelemetry/android/internal/services/Preferences;
+	public final fun getVisibleScreenTracker ()Lio/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTracker;
+	public static final fun set (Lio/opentelemetry/android/internal/services/Services;)V
+}
+
+public final class io/opentelemetry/android/internal/services/Services$Companion {
+	public final fun get (Landroid/app/Application;)Lio/opentelemetry/android/internal/services/Services;
+	public final fun set (Lio/opentelemetry/android/internal/services/Services;)V
+}
+
+public final class io/opentelemetry/android/internal/services/applifecycle/AppLifecycle {
+	public final fun registerListener (Lio/opentelemetry/android/internal/services/applifecycle/ApplicationStateListener;)V
+}
+
+public abstract interface class io/opentelemetry/android/internal/services/applifecycle/ApplicationStateListener {
+	public abstract fun onApplicationBackgrounded ()V
+	public abstract fun onApplicationForegrounded ()V
+}
+
+public class io/opentelemetry/android/internal/services/network/CarrierFinder {
+	public fun <init> (Landroid/telephony/TelephonyManager;)V
+	public fun get ()Lio/opentelemetry/android/common/internal/features/networkattributes/data/Carrier;
+}
+
+public final class io/opentelemetry/android/internal/services/network/CurrentNetworkProvider {
+	public static final field NO_NETWORK Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;
+	public static final field UNKNOWN_NETWORK Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;
+	public fun <init> (Lio/opentelemetry/android/internal/services/network/detector/NetworkDetector;Landroid/net/ConnectivityManager;)V
+	public fun addNetworkChangeListener (Lio/opentelemetry/android/internal/services/network/NetworkChangeListener;)V
+	public fun getCurrentNetwork ()Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;
+	public fun refreshNetworkStatus ()Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;
+}
+
+public abstract interface class io/opentelemetry/android/internal/services/network/NetworkChangeListener {
+	public abstract fun onNetworkChange (Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;)V
+}
+
+public abstract interface class io/opentelemetry/android/internal/services/network/detector/NetworkDetector {
+	public static final field Companion Lio/opentelemetry/android/internal/services/network/detector/NetworkDetector$Companion;
+	public static fun create (Landroid/content/Context;)Lio/opentelemetry/android/internal/services/network/detector/NetworkDetector;
+	public abstract fun detectCurrentNetwork ()Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;
+}
+
+public final class io/opentelemetry/android/internal/services/network/detector/NetworkDetector$Companion {
+	public final fun create (Landroid/content/Context;)Lio/opentelemetry/android/internal/services/network/detector/NetworkDetector;
+}
+
+public final class io/opentelemetry/android/internal/services/network/detector/PostApi28NetworkDetectorKt {
+	public static final fun canReadPhoneState (Landroid/content/Context;)Z
+}
+
+public abstract class io/opentelemetry/android/internal/services/periodicwork/PeriodicRunnable : java/lang/Runnable {
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public abstract fun minimumDelayUntilNextRunInMillis ()J
+	public abstract fun onRun ()V
+	public final fun run ()V
+	public abstract fun shouldStopRunning ()Z
+}
+
+public final class io/opentelemetry/android/internal/services/periodicwork/PeriodicWork {
+	public final fun enqueue (Ljava/lang/Runnable;)V
+}
+
+public final class io/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTracker {
+	public final fun activityPaused (Landroid/app/Activity;)V
+	public final fun activityResumed (Landroid/app/Activity;)V
+	public final fun fragmentPaused (Landroidx/fragment/app/Fragment;)V
+	public final fun fragmentResumed (Landroidx/fragment/app/Fragment;)V
+	public final fun getCurrentlyVisibleScreen ()Ljava/lang/String;
+	public final fun getPreviouslyVisibleScreen ()Ljava/lang/String;
+}
+
+public abstract interface class io/opentelemetry/android/internal/services/visiblescreen/activities/DefaultingActivityLifecycleCallbacks : android/app/Application$ActivityLifecycleCallbacks {
+	public fun onActivityCreated (Landroid/app/Activity;Landroid/os/Bundle;)V
+	public fun onActivityDestroyed (Landroid/app/Activity;)V
+	public fun onActivityPaused (Landroid/app/Activity;)V
+	public fun onActivityResumed (Landroid/app/Activity;)V
+	public fun onActivitySaveInstanceState (Landroid/app/Activity;Landroid/os/Bundle;)V
+	public fun onActivityStarted (Landroid/app/Activity;)V
+	public fun onActivityStopped (Landroid/app/Activity;)V
+}
+
+public final class io/opentelemetry/android/internal/services/visiblescreen/activities/Pre29VisibleScreenLifecycleBinding : io/opentelemetry/android/internal/services/visiblescreen/activities/DefaultingActivityLifecycleCallbacks {
+	public fun <init> (Lio/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTracker;)V
+	public fun onActivityPaused (Landroid/app/Activity;)V
+	public fun onActivityResumed (Landroid/app/Activity;)V
+}
+
+public final class io/opentelemetry/android/internal/services/visiblescreen/activities/VisibleScreenLifecycleBinding : io/opentelemetry/android/internal/services/visiblescreen/activities/DefaultingActivityLifecycleCallbacks {
+	public fun <init> (Lio/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTracker;)V
+	public fun onActivityPostResumed (Landroid/app/Activity;)V
+	public fun onActivityPrePaused (Landroid/app/Activity;)V
+}
+
+public class io/opentelemetry/android/internal/services/visiblescreen/fragments/RumFragmentActivityRegisterer {
+	public static fun create (Landroidx/fragment/app/FragmentManager$FragmentLifecycleCallbacks;)Landroid/app/Application$ActivityLifecycleCallbacks;
+	public static fun createPre29 (Landroidx/fragment/app/FragmentManager$FragmentLifecycleCallbacks;)Landroid/app/Application$ActivityLifecycleCallbacks;
+}
+
+public final class io/opentelemetry/android/internal/services/visiblescreen/fragments/VisibleFragmentTracker : androidx/fragment/app/FragmentManager$FragmentLifecycleCallbacks {
+	public fun <init> (Lio/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTracker;)V
+	public fun onFragmentPaused (Landroidx/fragment/app/FragmentManager;Landroidx/fragment/app/Fragment;)V
+	public fun onFragmentResumed (Landroidx/fragment/app/FragmentManager;Landroidx/fragment/app/Fragment;)V
+}
+

--- a/session/api/session.api
+++ b/session/api/session.api
@@ -1,0 +1,40 @@
+public abstract interface class io/opentelemetry/android/session/Session {
+	public static final field Companion Lio/opentelemetry/android/session/Session$Companion;
+	public abstract fun getId ()Ljava/lang/String;
+	public abstract fun getStartTimestamp ()J
+}
+
+public final class io/opentelemetry/android/session/Session$Companion {
+	public final fun getNONE ()Lio/opentelemetry/android/session/Session$DefaultSession;
+}
+
+public final class io/opentelemetry/android/session/Session$DefaultSession : io/opentelemetry/android/session/Session {
+	public fun <init> (Ljava/lang/String;J)V
+	public final fun copy (Ljava/lang/String;J)Lio/opentelemetry/android/session/Session$DefaultSession;
+	public static synthetic fun copy$default (Lio/opentelemetry/android/session/Session$DefaultSession;Ljava/lang/String;JILjava/lang/Object;)Lio/opentelemetry/android/session/Session$DefaultSession;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getId ()Ljava/lang/String;
+	public fun getStartTimestamp ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/opentelemetry/android/session/SessionObserver {
+	public abstract fun onSessionEnded (Lio/opentelemetry/android/session/Session;)V
+	public abstract fun onSessionStarted (Lio/opentelemetry/android/session/Session;Lio/opentelemetry/android/session/Session;)V
+}
+
+public abstract interface class io/opentelemetry/android/session/SessionProvider {
+	public static final field Companion Lio/opentelemetry/android/session/SessionProvider$Companion;
+	public static fun getNoop ()Lio/opentelemetry/android/session/SessionProvider;
+	public abstract fun getSessionId ()Ljava/lang/String;
+}
+
+public final class io/opentelemetry/android/session/SessionProvider$Companion {
+	public final fun getNoop ()Lio/opentelemetry/android/session/SessionProvider;
+}
+
+public abstract interface class io/opentelemetry/android/session/SessionPublisher {
+	public abstract fun addObserver (Lio/opentelemetry/android/session/SessionObserver;)V
+}
+


### PR DESCRIPTION
## Goal

This changeset adds Kotlin's [binary compatibility validator](https://github.com/Kotlin/binary-compatibility-validator) which generates a dump of API signatures and checks whether the project source code matches the known dump, thus allowing any API changes to be detected. The project works on Java & Kotlin files that are publicly exposed. `./gradlew apiCheck` runs the task, `./gradlew apiDump` regenerates the API dump file. The check will automatically run with `./gradlew check` so CI should catch any regressions/changes in the public API.

I've added this to any module that applies the `otel.android-library-conventions` gradle script and have generated a dump file for the existing APIs.

Closes #217