### PR TITLE
Put version string literal back into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ from all other opentelemetry dependencies:
 ```kotlin
 dependencies {
     //...
-    api(platform("io.opentelemetry.android:opentelemetry-android-bom:<version>"))
+    api(platform("io.opentelemetry.android:opentelemetry-android-bom:0.16.0-alpha"))
     implementation("io.opentelemetry.android:android-agent") // Version is resolved through the BOM
     //...
 }


### PR DESCRIPTION
I left a comment about this in #1385, but it wasn't fixed before merge, so this puts the literal version string back in. This allows the build automation to replace the string with the actual version...the result is that users have something that should be copy/pasteable.