### PR TITLE
Feature/compose click node name from modifier

### DIFF
--- a/instrumentation/compose/click/api/click.api
+++ b/instrumentation/compose/click/api/click.api
@@ -9,3 +9,7 @@ public final class io/opentelemetry/instrumentation/compose/click/ComposeLayoutN
 	public static final field VIEW_CLICK_EVENT_NAME Ljava/lang/String;
 }
 
+public final class io/opentelemetry/instrumentation/compose/click/OpentelemetryModifierKt {
+	public static final fun opentelemetry (Landroidx/compose/ui/Modifier;Ljava/lang/String;)Landroidx/compose/ui/Modifier;
+}
+

--- a/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/OpentelemetryModifier.kt
+++ b/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/OpentelemetryModifier.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.compose.click
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsPropertyKey
+import androidx.compose.ui.semantics.SemanticsPropertyReceiver
+import androidx.compose.ui.semantics.semantics
+
+/**
+ * An opentelemetry Modifier that allows to mark a composable element as traceable.
+ * When a composable element that has this Modifier will be tapped, then the [name] from this
+ * Modifier will be taken as the element name
+ *
+ * @param name name of the tapped element
+ */
+fun Modifier.opentelemetry(name: String): Modifier =
+    this.semantics {
+        this.opentelemetry = name
+    }
+
+internal val OpentelemetrySemanticsPropertyKey: SemanticsPropertyKey<String> =
+    SemanticsPropertyKey(
+        name = "_opentelemetry_semantics",
+        mergePolicy = { parentValue, _ ->
+            parentValue
+        },
+    )
+
+private var SemanticsPropertyReceiver.opentelemetry by OpentelemetrySemanticsPropertyKey

--- a/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/TestTagFinder.kt
+++ b/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/TestTagFinder.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.compose.click
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsModifier
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import kotlin.jvm.java
+import kotlin.text.isNullOrEmpty
+
+private const val TEST_TAG_FIELD_NAME = "tag"
+
+internal fun Modifier.getTestTag(): String? = findTestTagInModifier(this)
+
+internal fun findTestTagInModifier(modifier: Modifier): String? {
+    if (modifier is SemanticsModifier) {
+        with(modifier.semanticsConfiguration) {
+            val testTag = getOrNull(SemanticsProperties.TestTag)
+            if (!testTag.isNullOrEmpty()) {
+                return testTag
+            }
+        }
+    }
+    // Often the Modifier is a TestTagElement. As this class is private there is only a way to
+    // get the TestTag value using reflection
+    if ("androidx.compose.ui.platform.TestTagElement" == modifier::class.qualifiedName) {
+        try {
+            val testTagField = modifier::class.java.getDeclaredField(TEST_TAG_FIELD_NAME)
+            testTagField.isAccessible = true
+            val testTag = testTagField.get(modifier) as String
+            if (testTag.isNotEmpty()) {
+                return testTag
+            }
+        } catch (_: Exception) {
+        }
+    }
+    return null
+}

