### PR TITLE
Add Incubating annotation to indicate unstable APIs

### DIFF
--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -1,3 +1,6 @@
+public abstract interface annotation class io/opentelemetry/android/Incubating : java/lang/annotation/Annotation {
+}
+
 public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer {
 	public static final field INSTANCE Lio/opentelemetry/android/agent/OpenTelemetryRumInitializer;
 	public static final fun initialize (Landroid/app/Application;Ljava/lang/String;Ljava/util/Map;Lio/opentelemetry/android/agent/connectivity/EndpointConnectivity;Lio/opentelemetry/android/agent/connectivity/EndpointConnectivity;Lio/opentelemetry/android/agent/connectivity/EndpointConnectivity;Lio/opentelemetry/android/config/OtelRumConfig;Lio/opentelemetry/android/agent/session/SessionConfig;Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/android/OpenTelemetryRum;
@@ -65,15 +68,8 @@ public final class io/opentelemetry/android/agent/session/SessionConfig {
 	public static final field Companion Lio/opentelemetry/android/agent/session/SessionConfig$Companion;
 	public synthetic fun <init> (JJILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1-UwyO8pc ()J
-	public final fun component2-UwyO8pc ()J
-	public final fun copy-QTBD994 (JJ)Lio/opentelemetry/android/agent/session/SessionConfig;
-	public static synthetic fun copy-QTBD994$default (Lio/opentelemetry/android/agent/session/SessionConfig;JJILjava/lang/Object;)Lio/opentelemetry/android/agent/session/SessionConfig;
-	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBackgroundInactivityTimeout-UwyO8pc ()J
 	public final fun getMaxLifetime-UwyO8pc ()J
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 	public static final fun withDefaults ()Lio/opentelemetry/android/agent/session/SessionConfig;
 }
 

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/Incubating.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/Incubating.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android
+
+/**
+ * Marks an API as incubating. Incubating APIs can be subject to breaking change without warning
+ * between versions, and require an opt-in annotation to prevent compiler warnings.
+ *
+ * This annotation is intended for use on opentelemetry-android's API only and should not be used
+ * by library consumers on their own code.
+ */
+@RequiresOptIn(level = RequiresOptIn.Level.WARNING)
+@Retention(AnnotationRetention.BINARY)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.TYPEALIAS,
+)
+annotation class Incubating

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
@@ -6,6 +6,7 @@
 package io.opentelemetry.android.agent
 
 import android.app.Application
+import io.opentelemetry.android.Incubating
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.OpenTelemetryRumBuilder
 import io.opentelemetry.android.agent.connectivity.EndpointConnectivity
@@ -35,6 +36,7 @@ import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
 import kotlin.time.Duration
 import kotlin.time.toJavaDuration
 
+@OptIn(Incubating::class)
 object OpenTelemetryRumInitializer {
     /**
      * Opinionated [OpenTelemetryRum] initialization.

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionConfig.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionConfig.kt
@@ -5,11 +5,13 @@
 
 package io.opentelemetry.android.agent.session
 
+import io.opentelemetry.android.Incubating
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 
-data class SessionConfig(
+@Incubating
+class SessionConfig(
     val backgroundInactivityTimeout: Duration = 15.minutes,
     val maxLifetime: Duration = 4.hours,
 ) {


### PR DESCRIPTION
## Goal

Adds the `Incubating` annotation which [enforces `RequiresOptIn`](https://kotlinlang.org/api/core/kotlin-stdlib/kotlin/-requires-opt-in/) on any symbol with the annotation. This results in a compiler warning for any consumer of symbols from the library that they must suppress to get rid of the warnings.

I've only added this to `SessionConfig` to demonstrate how the annotation works. `OpenTelemetryRumInitializer` has opted in to the incubating API as it uses the `SessionConfig` symbol.

I haven't added the annotation to anywhere else on the API surface - that's probably something that should be discussed as part of the 1.0.0 roadmap talks. Personally I feel like adding this annotation to any part of the public API surface folks aren't confident will remain the same would be good if it meant that 1.0.0 shipped sooner as a result.