### PR TITLE
Post release 0.15.0 version/docs fixes

### DIFF
--- a/.github/workflows/prepare-release-branch.yml
+++ b/.github/workflows/prepare-release-branch.yml
@@ -116,6 +116,13 @@ jobs:
       - name: Update version in README
         run: sed -Ei "s/(\"io.opentelemetry.android:opentelemetry-android-bom:).*\"/\1${VERSION}-alpha\"/" README.md
 
+      - name: Update instrumentation README.md versions
+        run: |
+          for f in $(find instrumentation -name README.md) ; do 
+            echo Updating version in $f; 
+            sed -Ei "s/(\(\"io\.opentelemetry\.android.*):[[:digit:]]+\.[[:digit:]]+\.[[:digit:]](-alpha)?\"/\1:${VERSION}-alpha\"/" $f
+          done
+
       - name: Update the change log on main
         run: |
           # the actual release date on main will be updated at the end of the release workflow

--- a/instrumentation/activity/README.md
+++ b/instrumentation/activity/README.md
@@ -48,5 +48,5 @@ manually install this instrumentation by following the steps below.
 ### Adding dependencies
 
 ```kotlin
-implementation("io.opentelemetry.android.instrumentation:activity:0.13.0-alpha")
+implementation("io.opentelemetry.android.instrumentation:activity:0.15.0-alpha")
 ```

