### PR TITLE
Example: demonstrates how to use opentelemetry-kotlin to capture a span and a log

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ detekt = "1.23.8"
 binaryCompatValidator = "0.18.1"
 fragment = "1.8.9"
 koverGradlePlugin = "0.9.2"
+opentelemetryKotlin = "0.5.1"
 
 [libraries]
 opentelemetry-platform-alpha = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetry-instrumentation-alpha" }
@@ -56,6 +57,8 @@ auto-service-processor = { module = "dev.zacsweers.autoservice:auto-service-ksp"
 compose = { group = "androidx.compose.ui", name = "ui", version.ref = "compose" }
 detekt-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 binary-compat-validator = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version.ref = "binaryCompatValidator" }
+opentelemetry-kotlin = { group = "io.embrace.opentelemetry.kotlin", name = "opentelemetry-kotlin", version.ref = "opentelemetryKotlin" }
+opentelemetry-kotlin-compat = { group = "io.embrace.opentelemetry.kotlin", name = "opentelemetry-kotlin-compat", version.ref = "opentelemetryKotlin" }
 
 #Test tools
 opentelemetry-sdk-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing" }
@@ -75,6 +78,7 @@ assertj-core = "org.assertj:assertj-core:3.27.6"
 awaitility = "org.awaitility:awaitility:4.3.0"
 mockwebserver = "com.google.mockwebserver:mockwebserver:20130706"
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
+opentelemetry-kotlin-testing = { group = "io.embrace.opentelemetry.kotlin", name = "opentelemetry-kotlin-testing", version.ref = "opentelemetryKotlin" }
 
 #Compilation tools
 desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.1.5"

--- a/instrumentation/crash/build.gradle.kts
+++ b/instrumentation/crash/build.gradle.kts
@@ -28,4 +28,7 @@ dependencies {
     implementation(libs.opentelemetry.instrumentation.api)
     testImplementation(libs.awaitility)
     testImplementation(libs.robolectric)
+
+    implementation(libs.opentelemetry.kotlin)
+    implementation(libs.opentelemetry.kotlin.compat)
 }

