### PR TITLE
Add lower bound (Marshmallow) for testing

### DIFF
--- a/core/src/integrationTest/kotlin/io/opentelemetry/android/AgentInitTest.kt
+++ b/core/src/integrationTest/kotlin/io/opentelemetry/android/AgentInitTest.kt
@@ -6,8 +6,8 @@
 package io.opentelemetry.android
 
 import android.app.Application
-import android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 import android.os.Build.VERSION_CODES.M
+import android.os.Build.VERSION_CODES.UPSIDE_DOWN_CAKE
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.opentelemetry.android.config.OtelRumConfig


### PR DESCRIPTION
This fixes an oversight in #1189.

In #1189 we stopped testing with LOLLIPOP because robolectric dropped support for it. This restores the next version, which is M(arshmallow), and only impacts the `AgentInitTest` which is a smoke test of sorts.