### PR TITLE
Bump max metaspace to 3g for demo-app build

### DIFF
--- a/demo-app/gradle.properties
+++ b/demo-app/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx4096M -XX:+UseParallelGC -XX:MaxMetaspaceSize=2g -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4096M"
+org.gradle.jvmargs=-Xmx4096M -XX:+UseParallelGC -XX:MaxMetaspaceSize=3g -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4096M"
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true


### PR DESCRIPTION
The [nightly build for the demo-app](https://github.com/open-telemetry/opentelemetry-android/issues/1351#issuecomment-3473409775) has been [failing](https://github.com/open-telemetry/opentelemetry-android/actions/runs/18975122249/job/54192572704#step:9:1623) due "Metaspace" (presumably running out of it).

<img width="431" height="114" alt="image" src="https://github.com/user-attachments/assets/1ada3efc-5b52-4f88-b514-ee0da7ab7ced" />


