### PR TITLE
Prevent verbose warnings around RequireExplicitNullMarking

### DIFF
--- a/buildSrc/src/main/kotlin/otel.errorprone-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.errorprone-conventions.gradle.kts
@@ -55,6 +55,8 @@ tasks {
             disable("CanIgnoreReturnValueSuggester")
             // Common to avoid an allocation
             disable("MixedMutabilityReturnType")
+            // Snuck in from NullAway see https://github.com/uber/NullAway/issues/1363#issuecomment-3607506788
+            disable("RequireExplicitNullMarking")
         }
     }
 }


### PR DESCRIPTION
The latest version of errorprone uses a new version of nullaway that causes a ton of warnings to be emitted in the console output. Let's suppress that for now.

See https://github.com/open-telemetry/opentelemetry-java/pull/7890 and https://github.com/uber/NullAway/issues/1363#issuecomment-3607506788