### PR TITLE
Update mockwebserver to latest

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -73,8 +73,7 @@ junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher
 robolectric = "org.robolectric:robolectric:4.16"
 assertj-core = "org.assertj:assertj-core:3.27.6"
 awaitility = "org.awaitility:awaitility:4.3.0"
-mockwebserver = "com.google.mockwebserver:mockwebserver:20130706"
-okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
+okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver3", version.ref = "okhttp" }
 
 #Compilation tools
 desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.1.5"

--- a/instrumentation/okhttp3-websocket/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/websocket/InstrumentationTest.kt
+++ b/instrumentation/okhttp3-websocket/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/websocket/InstrumentationTest.kt
@@ -10,13 +10,13 @@ import io.opentelemetry.instrumentation.library.okhttp.v3_0.websocket.internal.W
 import io.opentelemetry.semconv.HttpAttributes
 import io.opentelemetry.semconv.NetworkAttributes
 import io.opentelemetry.semconv.UrlAttributes
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
-import okhttp3.mockwebserver.MockResponse
-import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert
 import org.junit.Before
@@ -46,14 +46,14 @@ class InstrumentationTest {
     @After
     @Throws(IOException::class)
     fun tearDown() {
-        webServer.shutdown()
+        webServer.close()
     }
 
     @Test
     @Throws(InterruptedException::class)
     fun websocketOpenEvents() {
         val lock = CountDownLatch(1)
-        webServer.enqueue(MockResponse().withWebSocketUpgrade(webSocketListenerServer))
+        webServer.enqueue(MockResponse.Builder().webSocketUpgrade(webSocketListenerServer).build())
         val webSocketListenerClient: WebSocketListener =
             object : WebSocketListener() {
                 override fun onOpen(
@@ -95,7 +95,7 @@ class InstrumentationTest {
     @Throws(InterruptedException::class)
     fun websocketMessageEvent() {
         val lock = CountDownLatch(1)
-        webServer.enqueue(MockResponse().withWebSocketUpgrade(webSocketListenerServer))
+        webServer.enqueue(MockResponse.Builder().webSocketUpgrade(webSocketListenerServer).build())
         val webSocketListenerClient: WebSocketListener =
             object : WebSocketListener() {
                 override fun onMessage(

--- a/instrumentation/okhttp3/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/InstrumentationTest.java
+++ b/instrumentation/okhttp3/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/v3_0/InstrumentationTest.java
@@ -19,13 +19,13 @@ import io.opentelemetry.sdk.trace.SdkTracerProvider;
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor;
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -44,12 +44,12 @@ public class InstrumentationTest {
 
     @After
     public void tearDown() throws IOException {
-        server.shutdown();
+        server.close();
     }
 
     @Test
     public void okhttpTraces() throws IOException {
-        server.enqueue(new MockResponse().setResponseCode(200));
+        server.enqueue(new MockResponse.Builder().code(200).build());
 
         Span span = openTelemetryRumRule.getSpan();
 
@@ -79,7 +79,7 @@ public class InstrumentationTest {
         Span span = openTelemetryRumRule.getSpan();
 
         try (Scope ignored = span.makeCurrent()) {
-            server.enqueue(new MockResponse().setResponseCode(200));
+            server.enqueue(new MockResponse.Builder().code(200).build());
 
             OkHttpClient client =
                     new OkHttpClient.Builder()
@@ -131,7 +131,7 @@ public class InstrumentationTest {
                                         .build())
                         .build();
 
-        server.enqueue(new MockResponse().setResponseCode(200));
+        server.enqueue(new MockResponse.Builder().code(200).build());
 
         // This span should trigger 1 export okhttp call, which is the only okhttp call expected
         // for this test case.


### PR DESCRIPTION
Fixes #1300.

The coordinates changed, which is why renovate didn't pick this up.