### PR TITLE
Add smoke tests for OpenTelemetryRum

### DIFF
--- a/android-agent/build.gradle.kts
+++ b/android-agent/build.gradle.kts
@@ -33,6 +33,13 @@ dependencies {
     testImplementation(libs.opentelemetry.semconv)
     testImplementation(libs.opentelemetry.semconv.incubating)
     testImplementation(libs.robolectric)
+    testImplementation(libs.okhttp.mockwebserver)
+    testImplementation(libs.androidx.test.core)
+    testImplementation(libs.androidx.test.rules)
+    testImplementation(libs.androidx.test.runner)
+    testImplementation(libs.androidx.junit.ktx)
+    testImplementation(libs.opentelemetry.proto)
+    testImplementation(libs.protobuf.kotlin)
 }
 
 extra["pomName"] = "OpenTelemetry Android Agent"

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/DiskBufferingConfigurationSpec.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/DiskBufferingConfigurationSpec.kt
@@ -6,13 +6,25 @@
 package io.opentelemetry.android.agent.dsl
 
 import io.opentelemetry.android.agent.dsl.instrumentation.CanBeEnabledAndDisabled
+import io.opentelemetry.android.config.OtelRumConfig
+import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig
 
 /**
  * Type-safe config DSL that controls how disk buffering of exported telemetry should behave.
  */
 @OpenTelemetryDslMarker
