### PR TITLE
Initializer instrumentation config

### DIFF
--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -4,22 +4,22 @@ public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer {
 	public static synthetic fun initialize$default (Landroid/app/Application;Ljava/lang/String;Ljava/util/Map;Lio/opentelemetry/android/agent/connectivity/EndpointConnectivity;Lio/opentelemetry/android/agent/connectivity/EndpointConnectivity;Lio/opentelemetry/android/agent/connectivity/EndpointConnectivity;Lio/opentelemetry/android/config/OtelRumConfig;Lio/opentelemetry/android/agent/session/SessionConfig;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/opentelemetry/android/OpenTelemetryRum;
 }
 
-public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer$ActivityLifecycleConfiguration {
-	public final fun screenNameExtractor (Lio/opentelemetry/android/instrumentation/common/ScreenNameExtractor;)V
-	public final fun tracerCustomizer (Lkotlin/jvm/functions/Function1;)V
+public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer$ActivityLifecycleConfiguration : io/opentelemetry/android/agent/OpenTelemetryRumInitializer$ScreenLifecycleConfigurable {
+	public fun screenNameExtractor (Lio/opentelemetry/android/instrumentation/common/ScreenNameExtractor;)V
+	public fun tracerCustomizer (Lkotlin/jvm/functions/Function1;)V
 }
 
-public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer$AnrReporterConfiguration {
-	public final fun addAttributesExtractor (Lio/opentelemetry/android/instrumentation/common/EventAttributesExtractor;)V
+public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer$AnrReporterConfiguration : io/opentelemetry/android/agent/OpenTelemetryRumInitializer$WithEventAttributes {
+	public fun addAttributesExtractor (Lio/opentelemetry/android/instrumentation/common/EventAttributesExtractor;)V
 }
 
-public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer$CrashReporterConfiguration {
-	public final fun addAttributesExtractor (Lio/opentelemetry/android/instrumentation/common/EventAttributesExtractor;)V
+public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer$CrashReporterConfiguration : io/opentelemetry/android/agent/OpenTelemetryRumInitializer$WithEventAttributes {
+	public fun addAttributesExtractor (Lio/opentelemetry/android/instrumentation/common/EventAttributesExtractor;)V
 }
 
-public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer$FragmentLifecycleConfiguration {
-	public final fun screenNameExtractor (Lio/opentelemetry/android/instrumentation/common/ScreenNameExtractor;)V
-	public final fun tracerCustomizer (Lkotlin/jvm/functions/Function1;)V
+public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer$FragmentLifecycleConfiguration : io/opentelemetry/android/agent/OpenTelemetryRumInitializer$ScreenLifecycleConfigurable {
+	public fun screenNameExtractor (Lio/opentelemetry/android/instrumentation/common/ScreenNameExtractor;)V
+	public fun tracerCustomizer (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer$InstrumentationConfiguration {

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
@@ -145,49 +145,49 @@ object OpenTelemetryRumInitializer {
     }
 
     @InstrumentationConfigMarker
-    class ActivityLifecycleConfiguration internal constructor() {
+    class ActivityLifecycleConfiguration internal constructor() : ScreenLifecycleConfigurable {
         private val activityLifecycleInstrumentation: ActivityLifecycleInstrumentation by lazy {
             getInstrumentation()
         }
 
-        fun tracerCustomizer(value: (Tracer) -> Tracer) {
+        override fun tracerCustomizer(value: (Tracer) -> Tracer) {
             activityLifecycleInstrumentation.setTracerCustomizer(value)
         }
 
-        fun screenNameExtractor(value: ScreenNameExtractor) {
+        override fun screenNameExtractor(value: ScreenNameExtractor) {
             activityLifecycleInstrumentation.setScreenNameExtractor(value)
         }
     }
 
     @InstrumentationConfigMarker
-    class FragmentLifecycleConfiguration internal constructor() {
+    class FragmentLifecycleConfiguration internal constructor() : ScreenLifecycleConfigurable {
         private val fragmentLifecycleInstrumentation: FragmentLifecycleInstrumentation by lazy {
             getInstrumentation()
         }
 
-        fun tracerCustomizer(value: (Tracer) -> Tracer) {
+        override fun tracerCustomizer(value: (Tracer) -> Tracer) {
             fragmentLifecycleInstrumentation.setTracerCustomizer(value)
         }
 
-        fun screenNameExtractor(value: ScreenNameExtractor) {
+        override fun screenNameExtractor(value: ScreenNameExtractor) {
             fragmentLifecycleInstrumentation.setScreenNameExtractor(value)
         }
     }
 
     @InstrumentationConfigMarker
-    class AnrReporterConfiguration internal constructor() {
+    class AnrReporterConfiguration internal constructor() : WithEventAttributes<Array<StackTraceElement>> {
         private val anrInstrumentation: AnrInstrumentation by lazy { getInstrumentation() }
 
-        fun addAttributesExtractor(value: EventAttributesExtractor<Array<StackTraceElement>>) {
+        override fun addAttributesExtractor(value: EventAttributesExtractor<Array<StackTraceElement>>) {
             anrInstrumentation.addAttributesExtractor(value)
         }
     }
 
     @InstrumentationConfigMarker
-    class CrashReporterConfiguration internal constructor() {
+    class CrashReporterConfiguration internal constructor() : WithEventAttributes<CrashDetails> {
         private val crashReporterInstrumentation: CrashReporterInstrumentation by lazy { getInstrumentation() }
 
-        fun addAttributesExtractor(value: EventAttributesExtractor<CrashDetails>) {
+        override fun addAttributesExtractor(value: EventAttributesExtractor<CrashDetails>) {
             crashReporterInstrumentation.addAttributesExtractor(value)
         }
     }
@@ -212,6 +212,16 @@ object OpenTelemetryRumInitializer {
         fun enableVerboseDebugLogging() {
             slowRenderingInstrumentation.enableVerboseDebugLogging()
         }
+    }
+
+    internal interface ScreenLifecycleConfigurable {
+        fun tracerCustomizer(value: (Tracer) -> Tracer)
+
+        fun screenNameExtractor(value: ScreenNameExtractor)
+    }
+
+    internal interface WithEventAttributes<T> {
+        fun addAttributesExtractor(value: EventAttributesExtractor<T>)
     }
 
     @DslMarker


### PR DESCRIPTION
Enhances the RUM initializer configuration for the default instrumentations by:
- Using a more Kotlin idiomatic approach.
- Reducing the initializer function set of arguments, making it easier to read and extend.

This is an example of how users will be able to configure instrumentations after these changes:

```kotlin
rum = OpenTelemetryRumInitializer.initialize(
    //...
    instrumentations = {
        activity {
            screenNameExtractor(/*some screen name extractor*/)
        }
        slowRenderingReporter {
            detectionPollInterval(10.seconds)
            enableVerboseDebugLogging()
        }
    }
)
```