### PR TITLE
Setup codecov github action

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -21,7 +21,13 @@ jobs:
       - name: touch local props
         run: touch demo-app/local.properties
       - name: run gradle
-        run: ./gradlew check
+        run: ./gradlew check koverXmlReport
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: build/reports/kover/report.xml
+          slug: open-telemetry/opentelemetry-android
       - name: build demo app
         working-directory: ./demo-app
         run: ./gradlew assembleRelease


### PR DESCRIPTION
## Goal

Attempts to fix #1214 by setting up a Github action to upload coverage reports to codecov. I largely followed the [quick start instructions](https://docs.codecov.com/docs/quick-start) and used [this project in codecov](https://app.codecov.io/github/open-telemetry/opentelemetry-android/new).