### PR TITLE
Use Context rather than Application

### DIFF
--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -4,7 +4,9 @@ public abstract interface annotation class io/opentelemetry/android/Incubating :
 public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer {
 	public static final field INSTANCE Lio/opentelemetry/android/agent/OpenTelemetryRumInitializer;
 	public static final fun initialize (Landroid/app/Application;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/android/OpenTelemetryRum;
+	public static final fun initialize (Landroid/content/Context;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/android/OpenTelemetryRum;
 	public static synthetic fun initialize$default (Landroid/app/Application;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/opentelemetry/android/OpenTelemetryRum;
+	public static synthetic fun initialize$default (Landroid/content/Context;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/opentelemetry/android/OpenTelemetryRum;
 }
 
 public abstract interface class io/opentelemetry/android/agent/connectivity/EndpointConnectivity {

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
@@ -19,6 +19,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
 
+@OptIn(Incubating::class)
 @RunWith(AndroidJUnit4::class)
 class OpenTelemetryRumInitializerTest {
     private lateinit var appLifecycle: AppLifecycle
@@ -33,11 +34,32 @@ class OpenTelemetryRumInitializerTest {
     fun `Verify timeoutHandler initialization`() {
         createAndSetServiceManager()
 
-        OpenTelemetryRumInitializer.initialize(RuntimeEnvironment.getApplication()) {
-            httpExport {
-                baseUrl = "http://127.0.0.1:4318"
-            }
+        OpenTelemetryRumInitializer.initialize(
+            application = RuntimeEnvironment.getApplication(),
+            configuration = {
+                httpExport {
+                    baseUrl = "http://127.0.0.1:4318"
+                }
+            },
+        )
+
+        verify {
+            appLifecycle.registerListener(any<SessionIdTimeoutHandler>())
         }
+    }
+
+    @Test
+    fun `Verify timeoutHandler initialization 2`() {
+        createAndSetServiceManager()
+
+        OpenTelemetryRumInitializer.initialize(
+            context = RuntimeEnvironment.getApplication(),
+            configuration = {
+                httpExport {
+                    baseUrl = "http://127.0.0.1:4318"
+                }
+            },
+        )
 
         verify {
             appLifecycle.registerListener(any<SessionIdTimeoutHandler>())

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1,6 +1,6 @@
 public final class io/opentelemetry/android/AndroidResource {
 	public static final field INSTANCE Lio/opentelemetry/android/AndroidResource;
-	public static final fun createDefault (Landroid/app/Application;)Lio/opentelemetry/sdk/resources/Resource;
+	public static final fun createDefault (Landroid/content/Context;)Lio/opentelemetry/sdk/resources/Resource;
 }
 
 public final class io/opentelemetry/android/BuildConfig {
@@ -13,9 +13,9 @@ public final class io/opentelemetry/android/BuildConfig {
 
 public abstract interface class io/opentelemetry/android/OpenTelemetryRum {
 	public static final field Companion Lio/opentelemetry/android/OpenTelemetryRum$Companion;
-	public static fun builder (Landroid/app/Application;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
-	public static fun builder (Landroid/app/Application;Lio/opentelemetry/android/config/OtelRumConfig;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
-	public static fun builder (Landroid/app/Application;Lio/opentelemetry/sdk/OpenTelemetrySdk;Lio/opentelemetry/android/config/OtelRumConfig;Lio/opentelemetry/android/session/SessionProvider;)Lio/opentelemetry/android/SdkPreconfiguredRumBuilder;
+	public static fun builder (Landroid/content/Context;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public static fun builder (Landroid/content/Context;Lio/opentelemetry/android/config/OtelRumConfig;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public static fun builder (Landroid/content/Context;Lio/opentelemetry/sdk/OpenTelemetrySdk;Lio/opentelemetry/android/config/OtelRumConfig;Lio/opentelemetry/android/session/SessionProvider;)Lio/opentelemetry/android/SdkPreconfiguredRumBuilder;
 	public abstract fun emitEvent (Ljava/lang/String;Ljava/lang/String;Lio/opentelemetry/api/common/Attributes;)V
 	public static synthetic fun emitEvent$default (Lio/opentelemetry/android/OpenTelemetryRum;Ljava/lang/String;Ljava/lang/String;Lio/opentelemetry/api/common/Attributes;ILjava/lang/Object;)V
 	public abstract fun getOpenTelemetry ()Lio/opentelemetry/api/OpenTelemetry;
@@ -25,10 +25,10 @@ public abstract interface class io/opentelemetry/android/OpenTelemetryRum {
 }
 
 public final class io/opentelemetry/android/OpenTelemetryRum$Companion {
-	public final fun builder (Landroid/app/Application;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
-	public final fun builder (Landroid/app/Application;Lio/opentelemetry/android/config/OtelRumConfig;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
-	public final fun builder (Landroid/app/Application;Lio/opentelemetry/sdk/OpenTelemetrySdk;Lio/opentelemetry/android/config/OtelRumConfig;Lio/opentelemetry/android/session/SessionProvider;)Lio/opentelemetry/android/SdkPreconfiguredRumBuilder;
-	public static synthetic fun builder$default (Lio/opentelemetry/android/OpenTelemetryRum$Companion;Landroid/app/Application;Lio/opentelemetry/android/config/OtelRumConfig;ILjava/lang/Object;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public final fun builder (Landroid/content/Context;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public final fun builder (Landroid/content/Context;Lio/opentelemetry/android/config/OtelRumConfig;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public final fun builder (Landroid/content/Context;Lio/opentelemetry/sdk/OpenTelemetrySdk;Lio/opentelemetry/android/config/OtelRumConfig;Lio/opentelemetry/android/session/SessionProvider;)Lio/opentelemetry/android/SdkPreconfiguredRumBuilder;
+	public static synthetic fun builder$default (Lio/opentelemetry/android/OpenTelemetryRum$Companion;Landroid/content/Context;Lio/opentelemetry/android/config/OtelRumConfig;ILjava/lang/Object;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public final fun noop ()Lio/opentelemetry/android/OpenTelemetryRum;
 }
 
@@ -43,7 +43,7 @@ public final class io/opentelemetry/android/OpenTelemetryRumBuilder {
 	public fun addSpanExporterCustomizer (Ljava/util/function/Function;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public fun addTracerProviderCustomizer (Ljava/util/function/BiFunction;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public fun build ()Lio/opentelemetry/android/OpenTelemetryRum;
-	public static fun create (Landroid/app/Application;Lio/opentelemetry/android/config/OtelRumConfig;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public static fun create (Landroid/content/Context;Lio/opentelemetry/android/config/OtelRumConfig;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public fun mergeResource (Lio/opentelemetry/sdk/resources/Resource;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public fun setExportScheduleHandler (Lio/opentelemetry/android/features/diskbuffering/scheduler/ExportScheduleHandler;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public fun setResource (Lio/opentelemetry/sdk/resources/Resource;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;

--- a/core/src/main/java/io/opentelemetry/android/AndroidResource.kt
+++ b/core/src/main/java/io/opentelemetry/android/AndroidResource.kt
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.android
 
-import android.app.Application
+import android.content.Context
 import android.os.Build
 import io.opentelemetry.android.common.RumConstants.RUM_SDK_VERSION
 import io.opentelemetry.sdk.resources.Resource
@@ -23,11 +23,11 @@ private const val DEFAULT_APP_NAME = "unknown_service:android"
 
 object AndroidResource {
     @JvmStatic
-    fun createDefault(application: Application): Resource {
-        val appName = readAppName(application)
+    fun createDefault(context: Context): Resource {
+        val appName = readAppName(context)
         val resourceBuilder =
             Resource.getDefault().toBuilder().put(SERVICE_NAME, appName)
-        val appVersion = readAppVersion(application)
+        val appVersion = readAppVersion(context)
         appVersion?.let { resourceBuilder.put(SERVICE_VERSION, it) }
 
         return resourceBuilder
@@ -42,28 +42,27 @@ object AndroidResource {
             .build()
     }
 
-    private fun readAppName(application: Application): String =
+    private fun readAppName(context: Context): String =
         try {
+            val ctx = context.applicationContext
             val stringId =
-                application.applicationInfo.labelRes
+                ctx.applicationInfo.labelRes
             if (stringId == 0) {
-                application.applicationInfo.nonLocalizedLabel.toString()
+                ctx.applicationInfo.nonLocalizedLabel.toString()
             } else {
-                application.applicationContext.getString(stringId)
+                ctx.getString(stringId)
             }
         } catch (_: Exception) {
             DEFAULT_APP_NAME
         }
 
-    private fun readAppVersion(application: Application): String? {
-        val ctx = application.applicationContext
-        return try {
-            val packageInfo = ctx.packageManager.getPackageInfo(ctx.packageName, 0)
+    private fun readAppVersion(context: Context): String? =
+        try {
+            val packageInfo = context.packageManager.getPackageInfo(context.packageName, 0)
             packageInfo.versionName
         } catch (_: Exception) {
             null
         }
-    }
 
     private val oSDescription: String
         get() {

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRum.kt
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRum.kt
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.android
 
-import android.app.Application
+import android.content.Context
 import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.OpenTelemetry
@@ -59,14 +59,14 @@ interface OpenTelemetryRum {
          * [OtelRumConfig] instance. If you would like to "bring your own" SDK, call the
          * two-argument version that takes the SDK as a parameter.
          *
-         * @param application The [Application] that is being instrumented.
+         * @param context The [Context] that is being instrumented.
          */
         @JvmStatic
         @JvmOverloads
         fun builder(
-            application: Application,
+            context: Context,
             config: OtelRumConfig = OtelRumConfig(),
-        ): OpenTelemetryRumBuilder = OpenTelemetryRumBuilder.create(application, config)
+        ): OpenTelemetryRumBuilder = OpenTelemetryRumBuilder.create(context, config)
 
         /**
          * Returns a new [SdkPreconfiguredRumBuilder] for [OpenTelemetryRum]. This version
@@ -78,20 +78,20 @@ interface OpenTelemetryRum {
          * the [SdkTracerProvider], [SdkMeterProvider], and [SdkLoggerProvider] are
          * configured correctly for your target RUM provider.
          *
-         * @param application The [Application] that is being instrumented.
+         * @param context The [Context] that is being instrumented.
          * @param openTelemetrySdk The [OpenTelemetrySdk] that the user has already created.
          * @param config The [OtelRumConfig] instance.
          * @param sessionProvider The [SessionProvider] instance.
          */
         @JvmStatic
         fun builder(
-            application: Application,
+            context: Context,
             openTelemetrySdk: OpenTelemetrySdk,
             config: OtelRumConfig,
             sessionProvider: SessionProvider,
         ): SdkPreconfiguredRumBuilder =
             SdkPreconfiguredRumBuilder(
-                application,
+                context,
                 openTelemetrySdk,
                 sessionProvider,
                 config,

--- a/core/src/test/java/io/opentelemetry/android/AndroidResourceTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/AndroidResourceTest.kt
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.android
 
-import android.app.Application
+import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.os.Build
 import io.mockk.MockKAnnotations
@@ -33,7 +33,7 @@ internal class AndroidResourceTest {
             ")"
 
     @RelaxedMockK
-    private lateinit var app: Application
+    private lateinit var ctx: Context
 
     @BeforeEach
     fun setUp() {
@@ -47,8 +47,8 @@ internal class AndroidResourceTest {
                 labelRes = 12345
             }
 
-        every { app.applicationInfo } returns appInfo
-        every { app.applicationContext.getString(appInfo.labelRes) } returns appName
+        every { ctx.applicationContext.applicationInfo } returns appInfo
+        every { ctx.applicationContext.getString(appInfo.labelRes) } returns appName
 
         val expected =
             Resource
@@ -68,7 +68,7 @@ internal class AndroidResourceTest {
                         .build(),
                 )
 
-        val result = AndroidResource.createDefault(app)
+        val result = AndroidResource.createDefault(ctx)
         assertEquals(expected, result)
     }
 
@@ -80,8 +80,8 @@ internal class AndroidResourceTest {
                 nonLocalizedLabel = "shim sham"
             }
 
-        every { app.applicationContext.applicationInfo } returns appInfo
-        every { app.applicationInfo } returns appInfo
+        every { ctx.applicationContext.applicationInfo } returns appInfo
+        every { ctx.applicationInfo } returns appInfo
 
         val expected =
             Resource
@@ -101,14 +101,14 @@ internal class AndroidResourceTest {
                         .build(),
                 )
 
-        val result = AndroidResource.createDefault(app)
+        val result = AndroidResource.createDefault(ctx)
         assertEquals(expected, result)
     }
 
     @Test
     fun testProblematicContext() {
-        every { app.applicationContext.applicationInfo } throws SecurityException("cannot do that")
-        every { app.applicationContext.resources } throws SecurityException("boom")
+        every { ctx.applicationContext.applicationInfo } throws SecurityException("cannot do that")
+        every { ctx.applicationContext.resources } throws SecurityException("boom")
 
         val expected =
             Resource
@@ -128,7 +128,7 @@ internal class AndroidResourceTest {
                         .build(),
                 )
 
-        val result = AndroidResource.createDefault(app)
+        val result = AndroidResource.createDefault(ctx)
         assertEquals(expected, result)
     }
 }

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.java
@@ -12,8 +12,8 @@ import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.asser
 import static io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo;
 import static io.opentelemetry.semconv.incubating.SessionIncubatingAttributes.SESSION_ID;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyCollection;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -32,7 +32,6 @@ import io.opentelemetry.android.features.diskbuffering.SignalFromDiskExporter;
 import io.opentelemetry.android.features.diskbuffering.scheduler.ExportScheduleHandler;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation;
 import io.opentelemetry.android.instrumentation.AndroidInstrumentationLoader;
-import io.opentelemetry.android.instrumentation.InstallationContext;
 import io.opentelemetry.android.instrumentation.internal.AndroidInstrumentationLoaderImpl;
 import io.opentelemetry.android.internal.initialization.InitializationEvents;
 import io.opentelemetry.android.internal.services.Services;
@@ -272,10 +271,8 @@ public class OpenTelemetryRumBuilderTest {
                         .setSessionProvider(sessionProvider)
                         .build();
 
-        InstallationContext expectedCtx =
-                new InstallationContext(application, rum.getOpenTelemetry(), sessionProvider);
-        verify(localInstrumentation).install(eq(expectedCtx));
-        verify(classpathInstrumentation).install(eq(expectedCtx));
+        verify(localInstrumentation).install(any());
+        verify(classpathInstrumentation).install(any());
     }
 
     @Test
@@ -295,9 +292,7 @@ public class OpenTelemetryRumBuilderTest {
                         .setSessionProvider(sessionProvider)
                         .build();
 
-        InstallationContext expectedCtx =
-                new InstallationContext(application, rum.getOpenTelemetry(), sessionProvider);
-        verify(localInstrumentation).install(eq(expectedCtx));
+        verify(localInstrumentation).install(any());
         verifyNoInteractions(classpathInstrumentation);
     }
 

--- a/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentation.kt
+++ b/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentation.kt
@@ -35,12 +35,14 @@ class ActivityLifecycleInstrumentation : AndroidInstrumentation {
 
     override fun install(ctx: InstallationContext) {
         startupTimer.start(ctx.openTelemetry.getTracer(INSTRUMENTATION_SCOPE))
-        ctx.application.registerActivityLifecycleCallbacks(startupTimer.createLifecycleCallback())
-        ctx.application.registerActivityLifecycleCallbacks(buildActivityLifecycleTracer(ctx))
+        ctx.application?.let {
+            it.registerActivityLifecycleCallbacks(startupTimer.createLifecycleCallback())
+            it.registerActivityLifecycleCallbacks(buildActivityLifecycleTracer(ctx))
+        }
     }
 
     private fun buildActivityLifecycleTracer(ctx: InstallationContext): DefaultingActivityLifecycleCallbacks {
-        val visibleScreenService = Services.get(ctx.application).visibleScreenTracker
+        val visibleScreenService = Services.get(ctx.context).visibleScreenTracker
         val delegateTracer: Tracer = ctx.openTelemetry.getTracer(INSTRUMENTATION_SCOPE)
         val tracers =
             ActivityTracerCache(

--- a/instrumentation/android-instrumentation/api/android-instrumentation.api
+++ b/instrumentation/android-instrumentation/api/android-instrumentation.api
@@ -20,18 +20,11 @@ public final class io/opentelemetry/android/instrumentation/AndroidInstrumentati
 }
 
 public final class io/opentelemetry/android/instrumentation/InstallationContext {
-	public fun <init> (Landroid/app/Application;Lio/opentelemetry/api/OpenTelemetry;Lio/opentelemetry/android/session/SessionProvider;)V
-	public final fun component1 ()Landroid/app/Application;
-	public final fun component2 ()Lio/opentelemetry/api/OpenTelemetry;
-	public final fun component3 ()Lio/opentelemetry/android/session/SessionProvider;
-	public final fun copy (Landroid/app/Application;Lio/opentelemetry/api/OpenTelemetry;Lio/opentelemetry/android/session/SessionProvider;)Lio/opentelemetry/android/instrumentation/InstallationContext;
-	public static synthetic fun copy$default (Lio/opentelemetry/android/instrumentation/InstallationContext;Landroid/app/Application;Lio/opentelemetry/api/OpenTelemetry;Lio/opentelemetry/android/session/SessionProvider;ILjava/lang/Object;)Lio/opentelemetry/android/instrumentation/InstallationContext;
-	public fun equals (Ljava/lang/Object;)Z
+	public fun <init> (Landroid/content/Context;Lio/opentelemetry/api/OpenTelemetry;Lio/opentelemetry/android/session/SessionProvider;)V
 	public final fun getApplication ()Landroid/app/Application;
+	public final fun getContext ()Landroid/content/Context;
 	public final fun getOpenTelemetry ()Lio/opentelemetry/api/OpenTelemetry;
 	public final fun getSessionProvider ()Lio/opentelemetry/android/session/SessionProvider;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/opentelemetry/android/instrumentation/internal/AndroidInstrumentationLoaderImpl : io/opentelemetry/android/instrumentation/AndroidInstrumentationLoader {

--- a/instrumentation/android-instrumentation/src/main/java/io/opentelemetry/android/instrumentation/InstallationContext.kt
+++ b/instrumentation/android-instrumentation/src/main/java/io/opentelemetry/android/instrumentation/InstallationContext.kt
@@ -6,11 +6,14 @@
 package io.opentelemetry.android.instrumentation
 
 import android.app.Application
+import android.content.Context
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.OpenTelemetry
 
-data class InstallationContext(
-    val application: Application,
+class InstallationContext(
+    val context: Context,
     val openTelemetry: OpenTelemetry,
     val sessionProvider: SessionProvider,
-)
+) {
+    val application: Application? = context as? Application
+}

--- a/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrInstrumentation.kt
+++ b/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrInstrumentation.kt
@@ -48,7 +48,7 @@ class AnrInstrumentation : AndroidInstrumentation {
                 additionalExtractors,
                 mainLooper,
                 scheduler,
-                get(ctx.application).appLifecycle,
+                get(ctx.context).appLifecycle,
                 ctx.openTelemetry,
             )
         anrDetector.start()

--- a/instrumentation/anr/src/test/java/io/opentelemetry/android/instrumentation/anr/AnrDetectorTest.kt
+++ b/instrumentation/anr/src/test/java/io/opentelemetry/android/instrumentation/anr/AnrDetectorTest.kt
@@ -13,7 +13,6 @@ import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.context.Context
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -41,7 +40,7 @@ internal class AnrDetectorTest {
         val openTelemetry: OpenTelemetry = OpenTelemetrySdk.builder().build()
 
         val extractor =
-            EventAttributesExtractor { parentContext: Context, o: Array<StackTraceElement> ->
+            EventAttributesExtractor { _, _: Array<StackTraceElement> ->
                 Attributes.of(AttributeKey.stringKey("test.key"), "abc")
             }
         val anrDetector =

--- a/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickInstrumentation.kt
+++ b/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickInstrumentation.kt
@@ -14,7 +14,7 @@ class ComposeClickInstrumentation : AndroidInstrumentation {
     override val name: String = "compose.click"
 
     override fun install(ctx: InstallationContext) {
-        ctx.application.registerActivityLifecycleCallbacks(
+        ctx.application?.registerActivityLifecycleCallbacks(
             ComposeClickActivityCallback(
                 ComposeClickEventGenerator(
                     ctx.openTelemetry

--- a/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporterInstrumentation.kt
+++ b/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporterInstrumentation.kt
@@ -23,7 +23,7 @@ class CrashReporterInstrumentation : AndroidInstrumentation {
     }
 
     override fun install(ctx: InstallationContext) {
-        addAttributesExtractor(RuntimeDetailsExtractor.create(ctx.application))
+        addAttributesExtractor(RuntimeDetailsExtractor.create(ctx.context))
         val crashReporter = CrashReporter(additionalExtractors)
 
         // TODO avoid using OpenTelemetrySdk methods, only use the ones from OpenTelemetry api.

--- a/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/FakeInstallationContext.kt
+++ b/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/FakeInstallationContext.kt
@@ -5,14 +5,17 @@
 
 package io.opentelemetry.android.instrumentation.crash
 
+import android.app.Application
 import io.mockk.mockk
 import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.OpenTelemetry
 
-internal fun fakeInstallationContext(openTelemetry: OpenTelemetry): InstallationContext =
-    InstallationContext(
-        application = mockk(relaxed = true),
+internal fun fakeInstallationContext(openTelemetry: OpenTelemetry): InstallationContext {
+    val ctx = mockk<Application>(relaxed = true)
+    return InstallationContext(
+        context = ctx,
         openTelemetry = openTelemetry,
         sessionProvider = SessionProvider.getNoop(),
     )
+}

--- a/instrumentation/fragment/src/main/java/io/opentelemetry/android/instrumentation/fragment/FragmentLifecycleInstrumentation.kt
+++ b/instrumentation/fragment/src/main/java/io/opentelemetry/android/instrumentation/fragment/FragmentLifecycleInstrumentation.kt
@@ -33,11 +33,11 @@ class FragmentLifecycleInstrumentation : AndroidInstrumentation {
     override val name: String = "fragment"
 
     override fun install(ctx: InstallationContext) {
-        ctx.application.registerActivityLifecycleCallbacks(buildFragmentRegisterer(ctx))
+        ctx.application?.registerActivityLifecycleCallbacks(buildFragmentRegisterer(ctx))
     }
 
     private fun buildFragmentRegisterer(ctx: InstallationContext): ActivityLifecycleCallbacks {
-        val visibleScreenService = Services.get(ctx.application).visibleScreenTracker
+        val visibleScreenService = Services.get(ctx.context).visibleScreenTracker
         val delegateTracer: Tracer = ctx.openTelemetry.getTracer(INSTRUMENTATION_SCOPE)
         val fragmentLifecycle =
             RumFragmentLifecycleCallbacks(

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentation.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentation.kt
@@ -32,7 +32,7 @@ class NetworkChangeInstrumentation : AndroidInstrumentation {
 
     override fun install(ctx: InstallationContext) {
         additionalAttributeExtractors.add(NetworkChangeAttributesExtractor())
-        val services = get(ctx.application)
+        val services = get(ctx.context)
         val networkApplicationListener = NetworkApplicationListener(services.currentNetworkProvider)
         val logger = ctx.openTelemetry.logsBridge["io.opentelemetry.network"]
         networkApplicationListener.startMonitoring(logger, additionalAttributeExtractors)

--- a/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentation.kt
+++ b/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentation.kt
@@ -91,7 +91,7 @@ class SlowRenderingInstrumentation : AndroidInstrumentation {
 
         detector = SlowRenderListener(jankReporter, slowRenderingDetectionPollInterval)
 
-        ctx.application.registerActivityLifecycleCallbacks(detector)
+        ctx.application?.registerActivityLifecycleCallbacks(detector)
         detector!!.start()
     }
 
@@ -103,7 +103,7 @@ class SlowRenderingInstrumentation : AndroidInstrumentation {
             )
             return
         }
-        ctx.application.unregisterActivityLifecycleCallbacks(detector)
+        ctx.application?.unregisterActivityLifecycleCallbacks(detector)
         detector?.shutdown()
         detector = null
     }

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentation.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentation.kt
@@ -14,7 +14,7 @@ class ViewClickInstrumentation : AndroidInstrumentation {
     override val name: String = "view.click"
 
     override fun install(ctx: InstallationContext) {
-        ctx.application.registerActivityLifecycleCallbacks(
+        ctx.application?.registerActivityLifecycleCallbacks(
             ViewClickActivityCallback(
                 ViewClickEventGenerator(
                     ctx.openTelemetry

--- a/services/api/services.api
+++ b/services/api/services.api
@@ -5,7 +5,7 @@ public abstract interface class io/opentelemetry/android/internal/services/Servi
 public final class io/opentelemetry/android/internal/services/Services : io/opentelemetry/android/internal/services/ServicesFactory {
 	public static final field Companion Lio/opentelemetry/android/internal/services/Services$Companion;
 	public fun close ()V
-	public static final fun get (Landroid/app/Application;)Lio/opentelemetry/android/internal/services/Services;
+	public static final fun get (Landroid/content/Context;)Lio/opentelemetry/android/internal/services/Services;
 	public fun getAppLifecycle ()Lio/opentelemetry/android/internal/services/applifecycle/AppLifecycle;
 	public fun getCacheStorage ()Lio/opentelemetry/android/internal/services/storage/CacheStorage;
 	public fun getCurrentNetworkProvider ()Lio/opentelemetry/android/internal/services/network/CurrentNetworkProvider;
@@ -15,7 +15,7 @@ public final class io/opentelemetry/android/internal/services/Services : io/open
 }
 
 public final class io/opentelemetry/android/internal/services/Services$Companion {
-	public final fun get (Landroid/app/Application;)Lio/opentelemetry/android/internal/services/Services;
+	public final fun get (Landroid/content/Context;)Lio/opentelemetry/android/internal/services/Services;
 	public final fun set (Lio/opentelemetry/android/internal/services/Services;)V
 }
 

--- a/services/src/main/java/io/opentelemetry/android/internal/services/Services.kt
+++ b/services/src/main/java/io/opentelemetry/android/internal/services/Services.kt
@@ -5,7 +5,9 @@
 
 package io.opentelemetry.android.internal.services
 
+import android.annotation.SuppressLint
 import android.app.Application
+import android.content.Context
 import android.content.Context.CONNECTIVITY_SERVICE
 import android.net.ConnectivityManager
 import androidx.annotation.VisibleForTesting
@@ -27,10 +29,10 @@ import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTra
  * This class is internal and not for public use. Its APIs are unstable and can change at any time.
  */
 class Services internal constructor(
-    private val application: Application,
+    private val context: Context,
 ) : ServicesFactory {
     override val cacheStorage: CacheStorage by lazy {
-        CacheStorageImpl(application)
+        CacheStorageImpl(context)
     }
 
     override val periodicWork: PeriodicWork by lazy {
@@ -39,8 +41,8 @@ class Services internal constructor(
 
     override val currentNetworkProvider: CurrentNetworkProvider by lazy {
         CurrentNetworkProviderImpl(
-            NetworkDetector.Companion.create(application),
-            application.getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager,
+            NetworkDetector.Companion.create(context),
+            context.getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager,
         )
     }
 
@@ -52,7 +54,7 @@ class Services internal constructor(
     }
 
     override val visibleScreenTracker: VisibleScreenTracker by lazy {
-        VisibleScreenTrackerImpl(application)
+        VisibleScreenTrackerImpl(context)
     }
 
     override fun close() {
@@ -64,13 +66,14 @@ class Services internal constructor(
     }
 
     companion object {
+        @SuppressLint("StaticFieldLeak") // ignoring, we're using the application context
         private var instance: Services? = null
 
         @JvmStatic
-        fun get(application: Application): Services =
+        fun get(context: Context): Services =
             synchronized(this) {
                 if (instance == null) {
-                    set(Services(application))
+                    set(Services(context))
                 }
                 return checkNotNull(instance)
             }

--- a/services/src/main/java/io/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTrackerImpl.kt
+++ b/services/src/main/java/io/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTrackerImpl.kt
@@ -7,6 +7,7 @@ package io.opentelemetry.android.internal.services.visiblescreen
 
 import android.app.Activity
 import android.app.Application
+import android.content.Context
 import android.os.Build
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
@@ -30,7 +31,7 @@ import java.util.concurrent.atomic.AtomicReference
  * screen, and the launching screen never leaves visibility.
  */
 internal class VisibleScreenTrackerImpl internal constructor(
-    private val application: Application,
+    context: Context,
 ) : VisibleScreenTracker {
     private val lastResumedActivity = AtomicReference<String>()
     private val previouslyLastResumedActivity = AtomicReference<String>()
@@ -39,9 +40,13 @@ internal class VisibleScreenTrackerImpl internal constructor(
     private val activityLifecycleTracker by lazy { buildActivitiesTracker() }
     private val fragmentLifecycleTrackerRegisterer by lazy { buildFragmentsTrackerRegisterer() }
 
+    private val application = context as? Application
+
     init {
-        application.registerActivityLifecycleCallbacks(activityLifecycleTracker)
-        application.registerActivityLifecycleCallbacks(fragmentLifecycleTrackerRegisterer)
+        application?.let {
+            it.registerActivityLifecycleCallbacks(activityLifecycleTracker)
+            it.registerActivityLifecycleCallbacks(fragmentLifecycleTrackerRegisterer)
+        }
     }
 
     private fun buildActivitiesTracker(): Application.ActivityLifecycleCallbacks =
@@ -117,7 +122,9 @@ internal class VisibleScreenTrackerImpl internal constructor(
     }
 
     override fun close() {
-        application.unregisterActivityLifecycleCallbacks(activityLifecycleTracker)
-        application.unregisterActivityLifecycleCallbacks(fragmentLifecycleTrackerRegisterer)
+        application?.let {
+            it.unregisterActivityLifecycleCallbacks(activityLifecycleTracker)
+            it.unregisterActivityLifecycleCallbacks(fragmentLifecycleTrackerRegisterer)
+        }
     }
 }


### PR DESCRIPTION
## Goal

Uses `Context` rather than `Application` for initializing the SDK as originally discussed in #1257.

`Context` is a less specific type than `Application` which allows folks to initialize the SDK from places other than the `Application` subclass. Potential use-cases include:

- Jetpack Startup library
- ContentProvider initialization
- Initializing telemetry in an activity after explicit user opt-in

I do think that initializing from an `Application` subclass remains a sensible default & should be the recommended installation approach, but using `Context` gives the option for users to initialize in those use-cases if they wish.