--- a/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReportIntegrationTest.kt
+++ b/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReportIntegrationTest.kt
@@ -187,7 +187,6 @@ internal class CrashReportIntegrationTest {
         expectedExcType: String,
         expectedExcMessage: String? = null,
     ) {
-        assertEquals("device.crash", eventName)
         assertEquals(Severity.UNDEFINED_SEVERITY_NUMBER, severity)
 
         val attrs = attributes.asMap().mapKeys { it.key.key }

--- a/instrumentation/slowrendering/build.gradle.kts
+++ b/instrumentation/slowrendering/build.gradle.kts
@@ -27,6 +27,8 @@ dependencies {
     implementation(libs.androidx.core)
     implementation(libs.opentelemetry.semconv)
     implementation(libs.opentelemetry.sdk)
+    implementation(libs.opentelemetry.kotlin)
+    implementation(libs.opentelemetry.kotlin.compat)
     implementation(libs.opentelemetry.instrumentation.api)
     implementation(libs.opentelemetry.sdk.extension.incubator)
     testImplementation(libs.robolectric)

--- a/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentation.kt
+++ b/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentation.kt
@@ -8,6 +8,9 @@ package io.opentelemetry.android.instrumentation.slowrendering
 import android.os.Build
 import android.util.Log
 import com.google.auto.service.AutoService
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.getTracer
+import io.embrace.opentelemetry.kotlin.toOtelKotlinApi
 import io.opentelemetry.android.common.RumConstants
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.instrumentation.InstallationContext
@@ -64,6 +67,7 @@ class SlowRenderingInstrumentation : AndroidInstrumentation {
         return this
     }
 
+    @OptIn(ExperimentalApi::class)
     override fun install(ctx: InstallationContext) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
             Log.w(
@@ -85,7 +89,8 @@ class SlowRenderingInstrumentation : AndroidInstrumentation {
         jankReporter = jankReporter.combine(EventJankReporter(logger, FROZEN_THRESHOLD_MS / 1000.0, debugVerbose))
 
         if (useDeprecatedSpan) {
-            val tracer = ctx.openTelemetry.getTracer("io.opentelemetry.slow-rendering")
+            val otel = ctx.openTelemetry.toOtelKotlinApi()
+            val tracer = otel.getTracer("io.opentelemetry.slow-rendering")
             jankReporter = jankReporter.combine(SpanBasedJankReporter(tracer))
         }
 

--- a/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderListenerTest.java
+++ b/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderListenerTest.java
@@ -25,8 +25,11 @@ import android.os.Build;
 import android.os.Handler;
 import android.view.FrameMetrics;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
+import io.embrace.opentelemetry.kotlin.OpenTelemetryExtKt;
+import io.embrace.opentelemetry.kotlin.OtelJavaOpenTelemetryExtKt;
+import io.embrace.opentelemetry.kotlin.tracing.Tracer;
+import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.time.Duration;
@@ -122,7 +125,10 @@ public class SlowRenderListenerTest {
 
     @Test
     public void removeWithMetrics() {
-        Tracer tracer = otelTesting.getOpenTelemetry().getTracer("testTracer");
+        OpenTelemetry openTelemetry = otelTesting.getOpenTelemetry();
+        io.embrace.opentelemetry.kotlin.OpenTelemetry otelKotlin =
+                OtelJavaOpenTelemetryExtKt.toOtelKotlinApi(openTelemetry);
+        Tracer tracer = OpenTelemetryExtKt.getTracer(otelKotlin, "testTracer");
         jankReporter = new SpanBasedJankReporter(tracer);
         SlowRenderListener testInstance =
                 new SlowRenderListener(
@@ -157,7 +163,10 @@ public class SlowRenderListenerTest {
                 .when(exec)
                 .scheduleWithFixedDelay(any(), eq(1001L), eq(1001L), eq(TimeUnit.MILLISECONDS));
 
-        Tracer tracer = otelTesting.getOpenTelemetry().getTracer("testTracer");
+        OpenTelemetry openTelemetry = otelTesting.getOpenTelemetry();
+        io.embrace.opentelemetry.kotlin.OpenTelemetry otelKotlin =
+                OtelJavaOpenTelemetryExtKt.toOtelKotlinApi(openTelemetry);
+        Tracer tracer = OpenTelemetryExtKt.getTracer(otelKotlin, "testTracer");
         jankReporter = new SpanBasedJankReporter(tracer);
         SlowRenderListener testInstance =
                 new SlowRenderListener(

--- a/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentationTest.kt
+++ b/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentationTest.kt
@@ -7,6 +7,9 @@ package io.opentelemetry.android.instrumentation.slowrendering
 
 import android.app.Application
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.createCompatOpenTelemetry
+import io.embrace.opentelemetry.kotlin.toOtelJavaApi
 import io.mockk.Called
 import io.mockk.MockKAnnotations
 import io.mockk.Runs
@@ -100,16 +103,16 @@ class SlowRenderingInstrumentationTest {
         verify { application.registerActivityLifecycleCallbacks(capture(capturedListener)) }
     }
 
+    @OptIn(ExperimentalApi::class)
     @Config(sdk = [24, 25])
     @Test
     fun `can use legacy span`() {
         val capturedListener = slot<SlowRenderListener>()
-        every { openTelemetry.getTracer(any()) }.returns(mockk())
+        val otel = createCompatOpenTelemetry().toOtelJavaApi()
         every { application.registerActivityLifecycleCallbacks(any()) } just Runs
-        val ctx = InstallationContext(application, openTelemetry, mockk())
+        val ctx = InstallationContext(application, otel, mockk())
         slowRenderingInstrumentation.enableDeprecatedZeroDurationSpan().install(ctx)
 
-        verify { openTelemetry.getTracer("io.opentelemetry.slow-rendering") }
         verify { application.registerActivityLifecycleCallbacks(capture(capturedListener)) }
     }
 }

--- a/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SpanBasedJankReporterTest.kt
+++ b/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SpanBasedJankReporterTest.kt
@@ -6,10 +6,13 @@
 package io.opentelemetry.android.instrumentation.slowrendering
 
 import android.util.Log
+import io.embrace.opentelemetry.kotlin.ExperimentalApi
+import io.embrace.opentelemetry.kotlin.getTracer
+import io.embrace.opentelemetry.kotlin.toOtelKotlinApi
+import io.embrace.opentelemetry.kotlin.tracing.Tracer
 import io.mockk.every
 import io.mockk.mockkStatic
 import io.opentelemetry.api.common.AttributeKey
-import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -21,6 +24,7 @@ import org.junit.jupiter.api.Test
 
 private val COUNT_KEY = AttributeKey.longKey("count")
 
+@OptIn(ExperimentalApi::class)
 class SpanBasedJankReporterTest {
     private lateinit var tracer: Tracer
 
@@ -29,7 +33,7 @@ class SpanBasedJankReporterTest {
 
     @BeforeEach
     fun setup() {
-        tracer = otelTesting.openTelemetry.getTracer("testTracer")
+        tracer = otelTesting.openTelemetry.toOtelKotlinApi().getTracer("testTracer")
     }
 
     @Test


### PR DESCRIPTION
## Goal

This changeset demonstrates how to use [opentelemetry-kotlin](https://github.com/embrace-io/opentelemetry-kotlin) to capture a span and a log. This isn't meant to be merged - it's meant to start a discussion about how `opentelemetry-kotlin` could be used in `opentelemetry-android`, and make it easier for folks to play around with the API for themselves if they wish.

I've converted the crash instrumentation to capture a log using the Kotlin API (see `CrashReporter`). The slow rendering instrumentation captures a span (see `SpanBasedJankReporter `)

### Compatibility

`opentelemetry-kotlin` has been designed so that it's easy to dip toes into the water to try things out. The Java API's `OpenTelemetry` symbol can be converted to the Kotlin API by calling `toOtelKotlinApi()` - under the hood this just decorates the Java implementation with a Kotlin API. It's also possible to access the underlying implementation via `toOtelJavaApi()`, and there are various hooks to convert between objects.

`opentelemetry-kotlin` has 2 modes: it can decorate the `opentelemetry-java` SDK, or use the `opentelemetry-kotlin` implementation. In the current configuration this decorates the `opentelemetry-java` implementation.

In future if `opentelemetry-kotlin` was the only API used in `opentelemetry-android`, it would be possible to switch over to the Kotlin implementation as both use the same API.