### PR TITLE
Deprecate volley instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- Deprecate Volley HTTP instrumentation. This will be removed in 0.20.0.
+  Volley has [not seen a release in about 4 years](https://github.com/google/volley/releases)
+  and it is unlikely that it has much adoption. As a result, we have chosen to halt development
+  of the instrumentation in `opentelemetry-android`.
+
 ## Version 0.13.0 (2025-07-24)
 
 - Alter FilteringSpanExporter to leverage common code from contrib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   Volley has [not seen a release in about 4 years](https://github.com/google/volley/releases)
   and it is unlikely that it has much adoption. As a result, we have chosen to halt development
   of the instrumentation in `opentelemetry-android`.
+  [#1145](https://github.com/open-telemetry/opentelemetry-android/pull/1145)
 
 ## Version 0.13.0 (2025-07-24)
 

--- a/instrumentation/volley/README.md
+++ b/instrumentation/volley/README.md
@@ -1,7 +1,10 @@
 
 # OpenTelemetry Android Volley Instrumentation
 
-> :construction: &nbsp;Status: development
+> :warning: &nbsp;Status: DEPRECATED
+
+This instrumentation is deprecated and will be removed in a future release.
+It is not recommended to use this instrumentation in new deployments.
 
 This directory contains OpenTelemetry instrumentation for the [Volley](https://google.github.io/volley/)
 HTTP client library. If you use the Volley HTTP client in your Android application, you can

--- a/instrumentation/volley/library/src/main/java/io/opentelemetry/android/instrumentation/volley/VolleyTracing.java
+++ b/instrumentation/volley/library/src/main/java/io/opentelemetry/android/instrumentation/volley/VolleyTracing.java
@@ -6,7 +6,6 @@
 package io.opentelemetry.android.instrumentation.volley;
 
 import android.util.Log;
-
 import com.android.volley.toolbox.HttpResponse;
 import com.android.volley.toolbox.HurlStack;
 import io.opentelemetry.api.OpenTelemetry;
@@ -17,7 +16,9 @@ import javax.net.ssl.SSLSocketFactory;
 public final class VolleyTracing {
 
     static {
-        Log.w("OpenTelemetryRum", "The OpenTelemetry Android Volley Instrumentation is deprecated without replacement.");
+        Log.w(
+                "OpenTelemetryRum",
+                "The OpenTelemetry Android Volley Instrumentation is deprecated without replacement.");
     }
 
     /** Returns a new {@link VolleyTracing} configured with the given {@link OpenTelemetry}. */

--- a/instrumentation/volley/library/src/main/java/io/opentelemetry/android/instrumentation/volley/VolleyTracing.java
+++ b/instrumentation/volley/library/src/main/java/io/opentelemetry/android/instrumentation/volley/VolleyTracing.java
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.android.instrumentation.volley;
 
+import android.util.Log;
+
 import com.android.volley.toolbox.HttpResponse;
 import com.android.volley.toolbox.HurlStack;
 import io.opentelemetry.api.OpenTelemetry;
@@ -13,6 +15,10 @@ import javax.net.ssl.SSLSocketFactory;
 
 /** Entrypoint for tracing Volley clients. */
 public final class VolleyTracing {
+
+    static {
+        Log.w("OpenTelemetryRum", "The OpenTelemetry Android Volley Instrumentation is deprecated without replacement.");
+    }
 
     /** Returns a new {@link VolleyTracing} configured with the given {@link OpenTelemetry}. */
     public static VolleyTracing create(OpenTelemetry openTelemetry) {


### PR DESCRIPTION
As discussed today in the SIG, the Volley project has not had a release in ~4 years and we have chosen to deprecate it so that we may remove it in a future release.

This adds a changelog entry and logs a warning if someone uses it. 