### PR TITLE
Remove all usages of ExtendedLog*

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumImpl.kt
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumImpl.kt
@@ -8,7 +8,7 @@ package io.opentelemetry.android
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.incubator.logs.ExtendedLogger
+import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.sdk.OpenTelemetrySdk
 
 internal class OpenTelemetryRumImpl(
@@ -16,10 +16,10 @@ internal class OpenTelemetryRumImpl(
     private val sessionProvider: SessionProvider,
     private val onShutdown: Runnable,
 ) : OpenTelemetryRum {
-    private val logger: ExtendedLogger =
+    private val logger: Logger =
         openTelemetrySdk.logsBridge
             .loggerBuilder("io.opentelemetry.rum.events")
-            .build() as ExtendedLogger
+            .build()
 
     override fun getOpenTelemetry(): OpenTelemetry = openTelemetrySdk
 

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -53,7 +53,6 @@ import io.opentelemetry.context.propagation.TextMapPropagator;
 import io.opentelemetry.contrib.disk.buffering.SpanToDiskExporter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
-import io.opentelemetry.sdk.logs.data.internal.ExtendedLogRecordData;
 import io.opentelemetry.sdk.logs.export.LogRecordExporter;
 import io.opentelemetry.sdk.logs.export.SimpleLogRecordProcessor;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
@@ -180,7 +179,7 @@ public class OpenTelemetryRumBuilderTest {
                         equalTo(stringKey("body.field"), "foo"))
                 .hasResource(resource);
         // TODO: verify event name inline above when the assertions framework can handle it
-        ExtendedLogRecordData log0 = (ExtendedLogRecordData) logs.get(0);
+        LogRecordData log0 = logs.get(0);
         assertThat(log0.getEventName()).isEqualTo("test.event");
     }
 

--- a/instrumentation/android-log/library/api/library.api
+++ b/instrumentation/android-log/library/api/library.api
@@ -26,7 +26,7 @@ public final class io/opentelemetry/instrumentation/library/log/AndroidLogSubsti
 public final class io/opentelemetry/instrumentation/library/log/internal/LogRecordBuilderCreator {
 	public static final field INSTANCE Lio/opentelemetry/instrumentation/library/log/internal/LogRecordBuilderCreator;
 	public static final fun configure (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
-	public static final fun createLogRecordBuilder ()Lio/opentelemetry/api/incubator/logs/ExtendedLogRecordBuilder;
+	public static final fun createLogRecordBuilder ()Lio/opentelemetry/api/logs/LogRecordBuilder;
 	public static final fun getTypeName (Ljava/lang/Throwable;)Ljava/lang/String;
 	public static final fun printStacktrace (Ljava/lang/Throwable;)Ljava/lang/String;
 }

--- a/instrumentation/android-log/library/src/main/kotlin/io/opentelemetry/instrumentation/library/log/internal/LogRecordBuilderCreator.kt
+++ b/instrumentation/android-log/library/src/main/kotlin/io/opentelemetry/instrumentation/library/log/internal/LogRecordBuilderCreator.kt
@@ -7,8 +7,7 @@ package io.opentelemetry.instrumentation.library.log.internal
 
 import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.api.OpenTelemetry
-import io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder
-import io.opentelemetry.api.incubator.logs.ExtendedLogger
+import io.opentelemetry.api.logs.LogRecordBuilder
 
 object LogRecordBuilderCreator {
     private var logger =
@@ -16,7 +15,7 @@ object LogRecordBuilderCreator {
             .noop()
             .logsBridge
             .loggerBuilder("io.opentelemetry.android.log.noop")
-            .build() as ExtendedLogger
+            .build()
 
     @JvmStatic
     fun configure(context: InstallationContext) {
@@ -24,11 +23,11 @@ object LogRecordBuilderCreator {
             context.openTelemetry
                 .logsBridge
                 .loggerBuilder("io.opentelemetry.android.log")
-                .build() as ExtendedLogger
+                .build()
     }
 
     @JvmStatic
-    fun createLogRecordBuilder(): ExtendedLogRecordBuilder = logger.logRecordBuilder()
+    fun createLogRecordBuilder(): LogRecordBuilder = logger.logRecordBuilder()
 
     @JvmStatic
     fun printStacktrace(throwable: Throwable): String = throwable.stackTraceToString()

--- a/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrWatcher.kt
+++ b/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrWatcher.kt
@@ -8,7 +8,7 @@ package io.opentelemetry.android.instrumentation.anr
 import android.os.Handler
 import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor
 import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder
+import io.opentelemetry.api.logs.LogRecordBuilder
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.context.Context
 import io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE
@@ -88,7 +88,7 @@ internal class AnrWatcher(
             attributesBuilder.putAll(extractedAttributes)
         }
 
-        val eventBuilder = anrLogger.logRecordBuilder() as ExtendedLogRecordBuilder
+        val eventBuilder = anrLogger.logRecordBuilder()
         eventBuilder
             .setEventName("device.anr")
             .setAllAttributes(attributesBuilder.build())

--- a/instrumentation/anr/src/test/java/io/opentelemetry/android/instrumentation/anr/AnrWatcherTest.kt
+++ b/instrumentation/anr/src/test/java/io/opentelemetry/android/instrumentation/anr/AnrWatcherTest.kt
@@ -11,7 +11,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder
+import io.opentelemetry.api.logs.LogRecordBuilder
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
 import org.junit.Before
@@ -28,7 +28,7 @@ class AnrWatcherTest {
     private lateinit var handler: Handler
     private lateinit var mainThread: Thread
     private lateinit var logger: Logger
-    private lateinit var logRecordBuilder: ExtendedLogRecordBuilder
+    private lateinit var logRecordBuilder: LogRecordBuilder
 
     @Before
     fun setup() {

--- a/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGenerator.kt
+++ b/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGenerator.kt
@@ -11,16 +11,17 @@ import android.view.MotionEvent
 import android.view.Window
 import androidx.compose.ui.node.LayoutNode
 import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder
-import io.opentelemetry.api.incubator.logs.ExtendedLogger
+import io.opentelemetry.api.logs.LogRecordBuilder
+import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_X
 import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_Y
 import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_ID
 import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_NAME
 import java.lang.ref.WeakReference
+import kotlin.let
 
 internal class ComposeClickEventGenerator(
-    private val eventLogger: ExtendedLogger,
+    private val eventLogger: Logger,
     private val composeLayoutNodeUtil: ComposeLayoutNodeUtil = ComposeLayoutNodeUtil(),
     private val composeTapTargetDetector: ComposeTapTargetDetector = ComposeTapTargetDetector(composeLayoutNodeUtil),
 ) {
@@ -58,7 +59,7 @@ internal class ComposeClickEventGenerator(
         windowRef = null
     }
 
-    private fun createEvent(name: String): ExtendedLogRecordBuilder =
+    private fun createEvent(name: String): LogRecordBuilder =
         eventLogger
             .logRecordBuilder()
             .setEventName(name)

--- a/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickInstrumentation.kt
+++ b/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickInstrumentation.kt
@@ -8,7 +8,6 @@ package io.opentelemetry.instrumentation.compose.click
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.instrumentation.InstallationContext
-import io.opentelemetry.api.incubator.logs.ExtendedLogger
 
 @AutoService(AndroidInstrumentation::class)
 class ComposeClickInstrumentation : AndroidInstrumentation {
@@ -21,7 +20,7 @@ class ComposeClickInstrumentation : AndroidInstrumentation {
                     ctx.openTelemetry
                         .logsBridge
                         .loggerBuilder("io.opentelemetry.android.instrumentation.compose.click")
-                        .build() as ExtendedLogger,
+                        .build()
                 ),
             ),
         )

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGeneratorTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGeneratorTest.kt
@@ -29,8 +29,6 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockkClass
-import io.opentelemetry.api.incubator.logs.ExtendedLogger
-import io.opentelemetry.sdk.logs.data.internal.ExtendedLogRecordData
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
@@ -78,7 +76,7 @@ internal class ComposeClickEventGeneratorTest {
             ComposeClickEventGenerator(
                 openTelemetryRule.openTelemetry.logsBridge
                     .loggerBuilder("io.opentelemetry.android.instrumentation.compose")
-                    .build() as ExtendedLogger,
+                    .build(),
                 composeLayoutNodeUtil,
             )
 
@@ -108,7 +106,7 @@ internal class ComposeClickEventGeneratorTest {
         val events = openTelemetryRule.logRecords
         assertThat(events).hasSize(2)
 
-        var event = events[0] as ExtendedLogRecordData
+        var event = events[0]
         OpenTelemetryAssertions
             .assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
@@ -117,7 +115,7 @@ internal class ComposeClickEventGeneratorTest {
                 equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
             )
 
-        event = events[1] as ExtendedLogRecordData
+        event = events[1]
         assertThat(event)
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfying(
@@ -145,7 +143,7 @@ internal class ComposeClickEventGeneratorTest {
         val events = openTelemetryRule.logRecords
         assertThat(events).hasSize(2)
 
-        var event = events[0] as ExtendedLogRecordData
+        var event = events[0]
         OpenTelemetryAssertions
             .assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
@@ -154,7 +152,7 @@ internal class ComposeClickEventGeneratorTest {
                 equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
             )
 
-        event = events[1] as ExtendedLogRecordData
+        event = events[1]
         assertThat(event)
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfying(
@@ -183,7 +181,7 @@ internal class ComposeClickEventGeneratorTest {
         val events = openTelemetryRule.logRecords
         assertThat(events).hasSize(2)
 
-        var event = events[0] as ExtendedLogRecordData
+        var event = events[0]
         OpenTelemetryAssertions
             .assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
@@ -192,7 +190,7 @@ internal class ComposeClickEventGeneratorTest {
                 equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
             )
 
-        event = events[1] as ExtendedLogRecordData
+        event = events[1]
         assertThat(event)
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfying(

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
@@ -41,7 +41,7 @@ import io.mockk.slot
 import io.mockk.verify
 import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.session.SessionProvider
-import io.opentelemetry.sdk.logs.data.internal.ExtendedLogRecordData
+import io.opentelemetry.sdk.logs.data.LogRecordData
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
@@ -149,7 +149,7 @@ internal class ComposeInstrumentationTest {
         val events = openTelemetryRule.logRecords
         assertThat(events).hasSize(2)
 
-        var event = events[0] as ExtendedLogRecordData
+        var event = events[0]
         assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
@@ -157,7 +157,7 @@ internal class ComposeInstrumentationTest {
                 equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
             )
 
-        event = events[1] as ExtendedLogRecordData
+        event = events[1]
         assertThat(event)
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfying(

--- a/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.kt
+++ b/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.kt
@@ -7,7 +7,6 @@ package io.opentelemetry.android.instrumentation.crash
 
 import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor
 import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder
 import io.opentelemetry.context.Context
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE
@@ -59,7 +58,7 @@ internal class CrashReporter(
             attributesBuilder.putAll(extractedAttributes)
         }
         val eventBuilder =
-            logger.logRecordBuilder() as ExtendedLogRecordBuilder
+            logger.logRecordBuilder()
         eventBuilder
             .setEventName("device.crash")
             .setAllAttributes(attributesBuilder.build())

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkApplicationListener.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkApplicationListener.kt
@@ -11,7 +11,6 @@ import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
 import io.opentelemetry.android.internal.services.network.NetworkChangeListener
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder
 import io.opentelemetry.api.logs.Logger
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.function.Consumer
@@ -59,7 +58,7 @@ internal class NetworkApplicationListener(
                     extractor(attributesBuilder, currentNetwork)
                 },
             )
-            val builder = eventLogger.logRecordBuilder() as ExtendedLogRecordBuilder
+            val builder = eventLogger.logRecordBuilder()
             builder
                 .setEventName("network.change")
                 .setAllAttributes(attributesBuilder.build())

--- a/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentationTest.kt
+++ b/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentationTest.kt
@@ -25,7 +25,6 @@ import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateL
 import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
 import io.opentelemetry.android.internal.services.network.NetworkChangeListener
 import io.opentelemetry.android.session.SessionProvider
-import io.opentelemetry.sdk.logs.data.internal.ExtendedLogRecordData
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
@@ -68,7 +67,7 @@ class NetworkChangeInstrumentationTest {
 
         val events = otelTesting.logRecords
         assertThat(events).hasSize(1)
-        val event = events[0] as ExtendedLogRecordData
+        val event = events[0]
         assertThat(event)
             .hasEventName("network.change")
             .hasAttributesSatisfyingExactly(
@@ -98,7 +97,7 @@ class NetworkChangeInstrumentationTest {
 
         val events = otelTesting.logRecords
         assertThat(events).hasSize(1)
-        val event = events[0] as ExtendedLogRecordData
+        val event = events[0]
         assertThat(event)
             .hasEventName("network.change")
             .hasAttributesSatisfyingExactly(
@@ -126,7 +125,7 @@ class NetworkChangeInstrumentationTest {
 
         val events = otelTesting.logRecords
         assertThat(events).hasSize(1)
-        val event = events[0] as ExtendedLogRecordData
+        val event = events[0]
         assertThat(event)
             .hasEventName("network.change")
             .hasAttributesSatisfyingExactly(
@@ -165,7 +164,7 @@ class NetworkChangeInstrumentationTest {
             CurrentNetwork(NetworkState.NO_NETWORK_AVAILABLE),
         )
         assertThat(otelTesting.logRecords).hasSize(1)
-        val event: ExtendedLogRecordData = otelTesting.logRecords[0] as ExtendedLogRecordData
+        val event = otelTesting.logRecords[0]
         assertThat(event)
             .hasEventName("network.change")
             .hasAttributesSatisfyingExactly(

--- a/instrumentation/okhttp3-websocket/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/websocket/internal/WebsocketEventGenerator.java
+++ b/instrumentation/okhttp3-websocket/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/websocket/internal/WebsocketEventGenerator.java
@@ -8,8 +8,8 @@ package io.opentelemetry.instrumentation.library.okhttp.v3_0.websocket.internal;
 import io.opentelemetry.android.instrumentation.InstallationContext;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder;
-import io.opentelemetry.api.incubator.logs.ExtendedLogger;
+import io.opentelemetry.api.logs.LogRecordBuilder;
+import io.opentelemetry.api.logs.Logger;
 
 public final class WebsocketEventGenerator {
 
@@ -17,17 +17,16 @@ public final class WebsocketEventGenerator {
 
     private static final String SCOPE = "io.opentelemetry.websocket.events";
 
-    private static ExtendedLogger logger =
-            (ExtendedLogger) OpenTelemetry.noop().getLogsBridge().loggerBuilder(SCOPE).build();
+    private static Logger logger =
+            OpenTelemetry.noop().getLogsBridge().loggerBuilder(SCOPE).build();
 
     public static void configure(InstallationContext context) {
         WebsocketEventGenerator.logger =
-                (ExtendedLogger)
                         context.getOpenTelemetry().getLogsBridge().loggerBuilder(SCOPE).build();
     }
 
     public static void generateEvent(String eventName, Attributes attributes) {
-        ExtendedLogRecordBuilder logRecordBuilder = logger.logRecordBuilder();
+        LogRecordBuilder logRecordBuilder = logger.logRecordBuilder();
         logRecordBuilder.setEventName(eventName).setAllAttributes(attributes).emit();
     }
 }

--- a/instrumentation/sessions/src/main/kotlin/io/opentelemetry/android/instrumentation/sessions/SessionIdEventSender.kt
+++ b/instrumentation/sessions/src/main/kotlin/io/opentelemetry/android/instrumentation/sessions/SessionIdEventSender.kt
@@ -9,7 +9,7 @@ import io.opentelemetry.android.common.RumConstants.Events.EVENT_SESSION_END
 import io.opentelemetry.android.common.RumConstants.Events.EVENT_SESSION_START
 import io.opentelemetry.android.session.Session
 import io.opentelemetry.android.session.SessionObserver
-import io.opentelemetry.api.incubator.logs.ExtendedLogger
+import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes.SESSION_ID
 import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes.SESSION_PREVIOUS_ID
 
@@ -18,7 +18,7 @@ import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes.SESSION_P
  * specified in the OpenTelemetry semantic conventions.
  */
 internal class SessionIdEventSender(
-    private val eventLogger: ExtendedLogger,
+    private val eventLogger: Logger,
 ) : SessionObserver {
     override fun onSessionStarted(
         newSession: Session,

--- a/instrumentation/sessions/src/main/kotlin/io/opentelemetry/android/instrumentation/sessions/SessionInstrumentation.kt
+++ b/instrumentation/sessions/src/main/kotlin/io/opentelemetry/android/instrumentation/sessions/SessionInstrumentation.kt
@@ -5,19 +5,20 @@
 
 package io.opentelemetry.android.instrumentation.sessions
 
+import com.google.auto.service.AutoService
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.session.SessionPublisher
-import io.opentelemetry.api.incubator.logs.ExtendedLogger
 
+@AutoService(AndroidInstrumentation::class)
 class SessionInstrumentation : AndroidInstrumentation {
     override val name: String = "session"
 
     override fun install(ctx: InstallationContext) {
-        val eventLogger: ExtendedLogger =
+        val eventLogger =
             ctx.openTelemetry.logsBridge
                 .loggerBuilder("otel.session")
-                .build() as ExtendedLogger
+                .build()
         val sessionProvider = ctx.sessionProvider
         if (sessionProvider is SessionPublisher) {
             sessionProvider.addObserver(SessionIdEventSender(eventLogger))

--- a/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/EventJankReporter.kt
+++ b/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/EventJankReporter.kt
@@ -9,7 +9,7 @@ import android.util.Log
 import io.opentelemetry.android.common.RumConstants
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder
+import io.opentelemetry.api.logs.LogRecordBuilder
 import io.opentelemetry.api.logs.Logger
 
 // TODO: Replace with semconv constants
@@ -43,7 +43,7 @@ internal class EventJankReporter(
         }
 
         if (frameCount > 0) {
-            val eventBuilder = eventLogger.logRecordBuilder() as ExtendedLogRecordBuilder
+            val eventBuilder = eventLogger.logRecordBuilder()
             val attributes =
                 Attributes
                     .builder()

--- a/instrumentation/startup/src/main/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEvents.kt
+++ b/instrumentation/startup/src/main/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEvents.kt
@@ -13,7 +13,6 @@ import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.common.Value
-import io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.sdk.trace.export.SpanExporter
 import java.time.Instant
@@ -75,7 +74,7 @@ class SdkInitializationEvents(
     }
 
     private fun Event.emit(logger: Logger) {
-        val eventBuilder: ExtendedLogRecordBuilder = logger.logRecordBuilder() as ExtendedLogRecordBuilder
+        val eventBuilder = logger.logRecordBuilder()
         eventBuilder
             .setEventName(name)
             .setTimestamp(timestamp)

--- a/instrumentation/startup/src/test/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEventsTest.kt
+++ b/instrumentation/startup/src/test/java/io/opentelemetry/android/instrumentation/startup/SdkInitializationEventsTest.kt
@@ -17,7 +17,6 @@ import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.logs.LogRecordProcessor
 import io.opentelemetry.sdk.logs.ReadWriteLogRecord
 import io.opentelemetry.sdk.logs.SdkLoggerProvider
-import io.opentelemetry.sdk.logs.data.internal.ExtendedLogRecordData
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.trace.export.SpanExporter
 import org.junit.jupiter.api.Test
@@ -93,7 +92,7 @@ class SdkInitializationEventsTest {
         private var attrs: Attributes? = null
 
         override fun accept(log: ReadWriteLogRecord) {
-            val logData: ExtendedLogRecordData = log.toLogRecordData() as ExtendedLogRecordData
+            val logData = log.toLogRecordData()
             assertThat(logData.timestampEpochNanos).isEqualTo(timeNs)
             assertThat(logData).hasEventName(name)
             if (body == null) {

--- a/instrumentation/view-click/api/view-click.api
+++ b/instrumentation/view-click/api/view-click.api
@@ -5,7 +5,7 @@ public final class io/opentelemetry/android/instrumentation/view/click/ViewClick
 }
 
 public final class io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator {
-	public fun <init> (Lio/opentelemetry/api/incubator/logs/ExtendedLogger;)V
+	public fun <init> (Lio/opentelemetry/api/logs/Logger;)V
 	public final fun generateClick (Landroid/view/MotionEvent;)V
 	public final fun startTracking (Landroid/view/Window;)V
 	public final fun stopTracking ()V

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
@@ -12,8 +12,8 @@ import android.view.Window
 import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_CLICK_EVENT_NAME
 import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_CLICK_EVENT_NAME
 import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.api.incubator.logs.ExtendedLogRecordBuilder
-import io.opentelemetry.api.incubator.logs.ExtendedLogger
+import io.opentelemetry.api.logs.LogRecordBuilder
+import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_X
 import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_Y
 import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_ID
@@ -22,7 +22,7 @@ import java.lang.ref.WeakReference
 import java.util.LinkedList
 
 class ViewClickEventGenerator(
-    private val eventLogger: ExtendedLogger,
+    private val eventLogger: Logger,
 ) {
     private var windowRef: WeakReference<Window>? = null
 
@@ -60,7 +60,7 @@ class ViewClickEventGenerator(
         windowRef = null
     }
 
-    private fun createEvent(name: String): ExtendedLogRecordBuilder =
+    private fun createEvent(name: String): LogRecordBuilder =
         eventLogger
             .logRecordBuilder()
             .setEventName(name)

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentation.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentation.kt
@@ -8,7 +8,6 @@ package io.opentelemetry.android.instrumentation.view.click
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.instrumentation.InstallationContext
-import io.opentelemetry.api.incubator.logs.ExtendedLogger
 
 @AutoService(AndroidInstrumentation::class)
 class ViewClickInstrumentation : AndroidInstrumentation {
@@ -21,7 +20,7 @@ class ViewClickInstrumentation : AndroidInstrumentation {
                     ctx.openTelemetry
                         .logsBridge
                         .loggerBuilder("io.opentelemetry.android.instrumentation.view.click")
-                        .build() as ExtendedLogger,
+                        .build()
                 ),
             ),
         )

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
@@ -26,7 +26,6 @@ import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_CLICK_EVENT_NAME
 import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_CLICK_EVENT_NAME
 import io.opentelemetry.android.session.SessionProvider
-import io.opentelemetry.sdk.logs.data.internal.ExtendedLogRecordData
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
@@ -105,7 +104,7 @@ class ViewClickInstrumentationTest {
         val events = openTelemetryRule.logRecords
         assertThat(events).hasSize(2)
 
-        var event = events[0] as ExtendedLogRecordData
+        var event = events[0]
         assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
@@ -113,7 +112,7 @@ class ViewClickInstrumentationTest {
                 equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
             )
 
-        event = events[1] as ExtendedLogRecordData
+        event = events[1]
         assertThat(event)
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
@@ -172,7 +171,7 @@ class ViewClickInstrumentationTest {
         val events = openTelemetryRule.logRecords
         assertThat(events).hasSize(2)
 
-        var event = events[0] as ExtendedLogRecordData
+        var event = events[0]
         assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
@@ -180,7 +179,7 @@ class ViewClickInstrumentationTest {
                 equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
             )
 
-        event = events[1] as ExtendedLogRecordData
+        event = events[1]
         assertThat(event)
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
@@ -239,7 +238,7 @@ class ViewClickInstrumentationTest {
         val events = openTelemetryRule.logRecords
         assertThat(events).hasSize(1)
 
-        val event = events[0] as ExtendedLogRecordData
+        val event = events[0]
         assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(


### PR DESCRIPTION
This includes:

* `ExtendedLogger`
* `ExtendedLogRecordBuilder`
* `ExtendedLogRecord`
* `ExtendedLogRecordData`

We originally used these while the event name field on logs was incubating, but it's stable now and these extended usages are superfluous. 