### PR TITLE
Rename event name `event.app.widget.click` to [`app.widget.click`](ht…

### DIFF
--- a/instrumentation/compose/click/README.md
+++ b/instrumentation/compose/click/README.md
@@ -30,7 +30,7 @@ This instrumentation produces the following telemetry:
   for more details.
 
 * Type: Event
-* Name: `event.app.widget.click`
+* Name: `app.widget.click`
 * Description: This event is emitted when the user taps on a composable that is clickable.
 * See the [semantic convention definition](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/app/app-events.md#event-appwidgetclick)
   for more details.

--- a/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeLayoutNodeUtil.kt
+++ b/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeLayoutNodeUtil.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.node.LayoutNode
 
 const val APP_SCREEN_CLICK_EVENT_NAME = "app.screen.click"
-const val VIEW_CLICK_EVENT_NAME = "event.app.widget.click"
+const val VIEW_CLICK_EVENT_NAME = "app.widget.click"
 
 internal class ComposeLayoutNodeUtil {
     internal fun getLayoutNodeBoundsInWindow(node: LayoutNode): Rect? =

--- a/instrumentation/view-click/README.md
+++ b/instrumentation/view-click/README.md
@@ -27,7 +27,7 @@ This instrumentation produces the following telemetry:
   for more details.
 
 * Type: Event
-* Name: `event.app.widget.click`
+* Name: `app.widget.click`
 * Description: This event is emitted when the user taps on a view. Jetpack compose views are not currently supported.
 * See the [semantic convention definition](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/app/app-events.md#event-appwidgetclick)
   for more details.

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/internal/ViewUtils.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/internal/ViewUtils.kt
@@ -6,4 +6,4 @@
 package io.opentelemetry.android.instrumentation.view.click.internal
 
 const val APP_SCREEN_CLICK_EVENT_NAME = "app.screen.click"
-const val VIEW_CLICK_EVENT_NAME = "event.app.widget.click"
+const val VIEW_CLICK_EVENT_NAME = "app.widget.click"


### PR DESCRIPTION
…tps://opentelemetry.io/docs/specs/semconv/app/app-events/#event-appwidgetclick)

Fixes https://github.com/open-telemetry/opentelemetry-android/issues/1386