### PR TITLE
Add ability to override clock

### DIFF
--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -42,11 +42,13 @@ public final class io/opentelemetry/android/agent/dsl/HttpExportConfiguration {
 public final class io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration {
 	public fun <init> ()V
 	public final fun diskBuffering (Lkotlin/jvm/functions/Function1;)V
+	public final fun getClock ()Lio/opentelemetry/sdk/common/Clock;
 	public final fun globalAttributes (Lkotlin/jvm/functions/Function0;)V
 	public final fun httpExport (Lkotlin/jvm/functions/Function1;)V
 	public final fun instrumentations (Lkotlin/jvm/functions/Function1;)V
 	public final fun resource (Lkotlin/jvm/functions/Function1;)V
 	public final fun session (Lkotlin/jvm/functions/Function1;)V
+	public final fun setClock (Lio/opentelemetry/sdk/common/Clock;)V
 }
 
 public final class io/opentelemetry/android/agent/dsl/SessionConfiguration {

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
@@ -10,6 +10,7 @@ import io.opentelemetry.android.agent.dsl.instrumentation.InstrumentationConfigu
 import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig
 import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.resources.ResourceBuilder
 
 /**
@@ -29,6 +30,11 @@ class OpenTelemetryConfiguration internal constructor(
     init {
         diskBuffering {}
     }
+
+    /**
+     * Configures the [Clock] used for capturing telemetry. Defaults to [Clock.getDefault].
+     */
+    var clock: Clock = Clock.getDefault()
 
     /**
      * Configures how OpenTelemetry should export telemetry over HTTP.

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionIdTimeoutHandler.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionIdTimeoutHandler.kt
@@ -36,8 +36,8 @@ internal class SessionIdTimeoutHandler(
 
     // for testing
     @OptIn(Incubating::class)
-    internal constructor(sessionConfig: SessionConfig) : this(
-        Clock.getDefault(),
+    internal constructor(sessionConfig: SessionConfig, clock: Clock) : this(
+        clock,
         sessionConfig.backgroundInactivityTimeout,
     )
 

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionManager.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionManager.kt
@@ -17,7 +17,7 @@ import kotlin.random.Random
 import kotlin.time.Duration
 
 internal class SessionManager(
-    private val clock: Clock = Clock.getDefault(),
+    private val clock: Clock,
     private val sessionStorage: SessionStorage = InMemorySessionStorage(),
     private val timeoutHandler: SessionIdTimeoutHandler,
     private val idGenerator: SessionIdGenerator = DefaultSessionIdGenerator(Random.Default),
@@ -85,10 +85,12 @@ internal class SessionManager(
         fun create(
             timeoutHandler: SessionIdTimeoutHandler,
             sessionConfig: SessionConfig,
+            clock: Clock,
         ): SessionManager =
             SessionManager(
                 timeoutHandler = timeoutHandler,
                 maxSessionLifetime = sessionConfig.maxLifetime,
+                clock = clock,
             )
     }
 }

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/ClockConfigTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/ClockConfigTest.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl
+
+import io.opentelemetry.sdk.common.Clock
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import org.junit.Test
+
+class ClockConfigTest {
+    @Test
+    fun testDefaults() {
+        val otelConfig = OpenTelemetryConfiguration()
+        assertThat(otelConfig.clock).isSameAs(Clock.getDefault())
+    }
+
+    @Test
+    fun testOverride() {
+        val fakeClock =
+            object : Clock {
+                override fun now(): Long = 0
+
+                override fun nanoTime(): Long = 0
+            }
+        val otelConfig =
+            OpenTelemetryConfiguration().apply {
+                clock = fakeClock
+            }
+        assertThat(otelConfig.clock).isSameAs(fakeClock)
+    }
+}

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionManagerTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionManagerTest.kt
@@ -16,6 +16,7 @@ import io.mockk.verify
 import io.mockk.verifyOrder
 import io.opentelemetry.android.session.Session
 import io.opentelemetry.android.session.SessionObserver
+import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.time.TestClock
 import org.junit.jupiter.api.BeforeEach
@@ -160,6 +161,7 @@ internal class SessionManagerTest {
             SessionManager(
                 timeoutHandler = timeoutHandler,
                 maxSessionLifetime = MAX_SESSION_LIFETIME.hours,
+                clock = Clock.getDefault(),
             )
 
         // When - access session ID twice, should be same

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -24,6 +24,7 @@ public final class io/opentelemetry/android/OpenTelemetryRumBuilder {
 	public final fun addTracerProviderCustomizer (Ljava/util/function/BiFunction;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public final fun build ()Lio/opentelemetry/android/OpenTelemetryRum;
 	public final fun mergeResource (Lio/opentelemetry/sdk/resources/Resource;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
+	public final fun setClock (Lio/opentelemetry/sdk/common/Clock;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public final fun setExportScheduleHandler (Lio/opentelemetry/android/features/diskbuffering/scheduler/ExportScheduleHandler;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public final fun setResource (Lio/opentelemetry/sdk/resources/Resource;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public final fun setSessionProvider (Lio/opentelemetry/android/session/SessionProvider;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.kt
@@ -47,6 +47,7 @@ import io.opentelemetry.exporter.logging.LoggingMetricExporter
 import io.opentelemetry.exporter.logging.LoggingSpanExporter
 import io.opentelemetry.exporter.logging.SystemOutLogRecordExporter
 import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.logs.LogRecordProcessor
 import io.opentelemetry.sdk.logs.SdkLoggerProvider
 import io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder
@@ -91,6 +92,7 @@ class OpenTelemetryRumBuilder internal constructor(
         ): OpenTelemetryRumBuilder = OpenTelemetryRumBuilder(context, config)
     }
 
+    private var clock: Clock = Clock.getDefault()
     private val tracerProviderCustomizers: MutableList<BiFunction<SdkTracerProviderBuilder, Context, SdkTracerProviderBuilder>> =
         mutableListOf()
     private val meterProviderCustomizers: MutableList<BiFunction<SdkMeterProviderBuilder, Context, SdkMeterProviderBuilder>> =
@@ -282,6 +284,14 @@ class OpenTelemetryRumBuilder internal constructor(
     }
 
     /**
+     * Sets a custom [Clock] implementation.
+     */
+    fun setClock(clock: Clock): OpenTelemetryRumBuilder {
+        this.clock = clock
+        return this
+    }
+
+    /**
      * Creates a new instance of [OpenTelemetryRum] with the settings of this [OpenTelemetryRum].
      *
      * This method will initialize the OpenTelemetry SDK and install built-in system
@@ -306,15 +316,21 @@ class OpenTelemetryRumBuilder internal constructor(
                         sessionProvider,
                         context,
                         bufferDelegatingSpanExporter,
+                        clock,
                     ),
                 ).setLoggerProvider(
                     buildLoggerProvider(
                         sessionProvider,
                         context,
                         bufferDelegatingLogExporter,
+                        clock,
                     ),
                 ).setMeterProvider(
-                    buildMeterProvider(context, bufferDelegatingMetricExporter),
+                    buildMeterProvider(
+                        context,
+                        bufferDelegatingMetricExporter,
+                        clock,
+                    ),
                 ).setPropagators(buildFinalPropagators())
                 .build()
 
@@ -325,7 +341,7 @@ class OpenTelemetryRumBuilder internal constructor(
         )
 
         val delegate =
-            SdkPreconfiguredRumBuilder(context, sdk, sessionProvider, config)
+            SdkPreconfiguredRumBuilder(context, sdk, sessionProvider, config, clock)
                 .setShutdownHook {
                     exportScheduleHandler?.disable()
                     services.close()
@@ -501,11 +517,13 @@ class OpenTelemetryRumBuilder internal constructor(
         sessionProvider: SessionProvider,
         context: Context,
         spanExporter: SpanExporter,
+        clock: Clock,
     ): SdkTracerProvider {
         var tracerProviderBuilder =
             SdkTracerProvider
                 .builder()
                 .setResource(resource)
+                .setClock(clock)
                 .addSpanProcessor(SessionIdSpanAppender(sessionProvider))
 
         val batchSpanProcessor = BatchSpanProcessor.builder(spanExporter).build()
@@ -521,11 +539,13 @@ class OpenTelemetryRumBuilder internal constructor(
         sessionProvider: SessionProvider,
         context: Context,
         logsExporter: LogRecordExporter,
+        clock: Clock,
     ): SdkLoggerProvider {
         var loggerProviderBuilder =
             SdkLoggerProvider
                 .builder()
                 .setResource(resource)
+                .setClock(clock)
                 .addLogRecordProcessor(SessionIdLogRecordAppender(sessionProvider))
                 .addLogRecordProcessor(
                     GlobalAttributesLogRecordAppender(
@@ -559,10 +579,15 @@ class OpenTelemetryRumBuilder internal constructor(
     private fun buildMeterProvider(
         context: Context,
         metricExporter: MetricExporter,
+        clock: Clock,
     ): SdkMeterProvider {
         val reader: MetricReader = PeriodicMetricReader.create(metricExporter)
         var meterProviderBuilder =
-            SdkMeterProvider.builder().registerMetricReader(reader).setResource(resource)
+            SdkMeterProvider
+                .builder()
+                .registerMetricReader(reader)
+                .setResource(resource)
+                .setClock(clock)
         for (customizer in meterProviderCustomizers) {
             meterProviderBuilder = customizer.apply(meterProviderBuilder, context)
         }

--- a/core/src/main/java/io/opentelemetry/android/RumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/RumBuilder.kt
@@ -9,6 +9,7 @@ import android.content.Context
 import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.common.Clock
 
 object RumBuilder {
     /**
@@ -55,6 +56,7 @@ object RumBuilder {
             openTelemetrySdk,
             sessionProvider,
             config,
+            Clock.getDefault(),
         )
 
     /**

--- a/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
@@ -14,12 +14,14 @@ import io.opentelemetry.android.instrumentation.AndroidInstrumentationLoader
 import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.common.Clock
 
 class SdkPreconfiguredRumBuilder internal constructor(
     private val context: Context,
     private val sdk: OpenTelemetrySdk,
     private val sessionProvider: SessionProvider,
     private val config: OtelRumConfig,
+    private val clock: Clock,
 ) {
     private var onShutdown: Runnable = Runnable {} // nop
     private val instrumentations = mutableListOf<AndroidInstrumentation>()
@@ -52,7 +54,7 @@ class SdkPreconfiguredRumBuilder internal constructor(
      * @return A new [io.opentelemetry.android.OpenTelemetryRum] instance.
      */
     fun build(): OpenTelemetryRum {
-        val ctx = InstallationContext(context, sdk, sessionProvider)
+        val ctx = InstallationContext(context, sdk, sessionProvider, clock)
         if (ctx.application == null) {
             Log.w(
                 RumConstants.OTEL_RUM_LOG_TAG,

--- a/instrumentation/activity/api/activity.api
+++ b/instrumentation/activity/api/activity.api
@@ -61,13 +61,10 @@ public final class io/opentelemetry/android/instrumentation/activity/startup/Anc
 
 public class io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimer {
 	public fun <init> ()V
-	public fun clockNow ()J
 	public fun createLifecycleCallback ()Landroid/app/Application$ActivityLifecycleCallbacks;
-	public fun detectBackgroundStart (Landroid/os/Handler;)V
 	public fun end ()V
 	public fun getStartupSpan ()Lio/opentelemetry/api/trace/Span;
 	public fun runCompletionCallback ()V
-	public fun setCompletionCallback (Ljava/lang/Runnable;)V
-	public fun start (Lio/opentelemetry/api/trace/Tracer;)Lio/opentelemetry/api/trace/Span;
+	public fun start (Lio/opentelemetry/api/trace/Tracer;Lio/opentelemetry/sdk/common/Clock;)Lio/opentelemetry/api/trace/Span;
 }
 

--- a/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentation.kt
+++ b/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentation.kt
@@ -37,7 +37,7 @@ class ActivityLifecycleInstrumentation : AndroidInstrumentation {
     }
 
     override fun install(ctx: InstallationContext) {
-        startupTimer.start(ctx.openTelemetry.getTracer(INSTRUMENTATION_SCOPE))
+        startupTimer.start(ctx.openTelemetry.getTracer(INSTRUMENTATION_SCOPE), ctx.clock)
         ctx.application?.let {
             startupLifecycle =
                 startupTimer.createLifecycleCallback().apply {

--- a/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimer.java
+++ b/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimer.java
@@ -8,7 +8,6 @@ package io.opentelemetry.android.instrumentation.activity.startup;
 import android.app.Activity;
 import android.app.Application;
 import android.os.Bundle;
-import android.os.Handler;
 import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -26,8 +25,8 @@ public class AppStartupTimer {
     private static final long MAX_TIME_TO_UI_INIT = TimeUnit.MINUTES.toNanos(1);
 
     // exposed so it can be used for the rest of the startup sequence timing.
-    private final AnchoredClock startupClock = AnchoredClock.create(Clock.getDefault());
-    private final long firstPossibleTimestamp = startupClock.now();
+    @Nullable private AnchoredClock startupClock = null;
+    private long firstPossibleTimestamp;
     @Nullable private volatile Span overallAppStartSpan = null;
     @Nullable private volatile Runnable completionCallback = null;
     // whether activity has been created
@@ -37,13 +36,15 @@ public class AppStartupTimer {
     // accessed only from UI thread
     private boolean uiInitTooLate = false;
     // accessed only from UI thread
-    private boolean isStartedFromBackground = false;
+    private final boolean isStartedFromBackground = false;
 
-    public Span start(Tracer tracer) {
+    public Span start(Tracer tracer, Clock clock) {
         // guard against a double-start and just return what's already in flight.
         if (overallAppStartSpan != null) {
             return overallAppStartSpan;
         }
+        startupClock = AnchoredClock.create(clock);
+        firstPossibleTimestamp = startupClock.now();
         final Span appStart =
                 tracer.spanBuilder("AppStart")
                         .setStartTimestamp(firstPossibleTimestamp, TimeUnit.NANOSECONDS)
@@ -51,11 +52,6 @@ public class AppStartupTimer {
                         .startSpan();
         overallAppStartSpan = appStart;
         return appStart;
-    }
-
-    /** Returns the epoch timestamp in nanos calculated by the startupClock. */
-    public long clockNow() {
-        return startupClock.now();
     }
 
     /**
@@ -79,20 +75,20 @@ public class AppStartupTimer {
             return;
         }
         uiInitStarted = true;
-        if (firstPossibleTimestamp + MAX_TIME_TO_UI_INIT < startupClock.now()) {
+        if (startupClock != null
+                && firstPossibleTimestamp + MAX_TIME_TO_UI_INIT < startupClock.now()) {
             Log.d(RumConstants.OTEL_RUM_LOG_TAG, "Max time to UI init exceeded");
             uiInitTooLate = true;
             clear();
         }
     }
 
-    public void setCompletionCallback(Runnable completionCallback) {
-        this.completionCallback = completionCallback;
-    }
-
     public void end() {
         Span overallAppStartSpan = this.overallAppStartSpan;
-        if (overallAppStartSpan != null && !uiInitTooLate && !isStartedFromBackground) {
+        if (startupClock != null
+                && overallAppStartSpan != null
+                && !uiInitTooLate
+                && !isStartedFromBackground) {
             runCompletionCallback();
             overallAppStartSpan.end(startupClock.now(), TimeUnit.NANOSECONDS);
         }
@@ -115,36 +111,5 @@ public class AppStartupTimer {
     private void clear() {
         overallAppStartSpan = null;
         completionCallback = null;
-    }
-
-    public void detectBackgroundStart(Handler handler) {
-        handler.post(new StartFromBackgroundRunnable(this));
-    }
-
-    /**
-     * See
-     * https://github.com/firebase/firebase-android-sdk/blob/939f90edd74373d42772518d04826657c2ef2e21/firebase-perf/src/main/java/com/google/firebase/perf/metrics/AppStartTrace.java#L283
-     * When a runnable posted to main UI thread is executed before any activity's onCreate() method
-     * then the app is started in background. If app is started from foreground, activity's
-     * onCreate() method is executed before this runnable. Firebase does this check from a
-     * ContentProvider, we do it from whatever used OpenTelemetryRum first. If the first use of
-     * OpenTelemetryRum happens when the app is already started for us it will look the same as a
-     * background start, which is fine as it wouldn't report correct time anyway.
-     */
-    private static class StartFromBackgroundRunnable implements Runnable {
-        private final AppStartupTimer startupTimer;
-
-        private StartFromBackgroundRunnable(AppStartupTimer startupTimer) {
-            this.startupTimer = startupTimer;
-        }
-
-        @Override
-        public void run() {
-            // check whether an activity has been created
-            if (!startupTimer.uiInitStarted) {
-                Log.d(RumConstants.OTEL_RUM_LOG_TAG, "Detected background app start");
-                startupTimer.isStartedFromBackground = true;
-            }
-        }
     }
 }

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentationTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentationTest.kt
@@ -19,6 +19,7 @@ import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanBuilder
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.common.Clock
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -56,7 +57,7 @@ class ActivityLifecycleInstrumentationTest {
         )
         every { startupSpanBuilder.startSpan() }.returns(startupSpan)
 
-        val ctx = InstallationContext(application, openTelemetry, sessionProvider)
+        val ctx = InstallationContext(application, openTelemetry, sessionProvider, Clock.getDefault())
         activityLifecycleInstrumentation.install(ctx)
 
         verify {

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityTracerTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityTracerTest.kt
@@ -15,6 +15,7 @@ import io.opentelemetry.android.instrumentation.activity.startup.AppStartupTimer
 import io.opentelemetry.android.instrumentation.common.ActiveSpan
 import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTracker
 import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
 import io.opentelemetry.sdk.trace.data.SpanData
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -133,7 +134,7 @@ class ActivityTracerTest {
 
     @Test
     fun create_initialActivity_firstTime() {
-        appStartupTimer.start(tracer)
+        appStartupTimer.start(tracer, Clock.getDefault())
         val trackableTracer =
             ActivityTracer
                 .builder(mockk<Activity>())

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimerTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimerTest.kt
@@ -7,6 +7,7 @@ package io.opentelemetry.android.instrumentation.activity.startup
 
 import io.opentelemetry.android.common.RumConstants
 import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -31,7 +32,7 @@ internal class AppStartupTimerTest {
     @Test
     fun start_end() {
         val appStartupTimer = AppStartupTimer()
-        val startSpan = appStartupTimer.start(tracer)
+        val startSpan = appStartupTimer.start(tracer, Clock.getDefault())
         assertNotNull(startSpan)
         appStartupTimer.end()
 
@@ -42,14 +43,14 @@ internal class AppStartupTimerTest {
         assertEquals("AppStart", spanData.name)
         assertEquals(
             "cold",
-            spanData.attributes.get<String>(RumConstants.START_TYPE_KEY),
+            spanData.attributes.get(RumConstants.START_TYPE_KEY),
         )
     }
 
     @Test
     fun multi_end() {
         val appStartupTimer = AppStartupTimer()
-        appStartupTimer.start(tracer)
+        appStartupTimer.start(tracer, Clock.getDefault())
         appStartupTimer.end()
         appStartupTimer.end()
 
@@ -59,8 +60,9 @@ internal class AppStartupTimerTest {
     @Test
     fun multi_start() {
         val appStartupTimer = AppStartupTimer()
-        appStartupTimer.start(tracer)
-        assertSame(appStartupTimer.start(tracer), appStartupTimer.start(tracer))
+        val clock = Clock.getDefault()
+        appStartupTimer.start(tracer, clock)
+        assertSame(appStartupTimer.start(tracer, clock), appStartupTimer.start(tracer, clock))
 
         appStartupTimer.end()
         assertEquals(1, otelTesting.spans.size)

--- a/instrumentation/android-instrumentation/api/android-instrumentation.api
+++ b/instrumentation/android-instrumentation/api/android-instrumentation.api
@@ -20,8 +20,9 @@ public final class io/opentelemetry/android/instrumentation/AndroidInstrumentati
 }
 
 public final class io/opentelemetry/android/instrumentation/InstallationContext {
-	public fun <init> (Landroid/content/Context;Lio/opentelemetry/api/OpenTelemetry;Lio/opentelemetry/android/session/SessionProvider;)V
+	public fun <init> (Landroid/content/Context;Lio/opentelemetry/api/OpenTelemetry;Lio/opentelemetry/android/session/SessionProvider;Lio/opentelemetry/sdk/common/Clock;)V
 	public final fun getApplication ()Landroid/app/Application;
+	public final fun getClock ()Lio/opentelemetry/sdk/common/Clock;
 	public final fun getContext ()Landroid/content/Context;
 	public final fun getOpenTelemetry ()Lio/opentelemetry/api/OpenTelemetry;
 	public final fun getSessionProvider ()Lio/opentelemetry/android/session/SessionProvider;

--- a/instrumentation/android-instrumentation/build.gradle.kts
+++ b/instrumentation/android-instrumentation/build.gradle.kts
@@ -16,6 +16,6 @@ android {
 dependencies {
     implementation(project(":services"))
     implementation(project(":session"))
-
     implementation(project(":agent-api"))
+    implementation(libs.opentelemetry.sdk)
 }

--- a/instrumentation/android-instrumentation/src/main/java/io/opentelemetry/android/instrumentation/InstallationContext.kt
+++ b/instrumentation/android-instrumentation/src/main/java/io/opentelemetry/android/instrumentation/InstallationContext.kt
@@ -9,11 +9,13 @@ import android.app.Application
 import android.content.Context
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.sdk.common.Clock
 
 class InstallationContext(
     val context: Context,
     val openTelemetry: OpenTelemetry,
     val sessionProvider: SessionProvider,
+    val clock: Clock,
 ) {
     val application: Application? = context as? Application
 }

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
@@ -41,6 +41,7 @@ import io.mockk.slot
 import io.mockk.verify
 import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.session.SessionProvider
+import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
@@ -102,6 +103,7 @@ internal class ComposeInstrumentationTest {
                 application,
                 openTelemetryRule.openTelemetry,
                 mockk<SessionProvider>(),
+                Clock.getDefault(),
             )
 
         val callbackCapturingSlot = slot<ComposeClickActivityCallback>()

--- a/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/FakeInstallationContext.kt
+++ b/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/FakeInstallationContext.kt
@@ -10,6 +10,7 @@ import io.mockk.mockk
 import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.sdk.common.Clock
 
 internal fun fakeInstallationContext(openTelemetry: OpenTelemetry): InstallationContext {
     val ctx = mockk<Application>(relaxed = true)
@@ -17,5 +18,6 @@ internal fun fakeInstallationContext(openTelemetry: OpenTelemetry): Installation
         context = ctx,
         openTelemetry = openTelemetry,
         sessionProvider = SessionProvider.getNoop(),
+        clock = Clock.getDefault(),
     )
 }

--- a/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentationTest.kt
+++ b/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentationTest.kt
@@ -25,6 +25,7 @@ import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateL
 import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
 import io.opentelemetry.android.internal.services.network.NetworkChangeListener
 import io.opentelemetry.android.session.SessionProvider
+import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
@@ -179,6 +180,11 @@ class NetworkChangeInstrumentationTest {
         every { services.currentNetworkProvider } returns currentNetworkProvider
         every { services.appLifecycle } returns appLifecycle
         Services.set(services)
-        return InstallationContext(app, otelTesting.openTelemetry, mockk<SessionProvider>())
+        return InstallationContext(
+            app,
+            otelTesting.openTelemetry,
+            mockk<SessionProvider>(),
+            Clock.getDefault(),
+        )
     }
 }

--- a/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentationTest.kt
+++ b/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderingInstrumentationTest.kt
@@ -20,6 +20,7 @@ import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.api.logs.LoggerProvider
 import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.common.Clock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -77,7 +78,7 @@ class SlowRenderingInstrumentationTest {
     @Config(sdk = [23])
     @Test
     fun `Not installing instrumentation on devices with API level lower than 24`() {
-        val ctx = InstallationContext(application, openTelemetry, mockk())
+        val ctx = InstallationContext(application, openTelemetry, mockk(), Clock.getDefault())
         slowRenderingInstrumentation.install(ctx)
 
         verify {
@@ -94,7 +95,7 @@ class SlowRenderingInstrumentationTest {
         val capturedListener = slot<SlowRenderListener>()
         every { openTelemetry.getTracer(any()) }.returns(mockk())
         every { application.registerActivityLifecycleCallbacks(any()) } just Runs
-        val ctx = InstallationContext(application, openTelemetry, mockk())
+        val ctx = InstallationContext(application, openTelemetry, mockk(), Clock.getDefault())
         slowRenderingInstrumentation.install(ctx)
 
         verify { application.registerActivityLifecycleCallbacks(capture(capturedListener)) }
@@ -106,7 +107,7 @@ class SlowRenderingInstrumentationTest {
         val capturedListener = slot<SlowRenderListener>()
         every { openTelemetry.getTracer(any()) }.returns(mockk())
         every { application.registerActivityLifecycleCallbacks(any()) } just Runs
-        val ctx = InstallationContext(application, openTelemetry, mockk())
+        val ctx = InstallationContext(application, openTelemetry, mockk(), Clock.getDefault())
         @Suppress("DEPRECATION")
         slowRenderingInstrumentation.enableDeprecatedZeroDurationSpan().install(ctx)
 

--- a/instrumentation/startup/src/test/java/io/opentelemetry/android/instrumentation/startup/StartupInstrumentationTest.kt
+++ b/instrumentation/startup/src/test/java/io/opentelemetry/android/instrumentation/startup/StartupInstrumentationTest.kt
@@ -14,6 +14,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.internal.initialization.InitializationEvents
+import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -67,5 +68,6 @@ class StartupInstrumentationTest {
             mockk<Application>(),
             otelTesting.openTelemetry,
             mockk(),
+            Clock.getDefault(),
         )
 }

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
@@ -26,6 +26,7 @@ import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_CLICK_EVENT_NAME
 import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_CLICK_EVENT_NAME
 import io.opentelemetry.android.session.SessionProvider
+import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
@@ -68,6 +69,7 @@ class ViewClickInstrumentationTest {
                 application,
                 openTelemetryRule.openTelemetry,
                 mockk<SessionProvider>(),
+                Clock.getDefault(),
             )
 
         val callbackCapturingSlot = slot<ViewClickActivityCallback>()
@@ -130,6 +132,7 @@ class ViewClickInstrumentationTest {
                 application,
                 openTelemetryRule.openTelemetry,
                 mockk<SessionProvider>(),
+                Clock.getDefault(),
             )
 
         val callbackCapturingSlot = slot<ViewClickActivityCallback>()
@@ -197,6 +200,7 @@ class ViewClickInstrumentationTest {
                 application,
                 openTelemetryRule.openTelemetry,
                 mockk<SessionProvider>(),
+                Clock.getDefault(),
             )
 
         val callbackCapturingSlot = slot<ViewClickActivityCallback>()
@@ -254,6 +258,7 @@ class ViewClickInstrumentationTest {
                 application,
                 openTelemetryRule.openTelemetry,
                 mockk<SessionProvider>(),
+                Clock.getDefault(),
             )
 
         val callbackCapturingSlot = slot<ViewClickActivityCallback>()


### PR DESCRIPTION
## Goal

Adds the ability to override the `Clock` used by specifying an instance either on `OpenTelemetryRumInitializer` or `OpenTelemetryRumBuilder`. This partially addresses #1364 as it allows overriding from the default behavior, and will also aid testing since it'll be possible to provide a fake implementation that is locked to a specific time.

Most of the changeset is just wiring through the `Clock` instance to various classes & test code. In a subsequent PR I'll look at implementing a better default clock for Android.

## Testing

Added unit tests for the configuration DSL.