### PR TITLE
Address android manifest namespace warning

### DIFF
--- a/instrumentation/okhttp3/testing/build.gradle.kts
+++ b/instrumentation/okhttp3/testing/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     id("net.bytebuddy.byte-buddy-gradle-plugin")
 }
 
+android.namespace = "io.opentelemetry.android.okhttp3"
+
 dependencies {
     byteBuddy(project(":instrumentation:okhttp3:agent"))
     implementation(project(":instrumentation:okhttp3:library"))


### PR DESCRIPTION
## Goal

Addresses a build warning about a namespace being used in multiple modules. I fixed this by setting a different namespace for the okhttp3 testing module.

> Task :instrumentation:okhttp3:testing:processDebugMainManifest
>/instrumentation/okhttp3/testing/src/main/AndroidManifest.xml Warning:
        Namespace 'io.opentelemetry.android' is used in multiple modules and/or libraries: AndroidManifest.xml, :core. Please ensure that all modules and libraries have a unique namespace. For more information, See https://developer.android.com/studio/build/configure-app-module#set-namespace
