### PR TITLE
Rollback kotlin to 2.2.0

### DIFF
--- a/demo-app/gradle/libs.versions.toml
+++ b/demo-app/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ opentelemetry = "1.52.0"
 opentelemetry-alpha = "1.52.0-alpha"
 junit = "5.13.4"
 spotless = "7.2.1"
-kotlin = "2.2.10"
+kotlin = "2.2.0"
 navigation-compose = "2.7.7"
 
 [libraries]


### PR DESCRIPTION
We have to wait for ksp to catch up, I think? The build output was being flooded with these:

```
ksp-2.2.0-2.0.2 is too old for kotlin-2.2.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.2.0.
ksp-2.2.0-2.0.2 is too old for kotlin-2.2.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.2.0.
ksp-2.2.0-2.0.2 is too old for kotlin-2.2.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.2.0.
ksp-2.2.0-2.0.2 is too old for kotlin-2.2.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.2.0.
ksp-2.2.0-2.0.2 is too old for kotlin-2.2.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.2.0.
ksp-2.2.0-2.0.2 is too old for kotlin-2.2.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.2.0.
ksp-2.2.0-2.0.2 is too old for kotlin-2.2.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.2.0.
ksp-2.2.0-2.0.2 is too old for kotlin-2.2.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.2.0.
ksp-2.2.0-2.0.2 is too old for kotlin-2.2.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.2.0.
ksp-2.2.0-2.0.2 is too old for kotlin-2.2.10. Please upgrade ksp or downgrade kotlin-gradle-plugin to 2.2.0.
```

([here is one example](https://github.com/open-telemetry/opentelemetry-android/actions/runs/16971176540/job/48108290415#step:7:233))