### PR TITLE
Fix maven badge on main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,6 @@ For more information about the Approver role, see the [community repository](htt
 
 [ci-url]: https://github.com/open-telemetry/opentelemetry-android/actions?query=workflow%3Abuild+branch%3Amain
 
-[maven-image]: https://maven-badges.sml.io/maven-central/io.opentelemetry.android/android-agent/badge.svg
+[maven-image]: https://img.shields.io/maven-central/v/io.opentelemetry.android/android-agent.svg
 
-[maven-url]: https://maven-badges.sml.io/maven-central/io.opentelemetry.android/android-agent
+[maven-url]: https://central.sonatype.com/artifact/io.opentelemetry.android/android-agent


### PR DESCRIPTION
The main README.md still claims that our maven release version is 0.11.0 (like 6 versions old, yikes). This seems to be a problem with the maven badges thing we were using, so let's switch it to this other one that seems to work better (for now).

Clicking the badge should also take you to the sonatype central repo, and not to the badge image. Whoops.