### PR TITLE
Demonstrate type-safe DSL for initializing OpenTelemetry

### DIFF
--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -3,50 +3,8 @@ public abstract interface annotation class io/opentelemetry/android/Incubating :
 
 public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer {
 	public static final field INSTANCE Lio/opentelemetry/android/agent/OpenTelemetryRumInitializer;
-	public static final fun initialize (Landroid/app/Application;Ljava/lang/String;Ljava/util/Map;Lio/opentelemetry/android/agent/connectivity/EndpointConnectivity;Lio/opentelemetry/android/agent/connectivity/EndpointConnectivity;Lio/opentelemetry/android/agent/connectivity/EndpointConnectivity;Lio/opentelemetry/android/config/OtelRumConfig;Lio/opentelemetry/android/agent/session/SessionConfig;Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/android/OpenTelemetryRum;
-	public static synthetic fun initialize$default (Landroid/app/Application;Ljava/lang/String;Ljava/util/Map;Lio/opentelemetry/android/agent/connectivity/EndpointConnectivity;Lio/opentelemetry/android/agent/connectivity/EndpointConnectivity;Lio/opentelemetry/android/agent/connectivity/EndpointConnectivity;Lio/opentelemetry/android/config/OtelRumConfig;Lio/opentelemetry/android/agent/session/SessionConfig;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/opentelemetry/android/OpenTelemetryRum;
-}
-
-public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer$ActivityLifecycleConfiguration : io/opentelemetry/android/agent/OpenTelemetryRumInitializer$CanBeEnabledAndDisabled, io/opentelemetry/android/agent/OpenTelemetryRumInitializer$ScreenLifecycleConfigurable {
-	public fun enabled (Z)V
-	public fun screenNameExtractor (Lio/opentelemetry/android/instrumentation/common/ScreenNameExtractor;)V
-	public fun tracerCustomizer (Lkotlin/jvm/functions/Function1;)V
-}
-
-public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer$AnrReporterConfiguration : io/opentelemetry/android/agent/OpenTelemetryRumInitializer$CanBeEnabledAndDisabled, io/opentelemetry/android/agent/OpenTelemetryRumInitializer$WithEventAttributes {
-	public fun addAttributesExtractor (Lio/opentelemetry/android/instrumentation/common/EventAttributesExtractor;)V
-	public fun enabled (Z)V
-}
-
-public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer$CrashReporterConfiguration : io/opentelemetry/android/agent/OpenTelemetryRumInitializer$CanBeEnabledAndDisabled, io/opentelemetry/android/agent/OpenTelemetryRumInitializer$WithEventAttributes {
-	public fun addAttributesExtractor (Lio/opentelemetry/android/instrumentation/common/EventAttributesExtractor;)V
-	public fun enabled (Z)V
-}
-
-public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer$FragmentLifecycleConfiguration : io/opentelemetry/android/agent/OpenTelemetryRumInitializer$CanBeEnabledAndDisabled, io/opentelemetry/android/agent/OpenTelemetryRumInitializer$ScreenLifecycleConfigurable {
-	public fun enabled (Z)V
-	public fun screenNameExtractor (Lio/opentelemetry/android/instrumentation/common/ScreenNameExtractor;)V
-	public fun tracerCustomizer (Lkotlin/jvm/functions/Function1;)V
-}
-
-public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer$InstrumentationConfiguration {
-	public final fun activity (Lkotlin/jvm/functions/Function1;)V
-	public final fun anrReporter (Lkotlin/jvm/functions/Function1;)V
-	public final fun crashReporter (Lkotlin/jvm/functions/Function1;)V
-	public final fun fragment (Lkotlin/jvm/functions/Function1;)V
-	public final fun networkMonitoring (Lkotlin/jvm/functions/Function1;)V
-	public final fun slowRenderingReporter (Lkotlin/jvm/functions/Function1;)V
-}
-
-public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer$NetworkMonitoringConfiguration : io/opentelemetry/android/agent/OpenTelemetryRumInitializer$CanBeEnabledAndDisabled {
-	public final fun addAttributesExtractor (Lio/opentelemetry/android/instrumentation/network/NetworkAttributesExtractor;)V
-	public fun enabled (Z)V
-}
-
-public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer$SlowRenderingReporterConfiguration : io/opentelemetry/android/agent/OpenTelemetryRumInitializer$CanBeEnabledAndDisabled {
-	public final fun detectionPollInterval-LRDsOJo (J)V
-	public final fun enableVerboseDebugLogging ()V
-	public fun enabled (Z)V
+	public static final fun initialize (Landroid/app/Application;Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/android/OpenTelemetryRum;
+	public static synthetic fun initialize$default (Landroid/app/Application;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/opentelemetry/android/OpenTelemetryRum;
 }
 
 public abstract interface class io/opentelemetry/android/agent/connectivity/EndpointConnectivity {
@@ -68,6 +26,84 @@ public final class io/opentelemetry/android/agent/connectivity/HttpEndpointConne
 	public static synthetic fun forMetrics$default (Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity$Companion;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity;
 	public final fun forTraces (Ljava/lang/String;Ljava/util/Map;)Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity;
 	public static synthetic fun forTraces$default (Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity$Companion;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity;
+}
+
+public final class io/opentelemetry/android/agent/dsl/EndpointConfiguration {
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getHeaders ()Ljava/util/Map;
+	public final fun getUrl ()Ljava/lang/String;
+	public final fun setHeaders (Ljava/util/Map;)V
+	public final fun setUrl (Ljava/lang/String;)V
+}
+
+public final class io/opentelemetry/android/agent/dsl/HttpExportConfiguration {
+	public fun <init> ()V
+	public final fun getBaseHeaders ()Ljava/util/Map;
+	public final fun getBaseUrl ()Ljava/lang/String;
+	public final fun logs (Lkotlin/jvm/functions/Function1;)V
+	public final fun metrics (Lkotlin/jvm/functions/Function1;)V
+	public final fun setBaseHeaders (Ljava/util/Map;)V
+	public final fun setBaseUrl (Ljava/lang/String;)V
+	public final fun spans (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration {
+	public fun <init> ()V
+	public final fun httpExport (Lkotlin/jvm/functions/Function1;)V
+	public final fun instrumentations (Lkotlin/jvm/functions/Function1;)V
+	public final fun session (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class io/opentelemetry/android/agent/dsl/SessionConfiguration {
+	public synthetic fun <init> (JJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getBackgroundInactivityTimeout-UwyO8pc ()J
+	public final fun getMaxLifetime-UwyO8pc ()J
+	public final fun setBackgroundInactivityTimeout-LRDsOJo (J)V
+	public final fun setMaxLifetime-LRDsOJo (J)V
+}
+
+public final class io/opentelemetry/android/agent/dsl/instrumentation/ActivityLifecycleConfiguration : io/opentelemetry/android/agent/dsl/instrumentation/CanBeEnabledAndDisabled, io/opentelemetry/android/agent/dsl/instrumentation/ScreenLifecycleConfigurable {
+	public fun enabled (Z)V
+	public fun screenNameExtractor (Lio/opentelemetry/android/instrumentation/common/ScreenNameExtractor;)V
+	public fun tracerCustomizer (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class io/opentelemetry/android/agent/dsl/instrumentation/AnrReporterConfiguration : io/opentelemetry/android/agent/dsl/instrumentation/CanBeEnabledAndDisabled, io/opentelemetry/android/agent/dsl/instrumentation/WithEventAttributes {
+	public fun addAttributesExtractor (Lio/opentelemetry/android/instrumentation/common/EventAttributesExtractor;)V
+	public fun enabled (Z)V
+}
+
+public final class io/opentelemetry/android/agent/dsl/instrumentation/CrashReporterConfiguration : io/opentelemetry/android/agent/dsl/instrumentation/CanBeEnabledAndDisabled, io/opentelemetry/android/agent/dsl/instrumentation/WithEventAttributes {
+	public fun addAttributesExtractor (Lio/opentelemetry/android/instrumentation/common/EventAttributesExtractor;)V
+	public fun enabled (Z)V
+}
+
+public final class io/opentelemetry/android/agent/dsl/instrumentation/FragmentLifecycleConfiguration : io/opentelemetry/android/agent/dsl/instrumentation/CanBeEnabledAndDisabled, io/opentelemetry/android/agent/dsl/instrumentation/ScreenLifecycleConfigurable {
+	public fun enabled (Z)V
+	public fun screenNameExtractor (Lio/opentelemetry/android/instrumentation/common/ScreenNameExtractor;)V
+	public fun tracerCustomizer (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class io/opentelemetry/android/agent/dsl/instrumentation/InstrumentationConfiguration {
+	public final fun activity (Lkotlin/jvm/functions/Function1;)V
+	public final fun anrReporter (Lkotlin/jvm/functions/Function1;)V
+	public final fun crashReporter (Lkotlin/jvm/functions/Function1;)V
+	public final fun fragment (Lkotlin/jvm/functions/Function1;)V
+	public final fun networkMonitoring (Lkotlin/jvm/functions/Function1;)V
+	public final fun slowRenderingReporter (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class io/opentelemetry/android/agent/dsl/instrumentation/NetworkMonitoringConfiguration : io/opentelemetry/android/agent/dsl/instrumentation/CanBeEnabledAndDisabled {
+	public final fun addAttributesExtractor (Lio/opentelemetry/android/instrumentation/network/NetworkAttributesExtractor;)V
+	public fun enabled (Z)V
+}
+
+public final class io/opentelemetry/android/agent/dsl/instrumentation/SlowRenderingReporterConfiguration : io/opentelemetry/android/agent/dsl/instrumentation/CanBeEnabledAndDisabled {
+	public final fun detectionPollInterval-LRDsOJo (J)V
+	public final fun enableVerboseDebugLogging ()V
+	public fun enabled (Z)V
 }
 
 public final class io/opentelemetry/android/agent/session/SessionConfig {

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
@@ -8,33 +8,17 @@ package io.opentelemetry.android.agent
 import android.app.Application
 import io.opentelemetry.android.Incubating
 import io.opentelemetry.android.OpenTelemetryRum
-import io.opentelemetry.android.OpenTelemetryRumBuilder
-import io.opentelemetry.android.agent.connectivity.EndpointConnectivity
-import io.opentelemetry.android.agent.connectivity.HttpEndpointConnectivity
+import io.opentelemetry.android.agent.dsl.OpenTelemetryConfiguration
 import io.opentelemetry.android.agent.session.SessionConfig
 import io.opentelemetry.android.agent.session.SessionIdTimeoutHandler
 import io.opentelemetry.android.agent.session.SessionManager
-import io.opentelemetry.android.config.OtelRumConfig
-import io.opentelemetry.android.instrumentation.AndroidInstrumentation
-import io.opentelemetry.android.instrumentation.AndroidInstrumentationLoader
-import io.opentelemetry.android.instrumentation.activity.ActivityLifecycleInstrumentation
-import io.opentelemetry.android.instrumentation.anr.AnrInstrumentation
-import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor
-import io.opentelemetry.android.instrumentation.common.ScreenNameExtractor
-import io.opentelemetry.android.instrumentation.crash.CrashDetails
-import io.opentelemetry.android.instrumentation.crash.CrashReporterInstrumentation
-import io.opentelemetry.android.instrumentation.fragment.FragmentLifecycleInstrumentation
-import io.opentelemetry.android.instrumentation.network.NetworkAttributesExtractor
-import io.opentelemetry.android.instrumentation.network.NetworkChangeInstrumentation
-import io.opentelemetry.android.instrumentation.slowrendering.SlowRenderingInstrumentation
 import io.opentelemetry.android.internal.services.Services
 import io.opentelemetry.android.session.SessionProvider
-import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
-import kotlin.time.Duration
-import kotlin.time.toJavaDuration
+import kotlin.time.Duration.Companion.minutes
 
 @OptIn(Incubating::class)
 object OpenTelemetryRumInitializer {
@@ -42,63 +26,43 @@ object OpenTelemetryRumInitializer {
      * Opinionated [OpenTelemetryRum] initialization.
      *
      * @param application Your android app's application object.
-     * @param endpointBaseUrl The base endpoint for exporting all your signals.
-     * @param endpointHeaders These will be added to each signal export request.
-     * @param spanEndpointConnectivity Span-specific endpoint configuration.
-     * @param logEndpointConnectivity Log-specific endpoint configuration.
-     * @param metricEndpointConnectivity Metric-specific endpoint configuration.
-     * @param rumConfig Configuration used by [OpenTelemetryRumBuilder].
-     * @param sessionConfig The session configuration, which includes inactivity timeout and maximum lifetime durations.
-     * @param instrumentations Configurations for all the default instrumentations.
+     * @param openTelemetryConfiguration Type-safe config DSL that controls how OpenTelemetry
+     * should behave.
      */
     @Suppress("LongParameterList")
     @JvmStatic
     fun initialize(
         application: Application,
-        endpointBaseUrl: String,
-        endpointHeaders: Map<String, String> = emptyMap(),
-        spanEndpointConnectivity: EndpointConnectivity =
-            HttpEndpointConnectivity.forTraces(
-                endpointBaseUrl,
-                endpointHeaders,
-            ),
-        logEndpointConnectivity: EndpointConnectivity =
-            HttpEndpointConnectivity.forLogs(
-                endpointBaseUrl,
-                endpointHeaders,
-            ),
-        metricEndpointConnectivity: EndpointConnectivity =
-            HttpEndpointConnectivity.forMetrics(
-                endpointBaseUrl,
-                endpointHeaders,
-            ),
-        rumConfig: OtelRumConfig = OtelRumConfig(),
-        sessionConfig: SessionConfig = SessionConfig.withDefaults(),
-        instrumentations: (InstrumentationConfiguration.() -> Unit)? = null,
+        openTelemetryConfiguration: (OpenTelemetryConfiguration.() -> Unit) = {},
     ): OpenTelemetryRum {
-        instrumentations?.let { configure ->
-            InstrumentationConfiguration(rumConfig).configure()
-        }
+        val cfg = OpenTelemetryConfiguration()
+        openTelemetryConfiguration(cfg)
+
+        val sessionConfig =
+            SessionConfig(
+                cfg.sessionConfig.backgroundInactivityTimeout,
+                cfg.sessionConfig.maxLifetime,
+            )
         return OpenTelemetryRum
-            .builder(application, rumConfig)
+            .builder(application, cfg.rumConfig)
             .setSessionProvider(createSessionProvider(application, sessionConfig))
             .addSpanExporterCustomizer {
                 OtlpHttpSpanExporter
                     .builder()
-                    .setEndpoint(spanEndpointConnectivity.getUrl())
-                    .setHeaders(spanEndpointConnectivity::getHeaders)
+                    .setEndpoint(cfg.exportConfig.spansConfig.url)
+                    .setHeaders(cfg.exportConfig.spansConfig::headers)
                     .build()
             }.addLogRecordExporterCustomizer {
                 OtlpHttpLogRecordExporter
                     .builder()
-                    .setEndpoint(logEndpointConnectivity.getUrl())
-                    .setHeaders(logEndpointConnectivity::getHeaders)
+                    .setEndpoint(cfg.exportConfig.logsConfig.url)
+                    .setHeaders(cfg.exportConfig.logsConfig::headers)
                     .build()
             }.addMetricExporterCustomizer {
                 OtlpHttpMetricExporter
                     .builder()
-                    .setEndpoint(metricEndpointConnectivity.getUrl())
-                    .setHeaders(metricEndpointConnectivity::getHeaders)
+                    .setEndpoint(cfg.exportConfig.metricsConfig.url)
+                    .setHeaders(cfg.exportConfig.metricsConfig::headers)
                     .build()
             }.build()
     }
@@ -111,210 +75,4 @@ object OpenTelemetryRumInitializer {
         Services.get(application).appLifecycle.registerListener(timeoutHandler)
         return SessionManager.create(timeoutHandler, sessionConfig)
     }
-
-    @InstrumentationConfigMarker
-    class InstrumentationConfiguration internal constructor(
-        config: OtelRumConfig,
-    ) {
-        private val activity: ActivityLifecycleConfiguration by lazy {
-            ActivityLifecycleConfiguration(
-                config,
-            )
-        }
-        private val fragment: FragmentLifecycleConfiguration by lazy {
-            FragmentLifecycleConfiguration(
-                config,
-            )
-        }
-        private val anr: AnrReporterConfiguration by lazy { AnrReporterConfiguration(config) }
-        private val crash: CrashReporterConfiguration by lazy { CrashReporterConfiguration(config) }
-        private val networkMonitoring: NetworkMonitoringConfiguration by lazy {
-            NetworkMonitoringConfiguration(
-                config,
-            )
-        }
-        private val slowRendering: SlowRenderingReporterConfiguration by lazy {
-            SlowRenderingReporterConfiguration(
-                config,
-            )
-        }
-
-        fun activity(configure: ActivityLifecycleConfiguration.() -> Unit) {
-            activity.configure()
-        }
-
-        fun fragment(configure: FragmentLifecycleConfiguration.() -> Unit) {
-            fragment.configure()
-        }
-
-        fun anrReporter(configure: AnrReporterConfiguration.() -> Unit) {
-            anr.configure()
-        }
-
-        fun crashReporter(configure: CrashReporterConfiguration.() -> Unit) {
-            crash.configure()
-        }
-
-        fun networkMonitoring(configure: NetworkMonitoringConfiguration.() -> Unit) {
-            networkMonitoring.configure()
-        }
-
-        fun slowRenderingReporter(configure: SlowRenderingReporterConfiguration.() -> Unit) {
-            slowRendering.configure()
-        }
-    }
-
-    @InstrumentationConfigMarker
-    class ActivityLifecycleConfiguration internal constructor(
-        private val config: OtelRumConfig,
-    ) : ScreenLifecycleConfigurable,
-        CanBeEnabledAndDisabled {
-        private val activityLifecycleInstrumentation: ActivityLifecycleInstrumentation by lazy {
-            getInstrumentation()
-        }
-
-        override fun tracerCustomizer(value: (Tracer) -> Tracer) {
-            activityLifecycleInstrumentation.setTracerCustomizer(value)
-        }
-
-        override fun screenNameExtractor(value: ScreenNameExtractor) {
-            activityLifecycleInstrumentation.setScreenNameExtractor(value)
-        }
-
-        override fun enabled(enabled: Boolean) {
-            if (enabled) {
-                config.allowInstrumentation(activityLifecycleInstrumentation.name)
-            } else {
-                config.suppressInstrumentation(activityLifecycleInstrumentation.name)
-            }
-        }
-    }
-
-    @InstrumentationConfigMarker
-    class FragmentLifecycleConfiguration internal constructor(
-        private val config: OtelRumConfig,
-    ) : ScreenLifecycleConfigurable,
-        CanBeEnabledAndDisabled {
-        private val fragmentLifecycleInstrumentation: FragmentLifecycleInstrumentation by lazy {
-            getInstrumentation()
-        }
-
-        override fun tracerCustomizer(value: (Tracer) -> Tracer) {
-            fragmentLifecycleInstrumentation.setTracerCustomizer(value)
-        }
-
-        override fun screenNameExtractor(value: ScreenNameExtractor) {
-            fragmentLifecycleInstrumentation.setScreenNameExtractor(value)
-        }
-
-        override fun enabled(enabled: Boolean) {
-            if (enabled) {
-                config.allowInstrumentation(fragmentLifecycleInstrumentation.name)
-            } else {
-                config.suppressInstrumentation(fragmentLifecycleInstrumentation.name)
-            }
-        }
-    }
-
-    @InstrumentationConfigMarker
-    class AnrReporterConfiguration internal constructor(
-        private val config: OtelRumConfig,
-    ) : WithEventAttributes<Array<StackTraceElement>>,
-        CanBeEnabledAndDisabled {
-        private val anrInstrumentation: AnrInstrumentation by lazy { getInstrumentation() }
-
-        override fun addAttributesExtractor(value: EventAttributesExtractor<Array<StackTraceElement>>) {
-            anrInstrumentation.addAttributesExtractor(value)
-        }
-
-        override fun enabled(enabled: Boolean) {
-            if (enabled) {
-                config.allowInstrumentation(anrInstrumentation.name)
-            } else {
-                config.suppressInstrumentation(anrInstrumentation.name)
-            }
-        }
-    }
-
-    @InstrumentationConfigMarker
-    class CrashReporterConfiguration internal constructor(
-        private val config: OtelRumConfig,
-    ) : WithEventAttributes<CrashDetails>,
-        CanBeEnabledAndDisabled {
-        private val crashReporterInstrumentation: CrashReporterInstrumentation by lazy { getInstrumentation() }
-
-        override fun addAttributesExtractor(value: EventAttributesExtractor<CrashDetails>) {
-            crashReporterInstrumentation.addAttributesExtractor(value)
-        }
-
-        override fun enabled(enabled: Boolean) {
-            if (enabled) {
-                config.allowInstrumentation(crashReporterInstrumentation.name)
-            } else {
-                config.suppressInstrumentation(crashReporterInstrumentation.name)
-            }
-        }
-    }
-
-    @InstrumentationConfigMarker
-    class NetworkMonitoringConfiguration internal constructor(
-        private val config: OtelRumConfig,
-    ) : CanBeEnabledAndDisabled {
-        private val networkInstrumentation: NetworkChangeInstrumentation by lazy { getInstrumentation() }
-
-        fun addAttributesExtractor(value: NetworkAttributesExtractor) {
-            networkInstrumentation.addAttributesExtractor(value)
-        }
-
-        override fun enabled(enabled: Boolean) {
-            if (enabled) {
-                config.allowInstrumentation(networkInstrumentation.name)
-            } else {
-                config.suppressInstrumentation(networkInstrumentation.name)
-            }
-        }
-    }
-
-    @InstrumentationConfigMarker
-    class SlowRenderingReporterConfiguration internal constructor(
-        private val config: OtelRumConfig,
-    ) : CanBeEnabledAndDisabled {
-        private val slowRenderingInstrumentation: SlowRenderingInstrumentation by lazy { getInstrumentation() }
-
-        fun detectionPollInterval(value: Duration) {
-            slowRenderingInstrumentation.setSlowRenderingDetectionPollInterval(value.toJavaDuration())
-        }
-
-        fun enableVerboseDebugLogging() {
-            slowRenderingInstrumentation.enableVerboseDebugLogging()
-        }
-
-        override fun enabled(enabled: Boolean) {
-            if (enabled) {
-                config.allowInstrumentation(slowRenderingInstrumentation.name)
-            } else {
-                config.suppressInstrumentation(slowRenderingInstrumentation.name)
-            }
-        }
-    }
-
-    internal interface ScreenLifecycleConfigurable {
-        fun tracerCustomizer(value: (Tracer) -> Tracer)
-
-        fun screenNameExtractor(value: ScreenNameExtractor)
-    }
-
-    internal interface WithEventAttributes<T> {
-        fun addAttributesExtractor(value: EventAttributesExtractor<T>)
-    }
-
-    internal interface CanBeEnabledAndDisabled {
-        fun enabled(enabled: Boolean)
-    }
-
-    @DslMarker
-    internal annotation class InstrumentationConfigMarker
-
-    private inline fun <reified T : AndroidInstrumentation> getInstrumentation(): T =
-        AndroidInstrumentationLoader.getInstrumentation(T::class.java)!!
 }

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/EndpointConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/EndpointConfiguration.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl
+
+@OpenTelemetryDslMarker
+class EndpointConfiguration(
+    var url: String,
+    var headers: Map<String, String> = emptyMap(),
+)

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/HttpExportConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/HttpExportConfiguration.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl
+
+import io.opentelemetry.android.agent.connectivity.HttpEndpointConnectivity
+
+@OpenTelemetryDslMarker
+class HttpExportConfiguration {
+    /**
+     * Global URL for HTTP export requests.
+     */
+    var baseUrl: String = ""
+
+    /**
+     * Global headers that should be attached to any HTTP export requests.
+     */
+    var baseHeaders: Map<String, String> = emptyMap()
+
+    internal val spansConfig: EndpointConfiguration =
+        HttpEndpointConnectivity
+            .forTraces(
+                baseUrl,
+                baseHeaders,
+            ).let(::toEndpointConfiguration)
+
+    internal val logsConfig: EndpointConfiguration =
+        HttpEndpointConnectivity
+            .forLogs(
+                baseUrl,
+                baseHeaders,
+            ).let(::toEndpointConfiguration)
+
+    internal val metricsConfig: EndpointConfiguration =
+        HttpEndpointConnectivity
+            .forMetrics(
+                baseUrl,
+                baseHeaders,
+            ).let(::toEndpointConfiguration)
+
+    fun spans(action: EndpointConfiguration.() -> Unit) {
+        spansConfig.action()
+    }
+
+    fun logs(action: EndpointConfiguration.() -> Unit) {
+        logsConfig.action()
+    }
+
+    fun metrics(action: EndpointConfiguration.() -> Unit) {
+        metricsConfig.action()
+    }
+
+    private fun toEndpointConfiguration(connectivity: HttpEndpointConnectivity): EndpointConfiguration =
+        EndpointConfiguration(connectivity.getUrl(), connectivity.getHeaders())
+}

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl
+
+import io.opentelemetry.android.Incubating
+import io.opentelemetry.android.agent.dsl.instrumentation.InstrumentationConfiguration
+import io.opentelemetry.android.config.OtelRumConfig
+
+/**
+ * Type-safe config DSL that controls how OpenTelemetry should behave.
+ */
+@OptIn(Incubating::class)
+@OpenTelemetryDslMarker
+class OpenTelemetryConfiguration {
+    internal val exportConfig: HttpExportConfiguration = HttpExportConfiguration()
+
+    internal val rumConfig: OtelRumConfig = OtelRumConfig()
+    internal val sessionConfig: SessionConfiguration = SessionConfiguration()
+
+    /**
+     * Configures individual instrumentations.
+     */
+    internal val instrumentations: InstrumentationConfiguration =
+        InstrumentationConfiguration(rumConfig)
+
+    /**
+     * Configures how OpenTelemetry should export telemetry over HTTP.
+     */
+    fun httpExport(action: HttpExportConfiguration.() -> Unit) {
+        exportConfig.action()
+    }
+
+    /**
+     * Configures individual instrumentations.
+     */
+    fun instrumentations(action: InstrumentationConfiguration.() -> Unit) {
+        instrumentations.action()
+    }
+
+    /**
+     * Configures session behavior
+     */
+    fun session(action: SessionConfiguration.() -> Unit) {
+        sessionConfig.action()
+    }
+}

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryDslMarker.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryDslMarker.kt
@@ -1,0 +1,9 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl
+
+@DslMarker
+internal annotation class OpenTelemetryDslMarker

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/SessionConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/SessionConfiguration.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+@OpenTelemetryDslMarker
+class SessionConfiguration(
+    var backgroundInactivityTimeout: Duration = 15.minutes,
+    var maxLifetime: Duration = 4.hours,
+)

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/ActivityLifecycleConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/ActivityLifecycleConfiguration.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl.instrumentation
+
+import io.opentelemetry.android.agent.dsl.OpenTelemetryDslMarker
+import io.opentelemetry.android.config.OtelRumConfig
+import io.opentelemetry.android.instrumentation.AndroidInstrumentationLoader
+import io.opentelemetry.android.instrumentation.activity.ActivityLifecycleInstrumentation
+import io.opentelemetry.android.instrumentation.common.ScreenNameExtractor
+import io.opentelemetry.api.trace.Tracer
+
+@OpenTelemetryDslMarker
+class ActivityLifecycleConfiguration internal constructor(
+    private val config: OtelRumConfig,
+) : ScreenLifecycleConfigurable,
+    CanBeEnabledAndDisabled {
+    private val activityLifecycleInstrumentation: ActivityLifecycleInstrumentation by lazy {
+        AndroidInstrumentationLoader.getInstrumentation(ActivityLifecycleInstrumentation::class.java)!!
+    }
+
+    override fun tracerCustomizer(value: (Tracer) -> Tracer) {
+        activityLifecycleInstrumentation.setTracerCustomizer(value)
+    }
+
+    override fun screenNameExtractor(value: ScreenNameExtractor) {
+        activityLifecycleInstrumentation.setScreenNameExtractor(value)
+    }
+
+    override fun enabled(enabled: Boolean) {
+        if (enabled) {
+            config.allowInstrumentation(activityLifecycleInstrumentation.name)
+        } else {
+            config.suppressInstrumentation(activityLifecycleInstrumentation.name)
+        }
+    }
+}

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/AnrReporterConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/AnrReporterConfiguration.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl.instrumentation
+
+import io.opentelemetry.android.agent.dsl.OpenTelemetryDslMarker
+import io.opentelemetry.android.config.OtelRumConfig
+import io.opentelemetry.android.instrumentation.AndroidInstrumentationLoader
+import io.opentelemetry.android.instrumentation.anr.AnrInstrumentation
+import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor
+
+@OpenTelemetryDslMarker
+class AnrReporterConfiguration internal constructor(
+    private val config: OtelRumConfig,
+) : WithEventAttributes<Array<StackTraceElement>>,
+    CanBeEnabledAndDisabled {
+    private val anrInstrumentation: AnrInstrumentation by lazy {
+        AndroidInstrumentationLoader.getInstrumentation(
+            AnrInstrumentation::class.java,
+        )!!
+    }
+
+    override fun addAttributesExtractor(value: EventAttributesExtractor<Array<StackTraceElement>>) {
+        anrInstrumentation.addAttributesExtractor(value)
+    }
+
+    override fun enabled(enabled: Boolean) {
+        if (enabled) {
+            config.allowInstrumentation(anrInstrumentation.name)
+        } else {
+            config.suppressInstrumentation(anrInstrumentation.name)
+        }
+    }
+}

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/CanBeEnabledAndDisabled.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/CanBeEnabledAndDisabled.kt
@@ -1,0 +1,10 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl.instrumentation
+
+internal interface CanBeEnabledAndDisabled {
+    fun enabled(enabled: Boolean)
+}

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/CrashReporterConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/CrashReporterConfiguration.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl.instrumentation
+
+import io.opentelemetry.android.agent.dsl.OpenTelemetryDslMarker
+import io.opentelemetry.android.config.OtelRumConfig
+import io.opentelemetry.android.instrumentation.AndroidInstrumentationLoader
+import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor
+import io.opentelemetry.android.instrumentation.crash.CrashDetails
+import io.opentelemetry.android.instrumentation.crash.CrashReporterInstrumentation
+
+@OpenTelemetryDslMarker
+class CrashReporterConfiguration internal constructor(
+    private val config: OtelRumConfig,
+) : WithEventAttributes<CrashDetails>,
+    CanBeEnabledAndDisabled {
+    private val crashReporterInstrumentation: CrashReporterInstrumentation by lazy {
+        AndroidInstrumentationLoader.getInstrumentation(
+            CrashReporterInstrumentation::class.java,
+        )!!
+    }
+
+    override fun addAttributesExtractor(value: EventAttributesExtractor<CrashDetails>) {
+        crashReporterInstrumentation.addAttributesExtractor(value)
+    }
+
+    override fun enabled(enabled: Boolean) {
+        if (enabled) {
+            config.allowInstrumentation(crashReporterInstrumentation.name)
+        } else {
+            config.suppressInstrumentation(crashReporterInstrumentation.name)
+        }
+    }
+}

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/FragmentLifecycleConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/FragmentLifecycleConfiguration.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl.instrumentation
+
+import io.opentelemetry.android.agent.dsl.OpenTelemetryDslMarker
+import io.opentelemetry.android.config.OtelRumConfig
+import io.opentelemetry.android.instrumentation.AndroidInstrumentationLoader
+import io.opentelemetry.android.instrumentation.common.ScreenNameExtractor
+import io.opentelemetry.android.instrumentation.fragment.FragmentLifecycleInstrumentation
+import io.opentelemetry.api.trace.Tracer
+
+@OpenTelemetryDslMarker
+class FragmentLifecycleConfiguration internal constructor(
+    private val config: OtelRumConfig,
+) : ScreenLifecycleConfigurable,
+    CanBeEnabledAndDisabled {
+    private val fragmentLifecycleInstrumentation: FragmentLifecycleInstrumentation by lazy {
+        AndroidInstrumentationLoader.getInstrumentation(FragmentLifecycleInstrumentation::class.java)!!
+    }
+
+    override fun tracerCustomizer(value: (Tracer) -> Tracer) {
+        fragmentLifecycleInstrumentation.setTracerCustomizer(value)
+    }
+
+    override fun screenNameExtractor(value: ScreenNameExtractor) {
+        fragmentLifecycleInstrumentation.setScreenNameExtractor(value)
+    }
+
+    override fun enabled(enabled: Boolean) {
+        if (enabled) {
+            config.allowInstrumentation(fragmentLifecycleInstrumentation.name)
+        } else {
+            config.suppressInstrumentation(fragmentLifecycleInstrumentation.name)
+        }
+    }
+}

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/InstrumentationConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/InstrumentationConfiguration.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl.instrumentation
+
+import io.opentelemetry.android.agent.dsl.OpenTelemetryDslMarker
+import io.opentelemetry.android.config.OtelRumConfig
+
+@OpenTelemetryDslMarker
+class InstrumentationConfiguration internal constructor(
+    config: OtelRumConfig,
+) {
+    private val activity: ActivityLifecycleConfiguration by lazy {
+        ActivityLifecycleConfiguration(
+            config,
+        )
+    }
+    private val fragment: FragmentLifecycleConfiguration by lazy {
+        FragmentLifecycleConfiguration(
+            config,
+        )
+    }
+    private val anr: AnrReporterConfiguration by lazy {
+        AnrReporterConfiguration(
+            config,
+        )
+    }
+    private val crash: CrashReporterConfiguration by lazy {
+        CrashReporterConfiguration(
+            config,
+        )
+    }
+    private val networkMonitoring: NetworkMonitoringConfiguration by lazy {
+        NetworkMonitoringConfiguration(
+            config,
+        )
+    }
+    private val slowRendering: SlowRenderingReporterConfiguration by lazy {
+        SlowRenderingReporterConfiguration(
+            config,
+        )
+    }
+
+    fun activity(configure: ActivityLifecycleConfiguration.() -> Unit) {
+        activity.configure()
+    }
+
+    fun fragment(configure: FragmentLifecycleConfiguration.() -> Unit) {
+        fragment.configure()
+    }
+
+    fun anrReporter(configure: AnrReporterConfiguration.() -> Unit) {
+        anr.configure()
+    }
+
+    fun crashReporter(configure: CrashReporterConfiguration.() -> Unit) {
+        crash.configure()
+    }
+
+    fun networkMonitoring(configure: NetworkMonitoringConfiguration.() -> Unit) {
+        networkMonitoring.configure()
+    }
+
+    fun slowRenderingReporter(configure: SlowRenderingReporterConfiguration.() -> Unit) {
+        slowRendering.configure()
+    }
+}

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/NetworkMonitoringConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/NetworkMonitoringConfiguration.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl.instrumentation
+
+import io.opentelemetry.android.agent.dsl.OpenTelemetryDslMarker
+import io.opentelemetry.android.config.OtelRumConfig
+import io.opentelemetry.android.instrumentation.AndroidInstrumentationLoader
+import io.opentelemetry.android.instrumentation.network.NetworkAttributesExtractor
+import io.opentelemetry.android.instrumentation.network.NetworkChangeInstrumentation
+
+@OpenTelemetryDslMarker
+class NetworkMonitoringConfiguration internal constructor(
+    private val config: OtelRumConfig,
+) : CanBeEnabledAndDisabled {
+    private val networkInstrumentation: NetworkChangeInstrumentation by lazy {
+        AndroidInstrumentationLoader.getInstrumentation(
+            NetworkChangeInstrumentation::class.java,
+        )!!
+    }
+
+    fun addAttributesExtractor(value: NetworkAttributesExtractor) {
+        networkInstrumentation.addAttributesExtractor(value)
+    }
+
+    override fun enabled(enabled: Boolean) {
+        if (enabled) {
+            config.allowInstrumentation(networkInstrumentation.name)
+        } else {
+            config.suppressInstrumentation(networkInstrumentation.name)
+        }
+    }
+}

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/ScreenLifecycleConfigurable.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/ScreenLifecycleConfigurable.kt
@@ -1,0 +1,15 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl.instrumentation
+
+import io.opentelemetry.android.instrumentation.common.ScreenNameExtractor
+import io.opentelemetry.api.trace.Tracer
+
+internal interface ScreenLifecycleConfigurable {
+    fun tracerCustomizer(value: (Tracer) -> Tracer)
+
+    fun screenNameExtractor(value: ScreenNameExtractor)
+}

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/SlowRenderingReporterConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/SlowRenderingReporterConfiguration.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl.instrumentation
+
+import io.opentelemetry.android.agent.dsl.OpenTelemetryDslMarker
+import io.opentelemetry.android.config.OtelRumConfig
+import io.opentelemetry.android.instrumentation.AndroidInstrumentationLoader
+import io.opentelemetry.android.instrumentation.slowrendering.SlowRenderingInstrumentation
+import kotlin.time.Duration
+import kotlin.time.toJavaDuration
+
+@OpenTelemetryDslMarker
+class SlowRenderingReporterConfiguration internal constructor(
+    private val config: OtelRumConfig,
+) : CanBeEnabledAndDisabled {
+    private val slowRenderingInstrumentation: SlowRenderingInstrumentation by lazy {
+        AndroidInstrumentationLoader.getInstrumentation(
+            SlowRenderingInstrumentation::class.java,
+        )!!
+    }
+
+    fun detectionPollInterval(value: Duration) {
+        slowRenderingInstrumentation.setSlowRenderingDetectionPollInterval(value.toJavaDuration())
+    }
+
+    fun enableVerboseDebugLogging() {
+        slowRenderingInstrumentation.enableVerboseDebugLogging()
+    }
+
+    override fun enabled(enabled: Boolean) {
+        if (enabled) {
+            config.allowInstrumentation(slowRenderingInstrumentation.name)
+        } else {
+            config.suppressInstrumentation(slowRenderingInstrumentation.name)
+        }
+    }
+}

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/WithEventAttributes.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/instrumentation/WithEventAttributes.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl.instrumentation
+
+import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor
+
+internal interface WithEventAttributes<T> {
+    fun addAttributesExtractor(value: EventAttributesExtractor<T>)
+}

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
@@ -31,10 +31,11 @@ class OpenTelemetryRumInitializerTest {
     fun `Verify timeoutHandler initialization`() {
         createAndSetServiceManager()
 
-        OpenTelemetryRumInitializer.initialize(
-            RuntimeEnvironment.getApplication(),
-            "http://127.0.0.1:4318",
-        )
+        OpenTelemetryRumInitializer.initialize(RuntimeEnvironment.getApplication()) {
+            httpExport {
+                baseUrl = "http://127.0.0.1:4318"
+            }
+        }
 
         verify {
             appLifecycle.registerListener(any<SessionIdTimeoutHandler>())


### PR DESCRIPTION
## Goal

This PR demonstrates what a [type-safe DSL](https://kotlinlang.org/docs/type-safe-builders.html) could look like for initializing OpenTelemetry, as originally discussed in #1257. It's not in a mergeable state - I'd like to get feedback before proceeding further with any changes, then split the work up into smaller changesets. After the changes in this PR, initializing opentelemetry-android would look something like the following:

```
fun exampleUsage(application: Application) {
    OpenTelemetryRumInitializer.initialize(application) {
        httpExport {
            baseUrl = "http://localhost:4317"
            baseHeaders = mapOf("key" to "value")
            spans {
                url = "http://localhost:4318"
                headers = mapOf("key" to "override")
            }
        }
        instrumentations {
            anrReporter {
                enabled(true)
                addAttributesExtractor { _, _ ->
                    Attributes.empty()
                }
            }
        }
        session {
            maxLifetime = 10.minutes
        }
    }
}
```

IMO this has a few main advantages over the current API:

1. Only one parameter is required to configure the SDK. If we need to add additional configuration, it will not be a breaking change to add an extra parameter to the `initialize` function, rather we can just add an extra function to the DSL
2. Configuration can be entirely declarative. This means implementation details that construct concrete types such as `HttpEndpointConnectivity` don't need to be exposed
3. Symbols have been moved to a separate package rather than being declared in `OpenTelemetryRumInitializer`. If configuration grows substantially in future this prevents a scenario where a single source file needs to contain $LARGE_NUMBER lines-of-code

### What else is needed if we want to land this change?

IMO the following things would be useful:

1. Splitting up the changeset into smaller PRs
2. Adding KDoc for every function that forms part of the DSL
3. Providing a DSL that replaces/allows `OtelRumConfig` to be configured




