### PR TITLE
Drop LOLLIPOP support and update robolectric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Drop support for Lollipop and API level 21.
+
 ## Version 0.14.0 (2025-08-21)
 
 ### 📣 Migration notes

--- a/core/src/integrationTest/kotlin/io/opentelemetry/android/AgentInitTest.kt
+++ b/core/src/integrationTest/kotlin/io/opentelemetry/android/AgentInitTest.kt
@@ -6,7 +6,6 @@
 package io.opentelemetry.android
 
 import android.app.Application
-import android.os.Build.VERSION_CODES.LOLLIPOP
 import android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -18,7 +17,7 @@ import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 internal class AgentInitTest {
-    @Config(sdk = [LOLLIPOP, UPSIDE_DOWN_CAKE])
+    @Config(sdk = [UPSIDE_DOWN_CAKE])
     @Test
     fun startOpenTelemetryRumInAndroid() {
         val application = getApplicationContext<Application>()

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/OtelDemoApplication.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/OtelDemoApplication.kt
@@ -7,6 +7,7 @@ package io.opentelemetry.android.demo
 
 import android.annotation.SuppressLint
 import android.app.Application
+import android.os.StrictMode
 import android.util.Log
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.agent.OpenTelemetryRumInitializer
@@ -27,6 +28,17 @@ class OtelDemoApplication : Application() {
     @SuppressLint("RestrictedApi")
     override fun onCreate() {
         super.onCreate()
+        StrictMode.setThreadPolicy(
+            StrictMode.ThreadPolicy.Builder()
+                .detectAll()
+                .build()
+        )
+        StrictMode.setVmPolicy(
+            StrictMode.VmPolicy.Builder()
+                .detectAll()
+                .build()
+        )
+        System.setProperty("io.opentelemetry.context.contextStorageProvider", "default")
 
         Log.i(TAG, "Initializing the opentelemetry-android-agent")
         val diskBufferingConfig = DiskBufferingConfig(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,7 @@ androidx-core = "androidx.core:core:1.17.0"
 androidx-annotation = "androidx.annotation:annotation:1.9.1"
 androidx-lifecycle-process = "androidx.lifecycle:lifecycle-process:2.9.2"
 androidx-preference-ktx = "androidx.preference:preference-ktx:1.2.1"
+apache-httpcore = "org.apache.httpcomponents:httpcore:4.4.16"
 findbugs-jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 byteBuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "byteBuddy" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,7 +67,7 @@ junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.re
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "1.13.4" }
-robolectric = "org.robolectric:robolectric:4.15.1"
+robolectric = "org.robolectric:robolectric:4.16"
 assertj-core = "org.assertj:assertj-core:3.27.4"
 awaitility = "org.awaitility:awaitility:4.3.0"
 mockwebserver = "com.google.mockwebserver:mockwebserver:20130706"

--- a/instrumentation/volley/library/build.gradle.kts
+++ b/instrumentation/volley/library/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     api(libs.opentelemetry.api)
 
     testImplementation(libs.volley)
+    testRuntimeOnly(libs.apache.httpcore)
     testImplementation(libs.robolectric)
     testImplementation(libs.mockwebserver)
 }

--- a/instrumentation/volley/library/src/test/java/io/opentelemetry/android/instrumentation/volley/TracingHurlStackTest.java
+++ b/instrumentation/volley/library/src/test/java/io/opentelemetry/android/instrumentation/volley/TracingHurlStackTest.java
@@ -69,8 +69,12 @@ public class TracingHurlStackTest {
 
     @After
     public void cleanup() throws IOException {
-        stuckTestHelper.close();
-        server.shutdown();
+        if (stuckTestHelper != null) {
+            stuckTestHelper.close();
+        }
+        if (server != null) {
+            server.shutdown();
+        }
     }
 
     @Test

--- a/services/src/test/java/io/opentelemetry/android/internal/services/network/detector/NetworkDetectorTest.java
+++ b/services/src/test/java/io/opentelemetry/android/internal/services/network/detector/NetworkDetectorTest.java
@@ -15,24 +15,19 @@ import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
 import android.net.Network;
 import android.net.NetworkCapabilities;
-import android.net.NetworkInfo;
 import android.os.Build;
 import android.telephony.TelephonyManager;
 import androidx.core.content.ContextCompat;
-import androidx.test.core.app.ApplicationProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import io.opentelemetry.android.common.internal.features.networkattributes.data.Carrier;
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork;
 import io.opentelemetry.android.common.internal.features.networkattributes.data.NetworkState;
 import org.junit.After;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockedStatic;
-import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
-import org.robolectric.shadows.ShadowNetworkInfo;
 
 @RunWith(AndroidJUnit4.class)
 public class NetworkDetectorTest {
@@ -190,60 +185,6 @@ public class NetworkDetectorTest {
         CurrentNetwork currentNetwork = networkDetector.detectCurrentNetwork();
         assertEquals(
                 CurrentNetwork.builder(NetworkState.TRANSPORT_UNKNOWN).build(), currentNetwork);
-    }
-
-    @Test
-    @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
-    public void none_legacy() {
-        ConnectivityManager cm =
-                (ConnectivityManager)
-                        ApplicationProvider.getApplicationContext()
-                                .getSystemService(Context.CONNECTIVITY_SERVICE);
-        Shadows.shadowOf(cm).setActiveNetworkInfo(null);
-        NetworkDetector networkDetector =
-                NetworkDetector.create(ApplicationProvider.getApplicationContext());
-        CurrentNetwork currentNetwork = networkDetector.detectCurrentNetwork();
-        Assert.assertEquals(
-                CurrentNetwork.builder(NetworkState.NO_NETWORK_AVAILABLE).build(), currentNetwork);
-    }
-
-    @Test
-    @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
-    public void wifi_legacy() {
-        ConnectivityManager cm =
-                (ConnectivityManager)
-                        ApplicationProvider.getApplicationContext()
-                                .getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo networkInfo =
-                ShadowNetworkInfo.newInstance(
-                        null, // Use null instead of deprecated DetailedState.CONNECTED
-                        ConnectivityManager.TYPE_WIFI,
-                        0,
-                        true,
-                        null); // Use null instead of deprecated State.CONNECTED
-        Shadows.shadowOf(cm).setActiveNetworkInfo(networkInfo);
-        NetworkDetector networkDetector =
-                NetworkDetector.create(ApplicationProvider.getApplicationContext());
-        CurrentNetwork currentNetwork = networkDetector.detectCurrentNetwork();
-        Assert.assertEquals(
-                CurrentNetwork.builder(NetworkState.TRANSPORT_WIFI).build(), currentNetwork);
-    }
-
-    @Test
-    @Config(sdk = Build.VERSION_CODES.LOLLIPOP)
-    public void cellularWithSubtype_legacy() {
-        ConnectivityManager cm =
-                (ConnectivityManager)
-                        ApplicationProvider.getApplicationContext()
-                                .getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkInfo networkInfo = mock(NetworkInfo.class);
-        when(networkInfo.getType()).thenReturn(ConnectivityManager.TYPE_MOBILE);
-        when(networkInfo.getSubtypeName()).thenReturn("LTE");
-        Shadows.shadowOf(cm).setActiveNetworkInfo(networkInfo);
-        NetworkDetector networkDetector =
-                NetworkDetector.create(ApplicationProvider.getApplicationContext());
-        CurrentNetwork currentNetwork = networkDetector.detectCurrentNetwork();
-        Assert.assertEquals(NetworkState.TRANSPORT_CELLULAR, currentNetwork.getState());
     }
 
     @Test


### PR DESCRIPTION
Supersedes #1186.

The [latest robolectric drops support for LOLLIPOP](https://github.com/open-telemetry/opentelemetry-android/pull/1186#issuecomment-3224891849), which I think makes a lot of sense these days. So let's go ahead and drop support for it as well (since we can't test for it after updating). It's less than 1% of the install base according to wikipedia.

Remember that we've deprecated Volley and will be dropping support for it in a few releases, but in the meantime, somehow this change also required apache http core to be on the classpath at test runtime. 🤷🏻 
