### PR TITLE
Fix build warnings

### DIFF
--- a/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrWatcher.kt
+++ b/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrWatcher.kt
@@ -74,10 +74,12 @@ internal class AnrWatcher(
     }
 
     private fun emitAnrEvent(stackTrace: Array<StackTraceElement>) {
+        @Suppress("DEPRECATION")
+        val id = mainThread.id
         val attributesBuilder =
             Attributes
                 .builder()
-                .put(THREAD_ID, mainThread.id)
+                .put(THREAD_ID, id)
                 .put(THREAD_NAME, mainThread.name)
                 .put(EXCEPTION_STACKTRACE, stackTraceToString(stackTrace))
 

--- a/instrumentation/common-api/src/test/java/io/opentelemetry/android/instrumentation/common/ScreenNameExtractorTest.kt
+++ b/instrumentation/common-api/src/test/java/io/opentelemetry/android/instrumentation/common/ScreenNameExtractorTest.kt
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+@file:Suppress("DEPRECATION") // suppress deprecation for android.app.Fragment
+
 package io.opentelemetry.android.instrumentation.common
 
 import android.app.Activity

--- a/services/src/test/java/io/opentelemetry/android/internal/services/periodicwork/PeriodicWorkTest.kt
+++ b/services/src/test/java/io/opentelemetry/android/internal/services/periodicwork/PeriodicWorkTest.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.android.internal.services.periodicwork
 
+import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -34,7 +35,7 @@ class PeriodicWorkTest {
         val threadIds = mutableSetOf<Long>()
         repeat(numberOfTasks) {
             service.enqueue {
-                threadIds.add(Thread.currentThread().id)
+                threadIds.add(findThreadId())
                 latch.countDown()
             }
         }
@@ -46,7 +47,16 @@ class PeriodicWorkTest {
         assertThat(threadIds.size).isEqualTo(1)
 
         // The worker thread is not the same as the main thread
-        assertThat(threadIds.first()).isNotEqualTo(Thread.currentThread().id)
+        assertThat(threadIds.first()).isNotEqualTo(findThreadId())
+    }
+
+    private fun findThreadId(): Long {
+        val thread = Thread.currentThread()
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
+            thread.threadId()
+        } else {
+            thread.id
+        }
     }
 
     @Test


### PR DESCRIPTION
## Goal

Fixes some additional build warnings I spotted when running `./gradlew check`, mostly related to deprecated symbols that need to be invoked from test code.