### PR TITLE
Fix links in markdown

### DIFF
--- a/instrumentation/httpurlconnection/README.md
+++ b/instrumentation/httpurlconnection/README.md
@@ -74,7 +74,7 @@ Executors.newSingleThreadScheduledExecutor().scheduleWithFixedDelay(instrumentat
 - It is efficient to run the harvester thread at the same time interval as the connection inactivity timeout used to identify the connections to be reported. `instrumentation.getReportIdleConnectionInterval()` is the API to get the same connection inactivity timeout interval (milliseconds) you have configured or the default value of 10000ms if not configured.
 
 #### Other Optional Configurations
-You can optionally configure the automatic instrumentation by using the setters from [HttpUrlInstrumentation](library/src/main/java/io/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlInstrumentation.java)
+You can optionally configure the automatic instrumentation by using the setters from [HttpUrlInstrumentation](library/src/main/java/io/opentelemetry/instrumentation/library/httpurlconnection/HttpUrlInstrumentation.kt)
 instance provided via the AndroidInstrumentationLoader as shown below:
 
 ```java

--- a/instrumentation/okhttp3/README.md
+++ b/instrumentation/okhttp3/README.md
@@ -41,7 +41,7 @@ automatically.
 
 You can configure the automatic instrumentation by using the setters
 from
-the [OkHttpInstrumentation](library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/OkHttpInstrumentation.java)
+the [OkHttpInstrumentation](library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/OkHttpInstrumentation.kt)
 instance provided via the AndroidInstrumentationLoader as shown below:
 
 ```java


### PR DESCRIPTION
Some java classes converted to kotlin and broke the links in the readme. Follows #1133 and #1139.