### PR TITLE
Add ability to override resource from OpenTelemetryRumInitializer

### DIFF
--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -45,6 +45,7 @@ public final class io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration
 	public final fun globalAttributes (Lkotlin/jvm/functions/Function0;)V
 	public final fun httpExport (Lkotlin/jvm/functions/Function1;)V
 	public final fun instrumentations (Lkotlin/jvm/functions/Function1;)V
+	public final fun resource (Lkotlin/jvm/functions/Function1;)V
 	public final fun session (Lkotlin/jvm/functions/Function1;)V
 }
 

--- a/android-agent/build.gradle.kts
+++ b/android-agent/build.gradle.kts
@@ -30,6 +30,8 @@ dependencies {
     implementation(project(":instrumentation:sessions"))
     implementation(project(":instrumentation:screen-orientation"))
 
+    testImplementation(libs.opentelemetry.semconv)
+    testImplementation(libs.opentelemetry.semconv.incubating)
     testImplementation(libs.robolectric)
 }
 

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
@@ -7,6 +7,7 @@ package io.opentelemetry.android.agent
 
 import android.app.Application
 import android.content.Context
+import io.opentelemetry.android.AndroidResource
 import io.opentelemetry.android.Incubating
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.RumBuilder
@@ -59,9 +60,15 @@ object OpenTelemetryRumInitializer {
         val spansEndpoint = cfg.exportConfig.spansEndpoint()
         val logsEndpoints = cfg.exportConfig.logsEndpoint()
         val metricsEndpoint = cfg.exportConfig.metricsEndpoint()
+
+        val resourceBuilder = AndroidResource.createDefault(ctx).toBuilder()
+        cfg.resourceAction(resourceBuilder)
+        val resource = resourceBuilder.build()
+
         return RumBuilder
             .builder(ctx, cfg.rumConfig)
             .setSessionProvider(createSessionProvider(ctx, sessionConfig))
+            .setResource(resource)
             .addSpanExporterCustomizer {
                 OtlpHttpSpanExporter
                     .builder()

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
@@ -10,6 +10,7 @@ import io.opentelemetry.android.agent.dsl.instrumentation.InstrumentationConfigu
 import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig
 import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.sdk.resources.ResourceBuilder
 
 /**
  * Type-safe config DSL that controls how OpenTelemetry should behave.
@@ -23,6 +24,7 @@ class OpenTelemetryConfiguration internal constructor(
     internal val sessionConfig = SessionConfiguration()
     internal val diskBufferingConfig = DiskBufferingConfigurationSpec()
     internal val instrumentations = InstrumentationConfiguration(rumConfig)
+    internal var resourceAction: ResourceBuilder.() -> Unit = {}
 
     init {
         diskBuffering {}
@@ -62,5 +64,12 @@ class OpenTelemetryConfiguration internal constructor(
     fun diskBuffering(action: DiskBufferingConfigurationSpec.() -> Unit) {
         diskBufferingConfig.action()
         rumConfig.setDiskBufferingConfig(DiskBufferingConfig.create(enabled = diskBufferingConfig.enabled))
+    }
+
+    /**
+     * Configures the resource attributes that are used globally by acting on a [ResourceBuilder].
+     */
+    fun resource(action: ResourceBuilder.() -> Unit) {
+        resourceAction = action
     }
 }

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/ResourceConfigTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/ResourceConfigTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.opentelemetry.android.agent.OpenTelemetryRumInitializer
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.sdk.resources.ResourceBuilder
+import io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME
+import io.opentelemetry.semconv.TelemetryAttributes.TELEMETRY_SDK_LANGUAGE
+import io.opentelemetry.semconv.TelemetryAttributes.TELEMETRY_SDK_NAME
+import io.opentelemetry.semconv.TelemetryAttributes.TELEMETRY_SDK_VERSION
+import io.opentelemetry.semconv.incubating.AndroidIncubatingAttributes.ANDROID_OS_API_LEVEL
+import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MANUFACTURER
+import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MODEL_IDENTIFIER
+import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MODEL_NAME
+import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_DESCRIPTION
+import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_NAME
+import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_TYPE
+import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_VERSION
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ResourceConfigTest {
+    @Test
+    fun testDefaults() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        lateinit var builder: ResourceBuilder
+
+        OpenTelemetryRumInitializer.initialize(ctx) {
+            resource {
+                builder = this
+            }
+        }
+
+        val resource = builder.build()
+        val attrs = resource.attributes.asMap()
+        assertCommonResources(attrs)
+    }
+
+    @Test
+    fun testOverrides() {
+        val ctx = ApplicationProvider.getApplicationContext<Context>()
+        lateinit var builder: ResourceBuilder
+        val customKey = "foo"
+        val customValue = "bar"
+        val customServiceName = "test-service"
+
+        OpenTelemetryRumInitializer.initialize(ctx) {
+            resource {
+                builder = this
+                put(customKey, customValue)
+                put(SERVICE_NAME, customServiceName)
+            }
+        }
+
+        val resource = builder.build()
+        val attrs = resource.attributes.asMap()
+        assertCommonResources(attrs)
+        assertEquals(customServiceName, attrs[SERVICE_NAME])
+        assertEquals("bar", attrs[AttributeKey.stringKey(customKey)])
+    }
+
+    private fun assertCommonResources(attrs: Map<AttributeKey<*>, Any>) {
+        assertEquals("23", attrs[ANDROID_OS_API_LEVEL])
+        assertEquals("unknown", attrs[DEVICE_MANUFACTURER])
+        assertEquals("robolectric", attrs[DEVICE_MODEL_IDENTIFIER])
+        assertEquals("robolectric", attrs[DEVICE_MODEL_NAME])
+        assertEquals("Android", attrs[OS_NAME])
+        assertEquals("linux", attrs[OS_TYPE])
+        assertEquals("6.0.1", attrs[OS_VERSION])
+        assertEquals("Android Version 6.0.1 (Build MMB29M API level 23)", attrs[OS_DESCRIPTION])
+        assertEquals("java", attrs[TELEMETRY_SDK_LANGUAGE])
+        assertEquals("opentelemetry", attrs[TELEMETRY_SDK_NAME])
+        assertNotNull(attrs[TELEMETRY_SDK_VERSION])
+    }
+}


### PR DESCRIPTION
## Goal

Makes it possible to override resource attributes from `OpenTelemetryRumInitializer`. This adds a new API to the DSL that allows actions to be performed on a `ResourceBuilder` instance when the `OpenTelemetryRumBuilder` is instantiated.

I did consider creating a more restrictive API than exposing `ResourceBuilder` as it does couple the project's API to opentelemetry-java's API. However, I figured the benefits of being able to merge resources and folks potentially being familiar with the existing `Resource` API surface outweighed the cons.

Fixes #1471

## Testing

Added unit tests to confirm the builder is altered.