### PR TITLE
Remove READ_PHONE_STATE permission and update docs

### DIFF
--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -3,6 +3,5 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
 
 </manifest>

--- a/instrumentation/network/README.md
+++ b/instrumentation/network/README.md
@@ -28,6 +28,11 @@ This instrumentation produces the following telemetry:
 Note: This instrumentation supports additional user-configurable `AttributeExtractors` that
 may set additional attributes when given a `CurrentNetwork` instance.
 
+The `CurrentNetworkAttributesExtractor` class is configured by default and provides additional information about the
+current network, depending on the Android version and permissions granted. In particular:
+- Detailed information about the carrier for mobile network connections is only available for Android 9+.
+- The [READ_PHONE_STATE](https://developer.android.com/reference/android/Manifest.permission#READ_PHONE_STATE) permission is required to extract the type of mobile network connection (e.g. LTE, 5G, etc.).
+
 ## Installation
 
 This instrumentation comes with the [android agent](../../android-agent) out of the box, so

--- a/services/src/main/AndroidManifest.xml
+++ b/services/src/main/AndroidManifest.xml
@@ -3,6 +3,5 @@
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
 
 </manifest>

--- a/services/src/main/java/io/opentelemetry/android/internal/services/network/detector/PostApi28NetworkDetector.kt
+++ b/services/src/main/java/io/opentelemetry/android/internal/services/network/detector/PostApi28NetworkDetector.kt
@@ -6,9 +6,8 @@
 package io.opentelemetry.android.internal.services.network.detector
 
 import android.Manifest
-import android.annotation.SuppressLint
 import android.content.Context
-import android.content.pm.PackageManager
+import android.content.pm.PackageManager.PERMISSION_GRANTED
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.os.Build
@@ -34,7 +33,7 @@ import android.telephony.TelephonyManager.NETWORK_TYPE_TD_SCDMA
 import android.telephony.TelephonyManager.NETWORK_TYPE_UMTS
 import android.telephony.TelephonyManager.NETWORK_TYPE_UNKNOWN
 import androidx.annotation.RequiresApi
-import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import io.opentelemetry.android.common.internal.features.networkattributes.data.Carrier
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
 import io.opentelemetry.android.common.internal.features.networkattributes.data.NetworkState
@@ -56,9 +55,10 @@ internal class PostApi28NetworkDetector
         private val telephonyManager: TelephonyManager,
         private val carrierFinder: CarrierFinder,
         private val context: Context,
-        private val readPhoneState: () -> Boolean = { canReadPhoneState(context) },
+        private val readPhoneState: () -> Boolean = {
+            ContextCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE) == PERMISSION_GRANTED
+        },
     ) : NetworkDetector {
-        @SuppressLint("MissingPermission")
         override fun detectCurrentNetwork(): CurrentNetwork {
             val capabilities =
                 connectivityManager.getNetworkCapabilities(connectivityManager.activeNetwork)
@@ -79,47 +79,40 @@ internal class PostApi28NetworkDetector
         private fun buildFromCarrier(carrier: Carrier): (NetworkState) -> CurrentNetwork =
             { CurrentNetwork.builder(it).carrier(carrier).build() }
 
-        private fun withCellDataType(carrier: Carrier): CurrentNetwork {
-            val builder =
-                CurrentNetwork
-                    .builder(TRANSPORT_CELLULAR)
-                    .carrier(carrier)
-            if (readPhoneState()) {
-                val dataNetworkType = getDataNetworkTypeName(telephonyManager.dataNetworkType)
-                return builder.subType(dataNetworkType).build()
-            }
-            return builder.build()
-        }
+        private fun withCellDataType(carrier: Carrier): CurrentNetwork =
+            CurrentNetwork
+                .builder(TRANSPORT_CELLULAR)
+                .carrier(carrier)
+                .subType(getDataNetworkTypeName())
+                .build()
 
-        private fun getDataNetworkTypeName(dataNetworkType: Int): String =
-            when (dataNetworkType) {
-                NETWORK_TYPE_1xRTT -> "1xRTT"
-                NETWORK_TYPE_CDMA -> "CDMA"
-                NETWORK_TYPE_EDGE -> "EDGE"
-                NETWORK_TYPE_EHRPD -> "EHRPD"
-                NETWORK_TYPE_EVDO_0 -> "EVDO_0"
-                NETWORK_TYPE_EVDO_A -> "EVDO_A"
-                NETWORK_TYPE_EVDO_B -> "EVDO_B"
-                NETWORK_TYPE_GPRS -> "GPRS"
-                NETWORK_TYPE_GSM -> "GSM"
-                NETWORK_TYPE_HSDPA -> "HSDPA"
-                NETWORK_TYPE_HSPA -> "HSPA"
-                NETWORK_TYPE_HSPAP -> "HSPAP"
-                NETWORK_TYPE_HSUPA -> "HSUPA"
-                NETWORK_TYPE_IDEN -> "IDEN"
-                NETWORK_TYPE_IWLAN -> "IWLAN"
-                NETWORK_TYPE_LTE -> "LTE"
-                NETWORK_TYPE_NR -> "NR"
-                NETWORK_TYPE_TD_SCDMA -> "SCDMA"
-                NETWORK_TYPE_UMTS -> "UMTS"
-                NETWORK_TYPE_UNKNOWN -> "UNKNOWN"
-                else -> "UNKNOWN"
+        @Suppress("MissingPermission", "CyclomaticComplexMethod")
+        private fun getDataNetworkTypeName(): String? =
+            if (readPhoneState()) {
+                when (telephonyManager.dataNetworkType) {
+                    NETWORK_TYPE_1xRTT -> "1xRTT"
+                    NETWORK_TYPE_CDMA -> "CDMA"
+                    NETWORK_TYPE_EDGE -> "EDGE"
+                    NETWORK_TYPE_EHRPD -> "EHRPD"
+                    NETWORK_TYPE_EVDO_0 -> "EVDO_0"
+                    NETWORK_TYPE_EVDO_A -> "EVDO_A"
+                    NETWORK_TYPE_EVDO_B -> "EVDO_B"
+                    NETWORK_TYPE_GPRS -> "GPRS"
+                    NETWORK_TYPE_GSM -> "GSM"
+                    NETWORK_TYPE_HSDPA -> "HSDPA"
+                    NETWORK_TYPE_HSPA -> "HSPA"
+                    NETWORK_TYPE_HSPAP -> "HSPAP"
+                    NETWORK_TYPE_HSUPA -> "HSUPA"
+                    NETWORK_TYPE_IDEN -> "IDEN"
+                    NETWORK_TYPE_IWLAN -> "IWLAN"
+                    NETWORK_TYPE_LTE -> "LTE"
+                    NETWORK_TYPE_NR -> "NR"
+                    NETWORK_TYPE_TD_SCDMA -> "SCDMA"
+                    NETWORK_TYPE_UMTS -> "UMTS"
+                    NETWORK_TYPE_UNKNOWN -> "UNKNOWN"
+                    else -> "UNKNOWN"
+                }
+            } else {
+                null
             }
     }
-
-// visible for testing
-fun canReadPhoneState(context: Context): Boolean =
-    (
-        ActivityCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE)
-            == PackageManager.PERMISSION_GRANTED
-    )


### PR DESCRIPTION
Remove what the Android docs call a "dangerous" permission from the SDK manifest. This only affects one attribute - the network subtype for mobile connections (e.g. LTE, 5G, etc.), and SDK users can grant this permission in their own manifest and get this extra information. Otherwise, it won't be included.