### PR TITLE
Demo app - Fix coordinates of local packages

### DIFF
--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -70,9 +70,11 @@ dependencies {
 
     coreLibraryDesugaring(libs.desugarJdkLibs)
 
-    implementation("io.opentelemetry.android:instrumentation-compose-click")
+    // These are sourced from local project dirs. See settings.gradle.kts for the
+    // configured substitutions.
     implementation("io.opentelemetry.android:android-agent")    //parent dir
-    implementation("io.opentelemetry.android:instrumentation-sessions")
+    implementation("io.opentelemetry.android.instrumentation:compose-click")
+    implementation("io.opentelemetry.android.instrumentation:sessions")
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/demo-app/settings.gradle.kts
+++ b/demo-app/settings.gradle.kts
@@ -22,11 +22,11 @@ dependencyResolutionManagement {
 
 includeBuild("..") {
     dependencySubstitution {
-        substitute(module("io.opentelemetry.android:instrumentation-compose-click"))
-            .using(project(":instrumentation:compose:click"))
         substitute(module("io.opentelemetry.android:android-agent"))
             .using(project(":android-agent"))
-        substitute(module("io.opentelemetry.android:instrumentation-sessions"))
+        substitute(module("io.opentelemetry.android.instrumentation:compose-click"))
+            .using(project(":instrumentation:compose:click"))
+        substitute(module("io.opentelemetry.android.instrumentation:sessions"))
             .using(project(":instrumentation:sessions"))
     }
 }


### PR DESCRIPTION
I was helping someone on slack and noticed that the coordinates we have substitutions for in the demo app no longer match what we publish. I think this was just an oversight from some time ago...but I think this could be seriously confusing for some users.

I also added a note about where to find the substitutions, because there is indeed a bit of gradle black magic there.