### PR TITLE
Finishes altering initialize to use a type-safe DSL

### DIFF
--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -3,31 +3,8 @@ public abstract interface annotation class io/opentelemetry/android/Incubating :
 
 public final class io/opentelemetry/android/agent/OpenTelemetryRumInitializer {
 	public static final field INSTANCE Lio/opentelemetry/android/agent/OpenTelemetryRumInitializer;
-	public static final fun initialize (Landroid/app/Application;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/android/OpenTelemetryRum;
-	public static final fun initialize (Landroid/content/Context;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/android/OpenTelemetryRum;
-	public static synthetic fun initialize$default (Landroid/app/Application;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/opentelemetry/android/OpenTelemetryRum;
-	public static synthetic fun initialize$default (Landroid/content/Context;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/opentelemetry/android/OpenTelemetryRum;
-}
-
-public abstract interface class io/opentelemetry/android/agent/connectivity/EndpointConnectivity {
-	public abstract fun getHeaders ()Ljava/util/Map;
-	public abstract fun getUrl ()Ljava/lang/String;
-}
-
-public final class io/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity : io/opentelemetry/android/agent/connectivity/EndpointConnectivity {
-	public static final field Companion Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity$Companion;
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getHeaders ()Ljava/util/Map;
-	public fun getUrl ()Ljava/lang/String;
-}
-
-public final class io/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity$Companion {
-	public final fun forLogs (Ljava/lang/String;Ljava/util/Map;)Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity;
-	public static synthetic fun forLogs$default (Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity$Companion;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity;
-	public final fun forMetrics (Ljava/lang/String;Ljava/util/Map;)Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity;
-	public static synthetic fun forMetrics$default (Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity$Companion;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity;
-	public final fun forTraces (Ljava/lang/String;Ljava/util/Map;)Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity;
-	public static synthetic fun forTraces$default (Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity$Companion;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity;
+	public static final fun initialize (Landroid/content/Context;Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/android/OpenTelemetryRum;
+	public static synthetic fun initialize$default (Landroid/content/Context;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/opentelemetry/android/OpenTelemetryRum;
 }
 
 public final class io/opentelemetry/android/agent/dsl/DiskBufferingConfigurationSpec : io/opentelemetry/android/agent/dsl/instrumentation/CanBeEnabledAndDisabled {
@@ -52,14 +29,14 @@ public final class io/opentelemetry/android/agent/dsl/HttpExportConfiguration {
 }
 
 public final class io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration {
-	public fun <init> ()V
+	public final fun diskBuffering (Lkotlin/jvm/functions/Function1;)V
+	public final fun globalAttributes (Lkotlin/jvm/functions/Function0;)V
 	public final fun httpExport (Lkotlin/jvm/functions/Function1;)V
 	public final fun instrumentations (Lkotlin/jvm/functions/Function1;)V
 	public final fun session (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/opentelemetry/android/agent/dsl/SessionConfiguration {
-	public synthetic fun <init> (JJILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getBackgroundInactivityTimeout-UwyO8pc ()J
 	public final fun getMaxLifetime-UwyO8pc ()J
 	public final fun setBackgroundInactivityTimeout-LRDsOJo (J)V
@@ -106,18 +83,5 @@ public final class io/opentelemetry/android/agent/dsl/instrumentation/SlowRender
 	public final fun detectionPollInterval-LRDsOJo (J)V
 	public final fun enableVerboseDebugLogging ()V
 	public fun enabled (Z)V
-}
-
-public final class io/opentelemetry/android/agent/session/SessionConfig {
-	public static final field Companion Lio/opentelemetry/android/agent/session/SessionConfig$Companion;
-	public synthetic fun <init> (JJILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun getBackgroundInactivityTimeout-UwyO8pc ()J
-	public final fun getMaxLifetime-UwyO8pc ()J
-	public static final fun withDefaults ()Lio/opentelemetry/android/agent/session/SessionConfig;
-}
-
-public final class io/opentelemetry/android/agent/session/SessionConfig$Companion {
-	public final fun withDefaults ()Lio/opentelemetry/android/agent/session/SessionConfig;
 }
 

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
@@ -9,16 +9,12 @@ import android.app.Application
 import android.content.Context
 import io.opentelemetry.android.Incubating
 import io.opentelemetry.android.OpenTelemetryRum
-import io.opentelemetry.android.agent.dsl.DiskBufferingConfigurationSpec
 import io.opentelemetry.android.agent.dsl.OpenTelemetryConfiguration
 import io.opentelemetry.android.agent.session.SessionConfig
 import io.opentelemetry.android.agent.session.SessionIdTimeoutHandler
 import io.opentelemetry.android.agent.session.SessionManager
-import io.opentelemetry.android.config.OtelRumConfig
-import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig
 import io.opentelemetry.android.internal.services.Services
 import io.opentelemetry.android.session.SessionProvider
-import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
@@ -28,56 +24,20 @@ object OpenTelemetryRumInitializer {
     /**
      * Opinionated [OpenTelemetryRum] initialization.
      *
-     * @param application Your android app's application object.
-     * @param globalAttributes Configures the set of global attributes to emit with every span and event.
-     * @param diskBuffering Configures the disk buffering feature.
-     * @param configuration Type-safe config DSL that controls how OpenTelemetry
-     * should behave.
-     */
-    @JvmStatic
-    fun initialize(
-        application: Application,
-        globalAttributes: (() -> Attributes)? = null,
-        diskBuffering: (DiskBufferingConfigurationSpec.() -> Unit)? = null,
-        configuration: (OpenTelemetryConfiguration.() -> Unit) = {},
-    ): OpenTelemetryRum =
-        initialize(
-            context = application,
-            globalAttributes = globalAttributes,
-            diskBuffering = diskBuffering,
-            configuration = configuration,
-        )
-
-    /**
-     * Opinionated [OpenTelemetryRum] initialization.
-     *
      * @param context Your android app's application context. This should be from your Application
      * subclass or an appropriate context that allows retrieving the application context. If you
      * supply an inappropriate context (e.g. from attachBaseContext) then instrumentation relying
      * on activity lifecycle callbacks will not function correctly.
-     * @param globalAttributes Configures the set of global attributes to emit with every span and event.
-     * @param diskBuffering Configures the disk buffering feature.
      * @param configuration Type-safe config DSL that controls how OpenTelemetry
      * should behave.
      */
     @JvmStatic
     fun initialize(
         context: Context,
-        globalAttributes: (() -> Attributes)? = null,
-        diskBuffering: (DiskBufferingConfigurationSpec.() -> Unit)? = null,
         configuration: (OpenTelemetryConfiguration.() -> Unit) = {},
     ): OpenTelemetryRum {
-        val rumConfig = OtelRumConfig()
-        val cfg = OpenTelemetryConfiguration(rumConfig)
+        val cfg = OpenTelemetryConfiguration()
         configuration(cfg)
-
-        val diskBufferingConfigurationSpec = DiskBufferingConfigurationSpec()
-        diskBuffering?.invoke(diskBufferingConfigurationSpec)
-        rumConfig.setDiskBufferingConfig(DiskBufferingConfig.create(enabled = diskBufferingConfigurationSpec.enabled))
-
-        globalAttributes?.let {
-            rumConfig.setGlobalAttributes(it::invoke)
-        }
 
         val sessionConfig =
             SessionConfig(
@@ -94,26 +54,29 @@ object OpenTelemetryRumInitializer {
                 else -> context.applicationContext ?: context
             }
 
+        val spansEndpoint = cfg.exportConfig.spansEndpoint()
+        val logsEndpoints = cfg.exportConfig.logsEndpoint()
+        val metricsEndpoint = cfg.exportConfig.metricsEndpoint()
         return OpenTelemetryRum
-            .builder(ctx, rumConfig)
+            .builder(ctx, cfg.rumConfig)
             .setSessionProvider(createSessionProvider(ctx, sessionConfig))
             .addSpanExporterCustomizer {
                 OtlpHttpSpanExporter
                     .builder()
-                    .setEndpoint(cfg.exportConfig.spansConfig.url)
-                    .setHeaders(cfg.exportConfig.spansConfig::headers)
+                    .setEndpoint(spansEndpoint.getUrl())
+                    .setHeaders(spansEndpoint::getHeaders)
                     .build()
             }.addLogRecordExporterCustomizer {
                 OtlpHttpLogRecordExporter
                     .builder()
-                    .setEndpoint(cfg.exportConfig.logsConfig.url)
-                    .setHeaders(cfg.exportConfig.logsConfig::headers)
+                    .setEndpoint(logsEndpoints.getUrl())
+                    .setHeaders(logsEndpoints::getHeaders)
                     .build()
             }.addMetricExporterCustomizer {
                 OtlpHttpMetricExporter
                     .builder()
-                    .setEndpoint(cfg.exportConfig.metricsConfig.url)
-                    .setHeaders(cfg.exportConfig.metricsConfig::headers)
+                    .setEndpoint(metricsEndpoint.getUrl())
+                    .setHeaders(metricsEndpoint::getHeaders)
                     .build()
             }.build()
     }

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/connectivity/EndpointConnectivity.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/connectivity/EndpointConnectivity.kt
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.android.agent.connectivity
 
-interface EndpointConnectivity {
+internal interface EndpointConnectivity {
     fun getUrl(): String
 
     fun getHeaders(): Map<String, String>

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity.kt
@@ -5,7 +5,7 @@
 
 package io.opentelemetry.android.agent.connectivity
 
-class HttpEndpointConnectivity private constructor(
+internal class HttpEndpointConnectivity private constructor(
     private val url: String,
     private val headers: Map<String, String>,
 ) : EndpointConnectivity {

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
@@ -8,24 +8,20 @@ package io.opentelemetry.android.agent.dsl
 import io.opentelemetry.android.Incubating
 import io.opentelemetry.android.agent.dsl.instrumentation.InstrumentationConfiguration
 import io.opentelemetry.android.config.OtelRumConfig
+import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig
+import io.opentelemetry.api.common.Attributes
 
 /**
  * Type-safe config DSL that controls how OpenTelemetry should behave.
  */
 @OptIn(Incubating::class)
 @OpenTelemetryDslMarker
-class OpenTelemetryConfiguration internal constructor(
-    internal val rumConfig: OtelRumConfig = OtelRumConfig(),
-) {
-    internal val exportConfig: HttpExportConfiguration = HttpExportConfiguration()
-
-    internal val sessionConfig: SessionConfiguration = SessionConfiguration()
-
-    /**
-     * Configures individual instrumentations.
-     */
-    internal val instrumentations: InstrumentationConfiguration =
-        InstrumentationConfiguration(rumConfig)
+class OpenTelemetryConfiguration internal constructor() {
+    internal val rumConfig: OtelRumConfig = OtelRumConfig()
+    internal val exportConfig = HttpExportConfiguration()
+    internal val sessionConfig = SessionConfiguration()
+    internal val diskBufferingConfig = DiskBufferingConfigurationSpec()
+    internal val instrumentations = InstrumentationConfiguration(rumConfig)
 
     /**
      * Configures how OpenTelemetry should export telemetry over HTTP.
@@ -46,5 +42,20 @@ class OpenTelemetryConfiguration internal constructor(
      */
     fun session(action: SessionConfiguration.() -> Unit) {
         sessionConfig.action()
+    }
+
+    /**
+     * Configures attributes that are used globally.
+     */
+    fun globalAttributes(action: () -> Attributes) {
+        rumConfig.setGlobalAttributes(action())
+    }
+
+    /**
+     * Configures disk buffering behavior of exported telemetry.
+     */
+    fun diskBuffering(action: DiskBufferingConfigurationSpec.() -> Unit) {
+        diskBufferingConfig.action()
+        rumConfig.setDiskBufferingConfig(DiskBufferingConfig.create(enabled = diskBufferingConfig.enabled))
     }
 }

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/SessionConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/SessionConfiguration.kt
@@ -10,7 +10,7 @@ import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 
 @OpenTelemetryDslMarker
-class SessionConfiguration internal constructor(
-    var backgroundInactivityTimeout: Duration = 15.minutes,
-    var maxLifetime: Duration = 4.hours,
-)
+class SessionConfiguration internal constructor() {
+    var backgroundInactivityTimeout: Duration = 15.minutes
+    var maxLifetime: Duration = 4.hours
+}

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionConfig.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionConfig.kt
@@ -5,13 +5,11 @@
 
 package io.opentelemetry.android.agent.session
 
-import io.opentelemetry.android.Incubating
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 
-@Incubating
-class SessionConfig(
+internal class SessionConfig(
     val backgroundInactivityTimeout: Duration = 15.minutes,
     val maxLifetime: Duration = 4.hours,
 ) {

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
@@ -29,25 +29,6 @@ class OpenTelemetryRumInitializerTest {
         appLifecycle = mockk(relaxed = true)
     }
 
-    @OptIn(Incubating::class)
-    @Test
-    fun `Verify timeoutHandler initialization`() {
-        createAndSetServiceManager()
-
-        OpenTelemetryRumInitializer.initialize(
-            application = RuntimeEnvironment.getApplication(),
-            configuration = {
-                httpExport {
-                    baseUrl = "http://127.0.0.1:4318"
-                }
-            },
-        )
-
-        verify {
-            appLifecycle.registerListener(any<SessionIdTimeoutHandler>())
-        }
-    }
-
     @Test
     fun `Verify timeoutHandler initialization 2`() {
         createAndSetServiceManager()

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/HttpExportConfigurationTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/HttpExportConfigurationTest.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl
+
+import io.opentelemetry.android.agent.connectivity.HttpEndpointConnectivity
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+
+internal class HttpExportConfigurationTest {
+    @Test
+    fun testDefaults() {
+        val config = HttpExportConfiguration()
+        val expectedHeaders = emptyMap<String, String>()
+        config.spansEndpoint().assertEndpointConfig("/v1/traces", expectedHeaders)
+        config.logsEndpoint().assertEndpointConfig("/v1/logs", expectedHeaders)
+        config.metricsEndpoint().assertEndpointConfig("/v1/metrics", expectedHeaders)
+        assertEquals("", config.baseUrl)
+        assertEquals(expectedHeaders, config.baseHeaders)
+    }
+
+    @Test
+    fun testBaseValueOverride() {
+        val url = "http://localhost:4318/"
+        val headers = mapOf("my-header" to "my-value")
+        val config =
+            HttpExportConfiguration().apply {
+                baseUrl = url
+                baseHeaders = headers
+            }
+
+        config.spansEndpoint().assertEndpointConfig("${url}v1/traces", headers)
+        config.logsEndpoint().assertEndpointConfig("${url}v1/logs", headers)
+        config.metricsEndpoint().assertEndpointConfig("${url}v1/metrics", headers)
+        assertEquals(url, config.baseUrl)
+        assertEquals(headers, config.baseHeaders)
+    }
+
+    @Test
+    fun testIndividualEndpointOverrides() {
+        val baseUrl = "http://localhost:4318/"
+        val baseHeaders = mapOf("my-header" to "my-value")
+
+        val spanUrl = "http://localhost:4318/spans/"
+        val spanHeaders = mapOf("span-header" to "span-value")
+
+        val logUrl = "http://localhost:4318/logs/"
+        val logHeaders = mapOf("log-header" to "log-value")
+
+        val metricsUrl = "http://localhost:4318/metrics/"
+        val metricsHeaders = mapOf("metrics-header" to "metrics-value")
+
+        val config =
+            HttpExportConfiguration().apply {
+                this.baseUrl = baseUrl
+                this.baseHeaders = baseHeaders
+
+                spans {
+                    url = spanUrl
+                    headers = spanHeaders
+                }
+                logs {
+                    url = logUrl
+                    headers = logHeaders
+                }
+                metrics {
+                    url = metricsUrl
+                    headers = metricsHeaders
+                }
+            }
+
+        config.spansEndpoint().assertEndpointConfig("${spanUrl}v1/traces", spanHeaders + baseHeaders)
+        config.logsEndpoint().assertEndpointConfig("${logUrl}v1/logs", logHeaders + baseHeaders)
+        config.metricsEndpoint().assertEndpointConfig(
+            "${metricsUrl}v1/metrics",
+            metricsHeaders + baseHeaders,
+        )
+        assertEquals(baseUrl, config.baseUrl)
+        assertEquals(baseHeaders, config.baseHeaders)
+    }
+
+    @Test
+    fun testIndividualEndpointOverrides2() {
+        val baseUrl = "http://localhost:4318/"
+        val baseHeaders = mapOf("my-header" to "my-value")
+
+        val spanUrl = "http://localhost:4318/spans/"
+        val spanHeaders = mapOf("span-header" to "span-value")
+
+        val logUrl = "http://localhost:4318/logs/"
+        val logHeaders = mapOf("log-header" to "log-value")
+
+        val metricsUrl = "http://localhost:4318/metrics/"
+        val metricsHeaders = mapOf("metrics-header" to "metrics-value")
+
+        val config =
+            HttpExportConfiguration().apply {
+                spans {
+                    url = spanUrl
+                    headers = spanHeaders
+                }
+                logs {
+                    url = logUrl
+                    headers = logHeaders
+                }
+                metrics {
+                    url = metricsUrl
+                    headers = metricsHeaders
+                }
+
+                // altering base values after setting individual endpoints should give same result as
+                // when setting base values before.
+                this.baseUrl = baseUrl
+                this.baseHeaders = baseHeaders
+            }
+
+        config.spansEndpoint().assertEndpointConfig("${spanUrl}v1/traces", spanHeaders + baseHeaders)
+        config.logsEndpoint().assertEndpointConfig("${logUrl}v1/logs", logHeaders + baseHeaders)
+        config.metricsEndpoint().assertEndpointConfig(
+            "${metricsUrl}v1/metrics",
+            metricsHeaders + baseHeaders,
+        )
+        assertEquals(baseUrl, config.baseUrl)
+        assertEquals(baseHeaders, config.baseHeaders)
+    }
+
+    private fun HttpEndpointConnectivity.assertEndpointConfig(
+        expectedUrl: String,
+        expectedHeaders: Map<String, String>,
+    ) {
+        assertEquals(expectedUrl, getUrl())
+        assertEquals(expectedHeaders, getHeaders())
+    }
+}

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/OtelDemoApplication.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/OtelDemoApplication.kt
@@ -34,11 +34,13 @@ class OtelDemoApplication : Application() {
         // 10.0.2.2 is a special binding to the host running the emulator
         try {
             rum = OpenTelemetryRumInitializer.initialize(
-                application = this,
-                globalAttributes = { Attributes.of(stringKey("toolkit"), "jetpack compose") },
+                context = this@OtelDemoApplication,
                 configuration = {
                     httpExport {
                         baseUrl = "http://10.0.2.2:4318"
+                    }
+                    globalAttributes {
+                        Attributes.of(stringKey("toolkit"), "jetpack compose")
                     }
                 }
             )


### PR DESCRIPTION
## Goal

Builds on #1292 by using a type-safe DSL rather than individual parameters. The last commit contains the changes for this PR specifically. Essentially, I have moved the `globalAttributes` and `diskBuffering` parameters onto `OpenTelemetryConfiguration`.

I also hid some values that are no longer publicly accessed from the public API by making them internal, and made some constructors internal too.