### PR TITLE
fix: add `openTelemetry` getter to `OpenTelemetryRum` to fix breaking API change

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -50,11 +50,6 @@ public final class io/opentelemetry/android/OpenTelemetryRumBuilder {
 	public fun setSessionProvider (Lio/opentelemetry/android/session/SessionProvider;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 }
 
-public final class io/opentelemetry/android/OpenTelemetryRumKt {
-	public static final fun getOpenTelemetry (Lio/opentelemetry/android/OpenTelemetryRum;)Lio/opentelemetry/api/OpenTelemetry;
-	public static final fun getRumSessionId (Lio/opentelemetry/android/OpenTelemetryRum;)Ljava/lang/String;
-}
-
 public final class io/opentelemetry/android/SdkPreconfiguredRumBuilder {
 	public final fun addInstrumentation (Lio/opentelemetry/android/instrumentation/AndroidInstrumentation;)Lio/opentelemetry/android/SdkPreconfiguredRumBuilder;
 	public final fun build ()Lio/opentelemetry/android/OpenTelemetryRum;

--- a/core/src/main/java/io/opentelemetry/android/NoopOpenTelemetryRum.kt
+++ b/core/src/main/java/io/opentelemetry/android/NoopOpenTelemetryRum.kt
@@ -10,7 +10,7 @@ import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.TraceId
 
 internal object NoopOpenTelemetryRum : OpenTelemetryRum {
-    override fun getOpenTelemetry(): OpenTelemetry = OpenTelemetry.noop()
+    override val openTelemetry: OpenTelemetry = OpenTelemetry.noop()
 
     override fun getRumSessionId(): String {
         // RUM session.id has the same format as traceId

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRum.kt
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRum.kt
@@ -20,7 +20,7 @@ interface OpenTelemetryRum {
      * Get a handle to the instance of the OpenTelemetry API that this
      * instance is using for instrumentation.
      */
-    fun getOpenTelemetry(): OpenTelemetry
+    val openTelemetry: OpenTelemetry
 
     /**
      * Get the client session ID associated with this instance of the RUM instrumentation library.
@@ -104,17 +104,3 @@ interface OpenTelemetryRum {
         fun noop(): OpenTelemetryRum = NoopOpenTelemetryRum
     }
 }
-
-/**
- * Property accessor for [OpenTelemetryRum.getOpenTelemetry]. Provided for backward compatibility
- * with code that accessed this as a property when the class was in Java.
- */
-val OpenTelemetryRum.openTelemetry: OpenTelemetry
-    get() = getOpenTelemetry()
-
-/**
- * Property accessor for [OpenTelemetryRum.getRumSessionId]. Provided for backward compatibility
- * with code that accessed this as a property when the class was in Java.
- */
-val OpenTelemetryRum.rumSessionId: String
-    get() = getRumSessionId()

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumImpl.kt
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumImpl.kt
@@ -21,7 +21,7 @@ internal class OpenTelemetryRumImpl(
             .loggerBuilder("io.opentelemetry.rum.events")
             .build()
 
-    override fun getOpenTelemetry(): OpenTelemetry = openTelemetrySdk
+    override val openTelemetry: OpenTelemetry = openTelemetrySdk
 
     override fun getRumSessionId(): String = sessionProvider.getSessionId()
 

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.kt
@@ -141,7 +141,7 @@ class OpenTelemetryRumBuilderTest {
             .untilAsserted {
                 val sessionId = openTelemetryRum.getRumSessionId()
                 openTelemetryRum
-                    .getOpenTelemetry()
+                    .openTelemetry
                     .getTracer("test")
                     .spanBuilder("test span")
                     .startSpan()
@@ -222,7 +222,7 @@ class OpenTelemetryRumBuilderTest {
                         .registerMetricReader(metricReader)
                 }.build()
 
-        val sdk = openTelemetryRum.getOpenTelemetry() as OpenTelemetrySdk
+        val sdk = openTelemetryRum.openTelemetry as OpenTelemetrySdk
         val meter = sdk.sdkMeterProvider.meterBuilder("myMeter").build()
         val counterAttrs = Attributes.of(AttributeKey.longKey("adams"), 42L)
         val counter = meter.counterBuilder("myCounter").build()
@@ -263,7 +263,7 @@ class OpenTelemetryRumBuilderTest {
                 }.addMetricExporterCustomizer(Function { x: MetricExporter -> exporter })
                 .build()
 
-        val sdk = openTelemetryRum.getOpenTelemetry() as OpenTelemetrySdk
+        val sdk = openTelemetryRum.openTelemetry as OpenTelemetrySdk
         val meter = sdk.sdkMeterProvider.meterBuilder("FOOMETER").build()
         val counter = meter.counterBuilder("FOOCOUNTER").build()
         counter.add(22)
@@ -366,7 +366,7 @@ class OpenTelemetryRumBuilderTest {
                 .build()
         val result =
             rum
-                .getOpenTelemetry()
+                .openTelemetry
                 .propagators
                 .textMapPropagator
                 .extract(context, carrier, getter)
@@ -381,7 +381,7 @@ class OpenTelemetryRumBuilderTest {
             makeBuilder()
                 .addPropagatorCustomizer(Function { x: TextMapPropagator -> customPropagator })
                 .build()
-        val result = rum.getOpenTelemetry().propagators.textMapPropagator
+        val result = rum.openTelemetry.propagators.textMapPropagator
         assertThat(result).isSameAs(customPropagator)
     }
 
@@ -406,7 +406,7 @@ class OpenTelemetryRumBuilderTest {
 
         val span =
             rum
-                .getOpenTelemetry()
+                .openTelemetry
                 .getTracer("test")
                 .spanBuilder("foo")
                 .startSpan()
@@ -443,7 +443,7 @@ class OpenTelemetryRumBuilderTest {
 
         val logger =
             rum
-                .getOpenTelemetry()
+                .openTelemetry
                 .logsBridge
                 .loggerBuilder("LogScope")
                 .build()
@@ -607,7 +607,7 @@ class OpenTelemetryRumBuilderTest {
 
         val logger =
             rum
-                .getOpenTelemetry()
+                .openTelemetry
                 .logsBridge
                 .loggerBuilder("LogScope")
                 .build()

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumNoopTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumNoopTest.kt
@@ -13,7 +13,7 @@ internal class OpenTelemetryRumNoopTest {
     @Test
     fun testNoopOpenTelemetryRum() {
         val noop = OpenTelemetryRum.noop()
-        assertEquals(OpenTelemetry.noop(), noop.getOpenTelemetry())
+        assertEquals(OpenTelemetry.noop(), noop.openTelemetry)
         assertEquals("00000000000000000000000000000000", noop.getRumSessionId())
 
         // assert no exceptions thrown

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/OtelDemoApplication.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/OtelDemoApplication.kt
@@ -74,11 +74,11 @@ class OtelDemoApplication : Application() {
         var rum: OpenTelemetryRum? = null
 
         fun tracer(name: String): Tracer? {
-            return rum?.getOpenTelemetry()?.tracerProvider?.get(name)
+            return rum?.openTelemetry?.tracerProvider?.get(name)
         }
 
         fun counter(name: String): LongCounter? {
-            return rum?.getOpenTelemetry()?.meterProvider?.get("demo.app")?.counterBuilder(name)
+            return rum?.openTelemetry?.meterProvider?.get("demo.app")?.counterBuilder(name)
                 ?.build()
         }
 
@@ -86,7 +86,7 @@ class OtelDemoApplication : Application() {
             if (rum == null) {
                 return LoggerProvider.noop().get("noop").logRecordBuilder()
             }
-            val logger = rum!!.getOpenTelemetry().logsBridge.loggerBuilder(scopeName).build()
+            val logger = rum!!.openTelemetry.logsBridge.loggerBuilder(scopeName).build()
             return logger.logRecordBuilder().setEventName(eventName)
         }
     }

--- a/test-common/src/main/kotlin/io/opentelemetry/android/test/common/OpenTelemetryRumRule.kt
+++ b/test-common/src/main/kotlin/io/opentelemetry/android/test/common/OpenTelemetryRumRule.kt
@@ -41,7 +41,7 @@ class OpenTelemetryRumRule : TestRule {
 
     fun getSpan(): Span =
         openTelemetryRum
-            .getOpenTelemetry()
+            .openTelemetry
             .getTracer("TestTracer")
             .spanBuilder("A Span")
             .startSpan()


### PR DESCRIPTION
I'm not sure if it was intentional, but when `OpenTelemetryRum` was ported from Java to Kotlin, existing Kotlin code that used `.openTelemetry` to access `getOpenTelemetry()` broke, because that getter had previously been added by the automatic Kotlin wrapper around the Java. This change adds an extension with a readonly property to fix those cases.

The property cannot be added the class itself, because then the automatic _Java_ wrapper around the Kotlin would add a `getOpenTelemetry()` method that would conflict with the existing one.

An alternative would be to _replace_ the `getOpenTelemetry()` method with the readonly property. But I think that would break existing Kotlin code that explicitly calls `getOpenTelemetry()`. So I chose the safer option.