-class DiskBufferingConfigurationSpec internal constructor() : CanBeEnabledAndDisabled {
+class DiskBufferingConfigurationSpec internal constructor(
+    private val rumConfig: OtelRumConfig,
+) : CanBeEnabledAndDisabled {
     internal var enabled: Boolean = true
+        set(value) {
+            field = value
+            rumConfig.setDiskBufferingConfig(DiskBufferingConfig.create(enabled = value))
+        }
+
+    init {
+        rumConfig.setDiskBufferingConfig(DiskBufferingConfig.create(enabled))
+    }
 
     override fun enabled(enabled: Boolean) {
         this.enabled = enabled

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
@@ -8,7 +8,6 @@ package io.opentelemetry.android.agent.dsl
 import io.opentelemetry.android.Incubating
 import io.opentelemetry.android.agent.dsl.instrumentation.InstrumentationConfiguration
 import io.opentelemetry.android.config.OtelRumConfig
-import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.sdk.resources.ResourceBuilder
 
@@ -19,16 +18,12 @@ import io.opentelemetry.sdk.resources.ResourceBuilder
 @OpenTelemetryDslMarker
 class OpenTelemetryConfiguration internal constructor(
     internal val rumConfig: OtelRumConfig = OtelRumConfig(),
+    internal val diskBufferingConfig: DiskBufferingConfigurationSpec = DiskBufferingConfigurationSpec(rumConfig),
 ) {
     internal val exportConfig = HttpExportConfiguration()
     internal val sessionConfig = SessionConfiguration()
-    internal val diskBufferingConfig = DiskBufferingConfigurationSpec()
     internal val instrumentations = InstrumentationConfiguration(rumConfig)
     internal var resourceAction: ResourceBuilder.() -> Unit = {}
-
-    init {
-        diskBuffering {}
-    }
 
     /**
      * Configures how OpenTelemetry should export telemetry over HTTP.
@@ -63,7 +58,6 @@ class OpenTelemetryConfiguration internal constructor(
      */
     fun diskBuffering(action: DiskBufferingConfigurationSpec.() -> Unit) {
         diskBufferingConfig.action()
-        rumConfig.setDiskBufferingConfig(DiskBufferingConfig.create(enabled = diskBufferingConfig.enabled))
     }
 
     /**

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/FakeOpenTelemetryServer.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/FakeOpenTelemetryServer.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.smoke
+
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
+import mockwebserver3.Dispatcher
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import mockwebserver3.RecordedRequest
+import java.io.InputStream
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.zip.GZIPInputStream
+
+/**
+ * Provides a fake server that can be used to test OTLP export. It launches a mock HTTP server
+ * and provides functions that can wait for requests to be received and then deserializes them
+ * into Protobuf models that can be asserted against.
+ */
+internal class FakeOpenTelemetryServer {
+    private val logRequests: MutableCollection<ExportLogsServiceRequest> = ConcurrentLinkedQueue()
+    private val traceRequests: MutableCollection<ExportTraceServiceRequest> =
+        ConcurrentLinkedQueue()
+
+    private val requestHandler: Dispatcher =
+        object : Dispatcher() {
+            override fun dispatch(request: RecordedRequest): MockResponse {
+                when (request.target) {
+                    "/v1/traces" -> {
+                        traceRequests.add(
+                            readRequestBodyAsStream(request).use {
+                                ExportTraceServiceRequest.parseFrom(it)
+                            },
+                        )
+                    }
+
+                    "/v1/logs" -> {
+                        logRequests.add(
+                            readRequestBodyAsStream(request).use {
+                                ExportLogsServiceRequest.parseFrom(it)
+                            },
+                        )
+                    }
+                    else -> error("Unsupported request path: ${request.target}")
+                }
+                return MockResponse(200)
+            }
+        }
+
+    private val server =
+        MockWebServer().apply {
+            dispatcher = requestHandler
+            start()
+        }
+
+    val url = server.url("/").toString()
+
+    /**
+     * Waits for a trace request or throws after a timeout.
+     */
+    fun awaitTraceRequest(predicate: (ExportTraceServiceRequest) -> Boolean = { true }): ExportTraceServiceRequest =
+        awaitRequestMatchingPredicate(traceRequests, predicate)
+
+    /**
+     * Waits for a log request or throws after a timeout.
+     */
+    fun awaitLogRequest(predicate: (ExportLogsServiceRequest) -> Boolean = { true }): ExportLogsServiceRequest =
+        awaitRequestMatchingPredicate(logRequests, predicate)
+
+    private fun readRequestBodyAsStream(request: RecordedRequest): InputStream {
+        val bytes =
+            checkNotNull(request.body?.toByteArray()) {
+                "No bytes in request body"
+            }
+        return gunzip(bytes)
+    }
+
+    private fun gunzip(bytes: ByteArray): InputStream = GZIPInputStream(bytes.inputStream())
+
+    private fun <T> awaitRequestMatchingPredicate(
+        collection: MutableCollection<T>,
+        predicate: (T) -> Boolean,
+        waitTimeMs: Int = 5000,
+        checkIntervalMs: Int = 1,
+    ): T {
+        val tries: Int = waitTimeMs / checkIntervalMs
+        val countDownLatch = CountDownLatch(1)
+
+        repeat(tries) {
+            val request = collection.find(predicate)
+            if (request != null) {
+                collection.remove(request)
+                return request
+            } else {
+                countDownLatch.await(checkIntervalMs.toLong(), TimeUnit.MILLISECONDS)
+            }
+        }
+        throw TimeoutException("Timed out waiting for HTTP request.")
+    }
+}

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/OpenTelemetryRumSmokeTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/OpenTelemetryRumSmokeTest.kt
@@ -1,0 +1,120 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.smoke
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.agent.OpenTelemetryRumInitializer
+import io.opentelemetry.android.agent.dsl.OpenTelemetryConfiguration
+import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class OpenTelemetryRumSmokeTest {
+    private lateinit var server: FakeOpenTelemetryServer
+
+    @Before
+    fun setUp() {
+        server = FakeOpenTelemetryServer()
+    }
+
+    @Test
+    fun testLogExported() {
+        performOpenTelemetryRumAction(
+            config = {
+                httpExport {
+                    baseUrl = server.url
+                }
+                diskBufferingConfig.enabled(false)
+            },
+            action = {
+                val logger = openTelemetry.logsBridge.get("logger")
+                logger.logRecordBuilder().setBody("Hello world").emit()
+            },
+        )
+
+        val logRequest = server.awaitLogRequest()
+        assertLogRequestReceived(logRequest)
+    }
+
+    @Test
+    fun testTraceExported() {
+        performOpenTelemetryRumAction(
+            config = {
+                httpExport {
+                    baseUrl = server.url
+                }
+                diskBufferingConfig.enabled(false)
+            },
+            action = {
+                val tracer = openTelemetry.tracerProvider.get("tracer")
+                tracer.spanBuilder("span").startSpan().end()
+            },
+        )
+
+        val traceRequest =
+            server.awaitTraceRequest {
+                it
+                    .getResourceSpans(0)
+                    .getScopeSpans(0)
+                    .getSpans(0)
+                    .name == "span"
+            }
+        assertTraceRequestReceived(traceRequest)
+    }
+
+    private fun assertLogRequestReceived(request: ExportLogsServiceRequest) {
+        assertThat(
+            request
+                .getResourceLogs(0)
+                .scopeLogsList
+                .first { x ->
+                    x.scope.name.equals("logger")
+                }.getLogRecords(0)
+                .body.stringValue,
+        ).isEqualTo("Hello world")
+    }
+
+    private fun assertTraceRequestReceived(request: ExportTraceServiceRequest) {
+        assertThat(
+            request
+                .getResourceSpans(0)
+                .scopeSpansList
+                .first { x ->
+                    x.scope.name.equals("tracer")
+                }.getSpans(0)
+                .name,
+        ).isEqualTo("span")
+    }
+
+    private fun performOpenTelemetryRumAction(
+        config: OpenTelemetryConfiguration.() -> Unit,
+        action: OpenTelemetryRum.() -> Unit,
+    ) {
+        var otelRum: OpenTelemetryRum? = null
+        try {
+            val ctx = ApplicationProvider.getApplicationContext<Context>()
+            InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                otelRum = OpenTelemetryRumInitializer.initialize(ctx, config)
+            }
+
+            // perform action on OpenTelemetryRum instance
+            otelRum?.action()
+        } finally {
+            // shutdown OTel
+            InstrumentationRegistry.getInstrumentation().runOnMainSync {
+                otelRum?.shutdown()
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,8 @@ detekt = "1.23.8"
 binaryCompatValidator = "0.18.1"
 fragment = "1.8.9"
 koverGradlePlugin = "0.9.4"
+openTelemetryProto = "1.9.0-alpha"
+protobufKotlin = "4.33.2"
 
 [libraries]
 opentelemetry-platform-alpha = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetry-instrumentation-alpha" }
@@ -71,6 +73,8 @@ robolectric = "org.robolectric:robolectric:4.16"
 assertj-core = "org.assertj:assertj-core:3.27.6"
 awaitility = "org.awaitility:awaitility:4.3.0"
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver3", version.ref = "okhttp" }
+opentelemetry-proto = { module = "io.opentelemetry.proto:opentelemetry-proto", version.ref = "openTelemetryProto" }
+protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version.ref = "protobufKotlin" }
 
 #Compilation tools
 desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.1.5"


### PR DESCRIPTION
## Goal

Begins to address #405 by creating an integration test that asserts `OpenTelemetryRum` is capable of exporting OTLP. This is achieved by [using `MockWebServer`](https://github.com/square/okhttp/tree/master/mockwebserver) and deserializing requests into OpenTelemetry's protobuf models.

For now, I've just asserted that _something_ is exported for both logs and traces, as that gives reassurance that the agent isn't completely broken. In future PRs we have the option of asserting against the Protobuf model class or asserting against a golden file of known output. I'd also envision writing more test cases to exercise different parts of the API.

Proof of the usefulness of these tests is demonstrated by the fact it found a bug with the disk buffering configuration. If `diskBuffering.enabled` was set to `false` in the DSL, this was ignored due to a logic bug, meaning disk buffering effectively couldn't be disabled via `OpenTelemetryRumInitializer`. I've fixed this in the changeset. In future we should probably also add some test cases that confirm data is delivered when using the disk buffering exporter too.