### PR TITLE
Use JDK 21

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: touch local props
         run: touch demo-app/local.properties
       - name: run gradle check

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,11 +25,11 @@ jobs:
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - name: Set up Java 17
+      - name: Set up Java
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: Set up gradle
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Setup Gradle build action
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
       - name: touch local props

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,7 @@ jobs:
         uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: Build and publish artifacts
         run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -Pfinal=true --no-build-cache --no-configuration-cache --no-parallel


### PR DESCRIPTION
## Goal

Uses JDK 21 to build the project on CI, bumping from 17. This gets the project closer to the latest LTS (AGP doesn't quite support it yet). I noticed there are a couple more warnings about targeting 1.8 bytecode when building the project, but functionally everything seems to work ok.