### PR TITLE
Exclude compose compose bom from renovate updates.

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -73,6 +73,12 @@
       "enabled": false
     },
     {
+      // androidx.compose:compose-bom 12.00+ requires minSdk 23, but we still support minSdk 21
+      "matchPackageNames": ["androidx.compose:compose-bom"],
+      "matchUpdateTypes": ["major", "minor"],
+      "enabled": false
+    },
+    {
       // somehow renovate gets confused by the android property in gradle.properties,
       // so let's just exclude it and hopefully clean up the dashboard
       "matchPackageNames": [


### PR DESCRIPTION
See #1447 for update breakage example. We need to also hold this until we bump minSdk = 23.