### PR TITLE
Hide symbols from public api

### DIFF
--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -77,27 +77,3 @@ public final class io/opentelemetry/android/agent/session/SessionConfig$Companio
 	public final fun withDefaults ()Lio/opentelemetry/android/agent/session/SessionConfig;
 }
 
-public abstract interface class io/opentelemetry/android/agent/session/SessionIdGenerator {
-	public abstract fun generateSessionId ()Ljava/lang/String;
-}
-
-public final class io/opentelemetry/android/agent/session/SessionIdGenerator$DEFAULT : io/opentelemetry/android/agent/session/SessionIdGenerator {
-	public static final field INSTANCE Lio/opentelemetry/android/agent/session/SessionIdGenerator$DEFAULT;
-	public fun generateSessionId ()Ljava/lang/String;
-}
-
-public abstract interface class io/opentelemetry/android/agent/session/SessionStorage {
-	public abstract fun get ()Lio/opentelemetry/android/session/Session;
-	public abstract fun save (Lio/opentelemetry/android/session/Session;)V
-}
-
-public final class io/opentelemetry/android/agent/session/SessionStorage$InMemory : io/opentelemetry/android/agent/session/SessionStorage {
-	public fun <init> ()V
-	public fun <init> (Lio/opentelemetry/android/session/Session;)V
-	public synthetic fun <init> (Lio/opentelemetry/android/session/Session;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun get ()Lio/opentelemetry/android/session/Session;
-	public final fun getSession ()Lio/opentelemetry/android/session/Session;
-	public fun save (Lio/opentelemetry/android/session/Session;)V
-	public final fun setSession (Lio/opentelemetry/android/session/Session;)V
-}
-

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/DefaultSessionIdGenerator.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/DefaultSessionIdGenerator.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.session
+
+import io.opentelemetry.api.trace.TraceId
+import kotlin.random.Random
+
+internal class DefaultSessionIdGenerator(
+    private val random: Random,
+) : SessionIdGenerator {
+    override fun generateSessionId(): String {
+        // The OTel TraceId has exactly the same format as a RUM SessionId, so let's re-use it here,
+        // rather than re-inventing the wheel.
+        return TraceId.fromLongs(random.nextLong(), random.nextLong())
+    }
+}

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/InMemorySessionStorage.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/InMemorySessionStorage.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.session
+
+import io.opentelemetry.android.session.Session
+
+internal class InMemorySessionStorage(
+    @Volatile var session: Session = Session.NONE,
+) : SessionStorage {
+    override fun get(): Session = session
+
+    override fun save(newSession: Session) {
+        this.session = newSession
+    }
+}

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionIdGenerator.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionIdGenerator.kt
@@ -5,18 +5,6 @@
 
 package io.opentelemetry.android.agent.session
 
-import io.opentelemetry.api.trace.TraceId
-import java.util.Random
-
-interface SessionIdGenerator {
+internal fun interface SessionIdGenerator {
     fun generateSessionId(): String
-
-    object DEFAULT : SessionIdGenerator {
-        override fun generateSessionId(): String {
-            val random = Random()
-            // The OTel TraceId has exactly the same format as a RUM SessionId, so let's re-use it here,
-            // rather than re-inventing the wheel.
-            return TraceId.fromLongs(random.nextLong(), random.nextLong())
-        }
-    }
 }

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionIdTimeoutHandler.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionIdTimeoutHandler.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.android.agent.session
 
+import io.opentelemetry.android.Incubating
 import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateListener
 import io.opentelemetry.sdk.common.Clock
 import kotlin.time.Duration
@@ -34,6 +35,7 @@ internal class SessionIdTimeoutHandler(
     private var state = State.FOREGROUND
 
     // for testing
+    @OptIn(Incubating::class)
     internal constructor(sessionConfig: SessionConfig) : this(
         Clock.getDefault(),
         sessionConfig.backgroundInactivityTimeout,

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionManager.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionManager.kt
@@ -5,19 +5,21 @@
 
 package io.opentelemetry.android.agent.session
 
+import io.opentelemetry.android.Incubating
 import io.opentelemetry.android.session.Session
 import io.opentelemetry.android.session.SessionObserver
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.android.session.SessionPublisher
 import io.opentelemetry.sdk.common.Clock
 import java.util.Collections.synchronizedList
+import kotlin.random.Random
 import kotlin.time.Duration
 
 internal class SessionManager(
     private val clock: Clock = Clock.getDefault(),
-    private val sessionStorage: SessionStorage = SessionStorage.InMemory(),
+    private val sessionStorage: SessionStorage = InMemorySessionStorage(),
     private val timeoutHandler: SessionIdTimeoutHandler,
-    private val idGenerator: SessionIdGenerator = SessionIdGenerator.DEFAULT,
+    private val idGenerator: SessionIdGenerator = DefaultSessionIdGenerator(Random.Default),
     private val maxSessionLifetime: Duration,
 ) : SessionProvider,
     SessionPublisher {
@@ -70,6 +72,7 @@ internal class SessionManager(
     }
 
     companion object {
+        @OptIn(Incubating::class)
         @JvmStatic
         fun create(
             timeoutHandler: SessionIdTimeoutHandler,

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionStorage.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionStorage.kt
@@ -7,18 +7,8 @@ package io.opentelemetry.android.agent.session
 
 import io.opentelemetry.android.session.Session
 
-interface SessionStorage {
+internal interface SessionStorage {
     fun get(): Session
 
     fun save(newSession: Session)
-
-    class InMemory(
-        @Volatile var session: Session = Session.NONE,
-    ) : SessionStorage {
-        override fun get(): Session = session
-
-        override fun save(newSession: Session) {
-            this.session = newSession
-        }
-    }
 }


### PR DESCRIPTION
## Goal

This changeset hides symbol from the public API exposed in `agent-api`. `SessionStorage` and `SessionIdGenerator` don't appear to be usable for an external consumer of the library, so IMO it makes sense to hide the concepts for now. I additionally separated out the implementations from the interfaces.