--- a/instrumentation/android-log/README.md
+++ b/instrumentation/android-log/README.md
@@ -37,6 +37,6 @@ plugins {
 ### Adding dependencies
 
 ```kotlin
-implementation("io.opentelemetry.android.instrumentation:android-log-library:0.13.0-alpha")
-byteBuddy("io.opentelemetry.android.instrumentation:android-log-agent:0.13.0-alpha") // <2>
+implementation("io.opentelemetry.android.instrumentation:android-log-library:0.15.0-alpha")
+byteBuddy("io.opentelemetry.android.instrumentation:android-log-agent:0.15.0-alpha") // <2>
 ```

--- a/instrumentation/anr/README.md
+++ b/instrumentation/anr/README.md
@@ -39,5 +39,5 @@ manually install this instrumentation by following the steps below.
 ### Adding dependencies
 
 ```kotlin
-implementation("io.opentelemetry.android.instrumentation:anr:0.13.0-alpha")
+implementation("io.opentelemetry.android.instrumentation:anr:0.15.0-alpha")
 ```

--- a/instrumentation/compose/click/README.md
+++ b/instrumentation/compose/click/README.md
@@ -40,5 +40,5 @@ This instrumentation produces the following telemetry:
 ### Adding dependencies
 
 ```kotlin
-implementation("io.opentelemetry.android.instrumentation:compose-click:0.13.0-alpha")
+implementation("io.opentelemetry.android.instrumentation:compose-click:0.15.0-alpha")
 ```

--- a/instrumentation/crash/README.md
+++ b/instrumentation/crash/README.md
@@ -35,5 +35,5 @@ manually install this instrumentation by following the steps below.
 ### Adding dependencies
 
 ```kotlin
-implementation("io.opentelemetry.android.instrumentation:crash:0.13.0-alpha")
+implementation("io.opentelemetry.android.instrumentation:crash:0.15.0-alpha")
 ```

--- a/instrumentation/fragment/README.md
+++ b/instrumentation/fragment/README.md
@@ -33,5 +33,5 @@ manually install this instrumentation by following the steps below.
 ### Adding dependencies
 
 ```kotlin
-implementation("io.opentelemetry.android.instrumentation:fragment:0.13.0-alpha")
+implementation("io.opentelemetry.android.instrumentation:fragment:0.15.0-alpha")
 ```

--- a/instrumentation/httpurlconnection/README.md
+++ b/instrumentation/httpurlconnection/README.md
@@ -37,9 +37,7 @@ Spans won't be automatically ended and reported otherwise. If any of your URLCon
 
 ### Add these dependencies to your project
 
-Replace `AUTO_HTTP_URL_INSTRUMENTATION_VERSION` with the [latest release](https://central.sonatype.com/search?q=g%3Aio.opentelemetry.android++a%3Ahttpurlconnection-library&smo=true).
-
-Replace `BYTEBUDDY_VERSION` with the [latest release](https://search.maven.org/search?q=g:net.bytebuddy%20AND%20a:byte-buddy).
+Replace `BYTEBUDDY_VERSION` with the [latest release](https://central.sonatype.com/artifact/net.bytebuddy/byte-buddy-gradle-plugin/versions).
 
 #### Byte buddy compilation plugin
 
@@ -54,8 +52,8 @@ plugins {
 #### Project dependencies
 
 ```kotlin
-implementation("io.opentelemetry.android.instrumentation:httpurlconnection-library:AUTO_HTTP_URL_INSTRUMENTATION_VERSION")
-byteBuddy("io.opentelemetry.android.instrumentation:httpurlconnection-agent:AUTO_HTTP_URL_INSTRUMENTATION_VERSION")
+implementation("io.opentelemetry.android.instrumentation:httpurlconnection-library:0.15.0-alpha")
+byteBuddy("io.opentelemetry.android.instrumentation:httpurlconnection-agent:0.15.0-alpha")
 ```
 
 ### Configurations
@@ -63,7 +61,7 @@ byteBuddy("io.opentelemetry.android.instrumentation:httpurlconnection-agent:AUTO
 #### Scheduling Harvester Thread
 
 To schedule a periodically running thread to conclude/report spans on any unreported, idle connections, add the below code in the function where your application starts ( that could be onCreate() method of first Activity/Fragment/Service):
-```Java
+```java
 HttpUrlInstrumentation instrumentation = AndroidInstrumentationLoader.getInstrumentation(HttpUrlInstrumentation.class);
 instrumentation.setConnectionInactivityTimeoutMs(customTimeoutValue); //This is optional. Replace customTimeoutValue with a long data type value which denotes the connection inactivity timeout in milli seconds. Defaults to 10000ms
 Executors.newSingleThreadScheduledExecutor().scheduleWithFixedDelay(instrumentation.getReportIdleConnectionRunnable(), 0, instrumentation.getReportIdleConnectionInterval(), TimeUnit.MILLISECONDS);

--- a/instrumentation/network/README.md
+++ b/instrumentation/network/README.md
@@ -46,5 +46,5 @@ manually install this instrumentation by following the steps below.
 ### Adding dependencies
 
 ```kotlin
-implementation("io.opentelemetry.android.instrumentation:network:0.13.0-alpha")
+implementation("io.opentelemetry.android.instrumentation:network:0.15.0-alpha")
 ```

--- a/instrumentation/okhttp3-websocket/README.md
+++ b/instrumentation/okhttp3-websocket/README.md
@@ -22,6 +22,6 @@ plugins {
 ### Adding dependencies
 
 ```kotlin
-implementation("io.opentelemetry.android.instrumentation:okhttp3-websocket-library:0.13.0-alpha")
-byteBuddy("io.opentelemetry.android.instrumentation:okhttp3-websocket-agent:0.13.0-alpha")
+implementation("io.opentelemetry.android.instrumentation:okhttp3-websocket-library:0.15.0-alpha")
+byteBuddy("io.opentelemetry.android.instrumentation:okhttp3-websocket-agent:0.15.0-alpha")
 ```

--- a/instrumentation/okhttp3/README.md
+++ b/instrumentation/okhttp3/README.md
@@ -8,9 +8,6 @@ Provides OpenTelemetry instrumentation for [okhttp3](https://square.github.io/ok
 
 ### Add these dependencies to your project
 
-Replace `OPENTELEMETRY_VERSION` with the [latest
-release](https://search.maven.org/search?q=g:io.opentelemetry.android%20AND%20a:okhttp-3.0-library).
-
 Replace `BYTEBUDDY_VERSION` with the [latest
 release](https://search.maven.org/search?q=g:net.bytebuddy%20AND%20a:byte-buddy).
 
@@ -30,8 +27,8 @@ plugins {
 #### Project dependencies
 
 ```kotlin
-implementation("io.opentelemetry.android.instrumentation:okhttp3-library:OPENTELEMETRY_VERSION")
-byteBuddy("io.opentelemetry.android.instrumentation:okhttp3-agent:OPENTELEMETRY_VERSION")
+implementation("io.opentelemetry.android.instrumentation:okhttp3-library:0.15.0-alpha")
+byteBuddy("io.opentelemetry.android.instrumentation:okhttp3-agent:0.15.0-alpha")
 ```
 
 After adding the plugin and the dependencies to your project, your OkHttp requests will be traced

--- a/instrumentation/okhttp3/README.md
+++ b/instrumentation/okhttp3/README.md
@@ -9,7 +9,7 @@ Provides OpenTelemetry instrumentation for [okhttp3](https://square.github.io/ok
 ### Add these dependencies to your project
 
 Replace `BYTEBUDDY_VERSION` with the [latest
-release](https://search.maven.org/search?q=g:net.bytebuddy%20AND%20a:byte-buddy).
+release](https://central.sonatype.com/artifact/net.bytebuddy/byte-buddy-gradle-plugin/versions).
 
 #### Byte buddy compilation plugin
 

--- a/instrumentation/sessions/README.md
+++ b/instrumentation/sessions/README.md
@@ -22,7 +22,7 @@ manually install this instrumentation by following the steps below.
 ### Adding dependencies
 
 ```kotlin
-implementation("io.opentelemetry.android.instrumentation:sessions:0.13.0-alpha")
+implementation("io.opentelemetry.android.instrumentation:sessions:0.15.0-alpha")
 ```
 
 1. You can find the latest version [here](https://central.sonatype.com/artifact/io.opentelemetry.android.instrumentation/sessions).

--- a/instrumentation/slowrendering/README.md
+++ b/instrumentation/slowrendering/README.md
@@ -49,5 +49,5 @@ manually install this instrumentation by following the steps below.
 ### Adding dependencies
 
 ```kotlin
-implementation("io.opentelemetry.android.instrumentation:slowrendering:0.13.0-alpha")
+implementation("io.opentelemetry.android.instrumentation:slowrendering:0.15.0-alpha")
 ```

--- a/instrumentation/startup/README.md
+++ b/instrumentation/startup/README.md
@@ -27,5 +27,5 @@ manually install this instrumentation by following the steps below.
 ### Adding dependencies
 
 ```kotlin
-implementation("io.opentelemetry.android.instrumentation:startup:0.13.0-alpha")
+implementation("io.opentelemetry.android.instrumentation:startup:0.15.0-alpha")
 ```

--- a/instrumentation/view-click/README.md
+++ b/instrumentation/view-click/README.md
@@ -38,5 +38,5 @@ This instrumentation produces the following telemetry:
 ### Adding dependencies
 
 ```kotlin
-implementation("io.opentelemetry.android.instrumentation:view-click:0.13.0-alpha")
+implementation("io.opentelemetry.android.instrumentation:view-click:0.15.0-alpha")
 ```


### PR DESCRIPTION
So this addresses a few things -- 

1. The release automation wasn't updating the versions in the instrumentation README in the main branch PR.
2. The link checker is getting 403s from `search.maven.org` so we just use the sonatype central url instead.