### PR TITLE
Improve build performance for demo app

### DIFF
--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -18,7 +18,7 @@ android {
     defaultConfig {
         applicationId = "io.opentelemetry.android.demo"
         minSdk = 21
-        targetSdk = 34
+        targetSdk = 36
         versionCode = 1
         versionName = "1.0"
 

--- a/demo-app/gradle.properties
+++ b/demo-app/gradle.properties
@@ -1,3 +1,9 @@
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096M -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4096M"
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.problems=fail
+org.gradle.configuration-cache.parallel=true
+
 android.useAndroidX=true
 android.useFullClasspathForDexingTransform=true


### PR DESCRIPTION
## Goal

Attempts to improve the performance of building the demo app by taking advantage of a few improvements that were applied to the main Gradle project in #1091. A recent [CI run](https://github.com/open-telemetry/opentelemetry-android/actions/runs/16772311829/job/47490177071) shows the demo app takes ~6m to build - this should help reduce that.

I also bumped the `targetSdk` to the latest available Android version as at the end of August it won't be possible to [ship to Google Play](https://developer.android.com/google/play/requirements/target-sdk) with 34.