### PR TITLE
Attempt to fix the build by disabling incremental kotlin compile 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,9 @@ jobs:
         working-directory: ./demo-app
         run: ./gradlew check assemble
       - name: publish snapshot
-        run: ./gradlew publishToSonatype
+        # See https://youtrack.jetbrains.com/projects/KT/issues/KT-79047/Gradle-compileKotlin-fails-with-configuration-cache for why this is needed
+        # We may be able to remove this when gradle 9.1 lands.
+        run: ./gradlew publishToSonatype -Pkotlin.incremental=false
         env:
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,9 @@ jobs:
           java-version: 17
 
       - name: Build and publish artifacts
-        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -Pfinal=true --no-build-cache --no-configuration-cache --no-parallel
+        # See https://youtrack.jetbrains.com/projects/KT/issues/KT-79047/Gradle-compileKotlin-fails-with-configuration-cache for why this is needed
+        # We may be able to remove this when gradle 9.1 lands.
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -Pkotlin.incremental=false -Pfinal=true --no-build-cache --no-configuration-cache --no-parallel
         env:
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}


### PR DESCRIPTION
Our CI builds for `main` are currently failing the (snapshot) publish step ([example 1](https://github.com/open-telemetry/opentelemetry-android/actions/runs/17046150939/job/48322387165), [example 2](https://github.com/open-telemetry/opentelemetry-android/actions/runs/17046169176/job/48322451764)). 

This seems to be caused by a bug in gradle ([see this thread](https://youtrack.jetbrains.com/projects/KT/issues/KT-79047/Gradle-compileKotlin-fails-with-configuration-cache)). It should be fixed in the next version which is imminent, but until then let's get our build fixed.

I've also disabled it for our release process builds, because we anticipate releasing this week can can't necessarily wait for the fix.