--- a/instrumentation/compose/click/src/test/kotlin/androidx/compose/ui/platform/TestTagElement.kt
+++ b/instrumentation/compose/click/src/test/kotlin/androidx/compose/ui/platform/TestTagElement.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package androidx.compose.ui.platform
+
+import androidx.compose.ui.Modifier
+
+// Test-only stand-in for the private Compose TestTagElement.
+// Must have a private field named `tag` so reflection in the production code finds it.
+class TestTagElement(
+    @Suppress("UnusedPrivateProperty") private val tag: String,
+) : Modifier.Element

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGeneratorTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGeneratorTest.kt
@@ -235,6 +235,8 @@ internal class ComposeClickEventGeneratorTest {
 
             every { semanticsModifier.semanticsConfiguration } returns semanticsConfiguration
             every { semanticsConfiguration.contains(eq(SemanticsActions.OnClick)) } returns true
+            every { semanticsConfiguration.contains(eq(OpentelemetrySemanticsPropertyKey)) } returns false
+            every { semanticsConfiguration.getOrNull(eq(OpentelemetrySemanticsPropertyKey)) } returns null
 
             if (useDescription) {
                 every { semanticsConfiguration.getOrNull(eq(SemanticsActions.OnClick)) } returns null
@@ -284,7 +286,7 @@ internal class ComposeClickEventGeneratorTest {
         }
 
         every { nodeList[0].zSortedChildren } returns mutableVectorOf(nodeList[1], nodeList[2])
-        every { nodeList[1].zSortedChildren } returns mutableVectorOf(nodeList[4], nodeList[3])
+        every { nodeList[1].zSortedChildren } returns mutableVectorOf(nodeList[3], nodeList[4])
         every { nodeList[2].zSortedChildren } returns mutableVectorOf()
 
         every { nodeList[3].zSortedChildren } returns mutableVectorOf()

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
@@ -97,6 +97,74 @@ internal class ComposeInstrumentationTest {
 
     @Test
     fun capture_compose_click() {
+        val motionEvent =
+            MotionEvent.obtain(0L, SystemClock.uptimeMillis(), MotionEvent.ACTION_UP, 250f, 50f, 0)
+        val mockLayoutNode =
+            createMockLayoutNode(
+                targetX = motionEvent.x,
+                targetY = motionEvent.y,
+                hit = true,
+                clickable = true,
+                useDescription = true,
+            )
+        mockComposeClick(mockLayoutNode, motionEvent)
+        val events = openTelemetryRule.logRecords
+        assertThat(events).hasSize(2)
+
+        var event = events[0]
+        assertThat(event)
+            .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
+            .hasAttributesSatisfyingExactly(
+                equalTo(APP_SCREEN_COORDINATE_X, motionEvent.x.toLong()),
+                equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
+            )
+
+        event = events[1]
+        assertThat(event)
+            .hasEventName(VIEW_CLICK_EVENT_NAME)
+            .hasAttributesSatisfying(
+                equalTo(APP_WIDGET_ID, mockLayoutNode.semanticsId.toString()),
+                equalTo(APP_WIDGET_NAME, "clickMe"),
+            )
+    }
+
+    @Test
+    fun capture_compose_click_using_modifier() {
+        val motionEvent =
+            MotionEvent.obtain(0L, SystemClock.uptimeMillis(), MotionEvent.ACTION_UP, 250f, 50f, 0)
+        val mockLayoutNode =
+            createMockLayoutNode(
+                targetX = motionEvent.x,
+                targetY = motionEvent.y,
+                hit = true,
+                clickable = true,
+                useOpenTelemetryModifier = true,
+            )
+        mockComposeClick(mockLayoutNode, motionEvent)
+        val events = openTelemetryRule.logRecords
+        assertThat(events).hasSize(2)
+
+        var event = events[0]
+        assertThat(event)
+            .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
+            .hasAttributesSatisfyingExactly(
+                equalTo(APP_SCREEN_COORDINATE_X, motionEvent.x.toLong()),
+                equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
+            )
+
+        event = events[1]
+        assertThat(event)
+            .hasEventName(VIEW_CLICK_EVENT_NAME)
+            .hasAttributesSatisfying(
+                equalTo(APP_WIDGET_ID, mockLayoutNode.semanticsId.toString()),
+                equalTo(APP_WIDGET_NAME, "opentelemetryClick"),
+            )
+    }
+
+    private fun mockComposeClick(
+        mockLayoutNode: LayoutNode,
+        motionEvent: MotionEvent,
+    ) {
         val installationContext =
             InstallationContext(
                 application,
@@ -121,19 +189,9 @@ internal class ComposeInstrumentationTest {
         val wrapperCapturingSlot = slot<WindowCallbackWrapper>()
         every { window.callback = any() } returns Unit
 
-        val motionEvent =
-            MotionEvent.obtain(0L, SystemClock.uptimeMillis(), MotionEvent.ACTION_UP, 250f, 50f, 0)
         every { window.decorView } returns composeView
         every { composeView.childCount } returns 0
 
-        val mockLayoutNode =
-            createMockLayoutNode(
-                targetX = motionEvent.x,
-                targetY = motionEvent.y,
-                hit = true,
-                clickable = true,
-                useDescription = true,
-            )
         every { composeView.root } returns mockLayoutNode
 
         viewClickActivityCallback.onActivityResumed(activity)
@@ -144,25 +202,6 @@ internal class ComposeInstrumentationTest {
         wrapperCapturingSlot.captured.dispatchTouchEvent(
             motionEvent,
         )
-
-        val events = openTelemetryRule.logRecords
-        assertThat(events).hasSize(2)
-
-        var event = events[0]
-        assertThat(event)
-            .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
-            .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, motionEvent.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
-            )
-
-        event = events[1]
-        assertThat(event)
-            .hasEventName(VIEW_CLICK_EVENT_NAME)
-            .hasAttributesSatisfying(
-                equalTo(APP_WIDGET_ID, mockLayoutNode.semanticsId.toString()),
-                equalTo(APP_WIDGET_NAME, "clickMe"),
-            )
     }
 
     private fun createMockLayoutNode(
@@ -173,6 +212,7 @@ internal class ComposeInstrumentationTest {
         hit: Boolean = false,
         clickable: Boolean = false,
         useDescription: Boolean = false,
+        useOpenTelemetryModifier: Boolean = false,
     ): LayoutNode {
         val mockNode = mockkClass(LayoutNode::class)
         every { mockNode.isPlaced } returns true
@@ -199,6 +239,13 @@ internal class ComposeInstrumentationTest {
             every { modifierInfo.modifier } returns semanticsModifier
 
             every { semanticsModifier.semanticsConfiguration } returns semanticsConfiguration
+            if (useOpenTelemetryModifier) {
+                every { semanticsConfiguration.contains(eq(OpentelemetrySemanticsPropertyKey)) } returns true
+                every { semanticsConfiguration.getOrNull(eq(OpentelemetrySemanticsPropertyKey)) } returns "opentelemetryClick"
+            } else {
+                every { semanticsConfiguration.contains(eq(OpentelemetrySemanticsPropertyKey)) } returns false
+                every { semanticsConfiguration.getOrNull(eq(OpentelemetrySemanticsPropertyKey)) } returns null
+            }
             every { semanticsConfiguration.contains(eq(SemanticsActions.OnClick)) } returns true
 
             if (useDescription) {

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/OpentelemetryModifierTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/OpentelemetryModifierTest.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.compose.click
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.SemanticsModifier
+import androidx.compose.ui.semantics.getOrNull
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class OpentelemetryModifierTest {
+    @Test
+    fun opentelemetryModifier_returnsModifiedModifier() {
+        val modifier = Modifier.opentelemetry("custom name")
+        with((modifier as SemanticsModifier).semanticsConfiguration) {
+            val opentelemetryModifierValue = getOrNull(OpentelemetrySemanticsPropertyKey)
+            assertEquals("custom name", opentelemetryModifierValue)
+        }
+    }
+}

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/TestTagFinderTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/TestTagFinderTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.compose.click
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.TestTagElement
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.jupiter.api.assertNull
+
+class TestTagFinderTest {
+    @Test
+    fun `finds tag via reflection on TestTagElement`() {
+        val element = TestTagElement("my-test-tag")
+        val result = findTestTagInModifier(element as Modifier)
+        assertEquals("my-test-tag", result)
+    }
+
+    @Test
+    fun `finds tag via reflection on TestTagElement with empty value`() {
+        val element = TestTagElement("")
+        val result = findTestTagInModifier(element as Modifier)
+        assertNull(result)
+    }
+
+    @Test
+    fun `finds tag via reflection on Modifier`() {
+        val element = Modifier
+        val result = findTestTagInModifier(element)
+        assertNull(result)
+    }
+}


### PR DESCRIPTION
This PR enchances the compose-click module for better detection of the name of tapped compose element.

It introduces two ways of detecting name of the tapped element:

1. `Modifier.opentelemetry` - introduces a custom Modifier (similar solution is used by other telemetry SDKs like Datadog and Sentry. Developers can use this modifier to mark a composable element and give it a name. Then the compose-click module will be able to easily find such tapped element and retrieve a name from it.
2. `Modifier.testTag` - handling as a fallback to read the TestTag value of tapped element. TestTag is often used for Unit tests and therefore it is useful to take it during composable element name discovery.