### PR TITLE
Adding support for otel.stable property

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,9 +27,6 @@ allprojects {
         google()
         mavenCentral()
     }
-    if (findProperty("final") != "true") {
-        version = "$version-SNAPSHOT"
-    }
 }
 
 nexusPublishing {

--- a/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.publish-conventions.gradle.kts
@@ -5,8 +5,23 @@ plugins {
     id("signing")
 }
 
-version = project.version.toString().replaceFirst("(-SNAPSHOT)?$".toRegex(), "-alpha$1")
+// If this module is not marked as stable (the default state) then append "-alpha" to its version.
+// ---
+// To mark a module as stable, it needs to define the following property: "otel.stable=true" preferably within a "gradle.properties" file
+// located in the same directory as the target module's "build.gradle.kts" file.
+if (findProperty("otel.stable") != "true") {
+    version = "$version-alpha"
+}
+// If this release isn't "final" (the default state) then append "-SNAPSHOT" to this module's version.
+// ---
+// To make a release "final", the gradle release command must include the "-Pfinal=true" argument.
+// For example: "./gradlew publishToMavenLocal -Pfinal=true".
+if (findProperty("final") != "true") {
+    version = "$version-SNAPSHOT"
+}
 
+// When isARelease is `false`, only the main deliverable is generated (.aar/.jar file) and is not signed.
+// When isARelease is `true`, some extra work is done to also generate javadoc/sources artifacts, while signing them all as well.
 val isARelease = System.getenv("CI") != null
 
 val android = extensions.findByType(LibraryExtension::class.java)


### PR DESCRIPTION
This is to enable a similar mechanism to the one used in OTel Java Contrib, for example, where a module that has the property `otel.stable=true` doesn't get the `-alpha` suffix on its version. This will allow us to mark the `android-agent` as stable in the future.