### PR TITLE
Setup code coverage tool

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,6 +16,7 @@ buildscript {
 plugins {
     id("otel.spotless-conventions")
     alias(libs.plugins.publishPlugin)
+    id("org.jetbrains.kotlinx.kover")
 }
 
 extra["java_version"] = JavaVersion.VERSION_1_8
@@ -44,6 +45,22 @@ nexusPublishing {
             snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
             username.set(System.getenv("SONATYPE_USER"))
             password.set(System.getenv("SONATYPE_KEY"))
+        }
+    }
+}
+
+kover {
+    merge {
+        subprojects { project ->
+            true
+        }
+    }
+    reports {
+        filters {
+            excludes {
+                androidGeneratedClasses()
+                classes("*.BuildConfig")
+            }
         }
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -26,4 +26,5 @@ dependencies {
     implementation(libs.detekt.plugin)
     implementation(libs.binary.compat.validator)
     implementation(libs.ksp.plugin)
+    implementation(libs.kover.plugin)
 }

--- a/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     id("otel.android-dependency-conventions")
     id("io.gitlab.arturbosch.detekt")
     id("org.jetbrains.kotlinx.binary-compatibility-validator")
+    id("org.jetbrains.kotlinx.kover")
 }
 
 val javaVersion = rootProject.extra["java_version"] as JavaVersion

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ androidx-navigation = "2.7.7"
 compose = "1.5.4"
 detekt = "1.23.8"
 binaryCompatValidator = "0.18.1"
+koverGradlePlugin = "0.9.1"
 
 [libraries]
 opentelemetry-platform-alpha = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetry-instrumentation-alpha" }
@@ -89,6 +90,7 @@ byteBuddy-plugin = { module = "net.bytebuddy:byte-buddy-gradle-plugin", version.
 kotlin-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 ksp-plugin = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "kspPlugin" }
 androidx-junit-ktx = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "junitKtx" }
+kover-plugin = { module = "org.jetbrains.kotlinx.kover:org.jetbrains.kotlinx.kover.gradle.plugin", version.ref = "koverGradlePlugin" }
 
 [bundles]
 mocking = ["mockito-core", "mockito-junit-jupiter", "mockk"]
@@ -99,3 +101,4 @@ publishPlugin = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 androidApp = { id = "com.android.application", version.ref = "androidPlugin" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "koverGradlePlugin" }


### PR DESCRIPTION
## Goal

Whilst code coverage isn't a perfect metric it is a useful tool for highlighting when parts of a codebase are missing tests entirely. [Kover](https://github.com/Kotlin/kotlinx-kover/) provides code coverage reports for both Kotlin/Java source code and allows generating either a HTML or XML file.

In this changeset I've applied Kover to all production modules and created an aggregate report that can be accessed with `./gradlew koverHtmlReport`. This report produces a HTML file that can be accessed at `build/reports/kover/html`.

If there was desire to setup code coverage tracking it would be possible to create an XML report using `./gradlew koverXmlReport` and upload it to a service such as codecov (what we use at Embrace). For now I feel it's just useful having this as an option to highlight code coverage locally rather than tracking things continuously.

