### PR TITLE
Fix dependencies for release

### DIFF
--- a/agent-api/build.gradle.kts
+++ b/agent-api/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     id("otel.publish-conventions")
 }
 
+description = "OpenTelemetry android agent api"
+
 android {
     namespace = "io.opentelemetry.android.agent.api"
 

--- a/android-agent/build.gradle.kts
+++ b/android-agent/build.gradle.kts
@@ -9,6 +9,8 @@ android {
 
 dependencies {
     api(project(":agent-api"))
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
+
     implementation(project(":core"))
     implementation(project(":common"))
     implementation(project(":session"))

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -14,6 +14,7 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
     implementation(project(":agent-api"))
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.instrumentation.api)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -60,6 +60,8 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
+
     implementation(project(":agent-api"))
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(project(":common"))

--- a/instrumentation/activity/build.gradle.kts
+++ b/instrumentation/activity/build.gradle.kts
@@ -14,6 +14,7 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
     implementation(project(":instrumentation:common-api"))
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(project(":services"))

--- a/instrumentation/android-log/library/build.gradle.kts
+++ b/instrumentation/android-log/library/build.gradle.kts
@@ -10,6 +10,7 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(project(":agent-api"))
 

--- a/instrumentation/anr/build.gradle.kts
+++ b/instrumentation/anr/build.gradle.kts
@@ -18,6 +18,7 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(project(":services"))
     implementation(project(":instrumentation:common-api"))

--- a/instrumentation/common-api/build.gradle.kts
+++ b/instrumentation/common-api/build.gradle.kts
@@ -14,6 +14,7 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
     implementation(project(":common"))
     implementation(project(":agent-api"))
     implementation(libs.opentelemetry.sdk)

--- a/instrumentation/compose/click/build.gradle.kts
+++ b/instrumentation/compose/click/build.gradle.kts
@@ -14,6 +14,8 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
+
     implementation(project(":agent-api"))
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(project(":services"))

--- a/instrumentation/crash/build.gradle.kts
+++ b/instrumentation/crash/build.gradle.kts
@@ -14,6 +14,7 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(project(":common"))
     implementation(project(":services"))

--- a/instrumentation/fragment/build.gradle.kts
+++ b/instrumentation/fragment/build.gradle.kts
@@ -14,6 +14,7 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
     implementation(project(":agent-api"))
     implementation(project(":instrumentation:common-api"))
     implementation(project(":instrumentation:android-instrumentation"))

--- a/instrumentation/httpurlconnection/library/build.gradle.kts
+++ b/instrumentation/httpurlconnection/library/build.gradle.kts
@@ -10,6 +10,7 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(project(":agent-api"))
     api(libs.opentelemetry.context)

--- a/instrumentation/network/build.gradle.kts
+++ b/instrumentation/network/build.gradle.kts
@@ -19,6 +19,7 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(project(":services"))
     implementation(project(":common"))

--- a/instrumentation/okhttp3-websocket/library/build.gradle.kts
+++ b/instrumentation/okhttp3-websocket/library/build.gradle.kts
@@ -14,6 +14,7 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
     implementation(project(":agent-api"))
     implementation(project(":instrumentation:android-instrumentation"))
     compileOnly(libs.okhttp)

--- a/instrumentation/sessions/build.gradle.kts
+++ b/instrumentation/sessions/build.gradle.kts
@@ -14,6 +14,7 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
     implementation(project(":agent-api"))
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(libs.opentelemetry.sdk)

--- a/instrumentation/slowrendering/build.gradle.kts
+++ b/instrumentation/slowrendering/build.gradle.kts
@@ -18,6 +18,7 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(project(":services"))
     implementation(project(":session"))

--- a/instrumentation/startup/build.gradle.kts
+++ b/instrumentation/startup/build.gradle.kts
@@ -14,6 +14,8 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
+
     implementation(project(":agent-api"))
     implementation(project(":core"))
     implementation(project(":instrumentation:android-instrumentation"))

--- a/instrumentation/view-click/build.gradle.kts
+++ b/instrumentation/view-click/build.gradle.kts
@@ -14,6 +14,7 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
     implementation(project(":services"))
     implementation(project(":agent-api"))
     implementation(project(":instrumentation:android-instrumentation"))

--- a/session/build.gradle.kts
+++ b/session/build.gradle.kts
@@ -14,6 +14,7 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
     implementation(project(":agent-api"))
     implementation(libs.opentelemetry.sdk)
 }


### PR DESCRIPTION
_Note: This is a PR into the v1.0.x release branch._

In #1387, we somehow overlooked the removal of all the `api(platform(bom))` dependencies, which [breaks the release process](https://github.com/open-telemetry/opentelemetry-android/actions/runs/19681990167/job/56378008928#step:9:1913). I hypothesized previously (when I discovered this in the past) that the updated sonatype publishing step has some additional checks to ensure that independent artifact versions have a complete pom -- one that allows for clear, unambiguous resolution of all dependencies with version information.

Once this merges and the release is complete, we can cherry pick this back to the main branch.