### PR TITLE
Using original metrics aggregation temporality on disk buffering

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.java
@@ -387,7 +387,10 @@ public final class OpenTelemetryRumBuilder {
                 final LogRecordExporter originalLogsExporter = logsExporter;
                 logsExporter = LogRecordToDiskExporter.builder(logStorage).build();
                 final MetricExporter originalMetricExporter = metricExporter;
-                metricExporter = MetricToDiskExporter.builder(metricStorage).build();
+                metricExporter =
+                        MetricToDiskExporter.builder(metricStorage)
+                                .setAggregationTemporalitySelector(originalMetricExporter)
+                                .build();
                 signalFromDiskExporter =
                         new SignalFromDiskExporter(
                                 spanStorage, originalSpanExporter,


### PR DESCRIPTION
Should fix #1390 