### PR TITLE
Avoid unnecessary check task

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: run gradle check
         run: ./gradlew check
       - name: create test coverage report
-        run: ./gradlew check koverXmlReport
+        run: ./gradlew koverXmlReport
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 # v5.5.1
         with:


### PR DESCRIPTION
## Goal

Explicitly stating `check` isn't required to generate a code coverage report, Gradle will pick up the necessary test tasks automatically. This shouldn't cause any serious perf issues due to the build's caching, but it can't hurt to clarify this.

Fixes #1458