### PR TITLE
Alter default clock implementation

### DIFF
--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
@@ -6,6 +6,7 @@
 package io.opentelemetry.android.agent.dsl
 
 import io.opentelemetry.android.Incubating
+import io.opentelemetry.android.OtelAndroidClock
 import io.opentelemetry.android.agent.dsl.instrumentation.InstrumentationConfiguration
 import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.api.common.Attributes
@@ -20,21 +21,15 @@ import io.opentelemetry.sdk.resources.ResourceBuilder
 class OpenTelemetryConfiguration internal constructor(
     internal val rumConfig: OtelRumConfig = OtelRumConfig(),
     internal val diskBufferingConfig: DiskBufferingConfigurationSpec = DiskBufferingConfigurationSpec(rumConfig),
+    /**
+     * Configures the [Clock] used for capturing telemetry.
+     */
+    var clock: Clock = OtelAndroidClock(),
 ) {
     internal val exportConfig = HttpExportConfiguration()
     internal val sessionConfig = SessionConfiguration()
     internal val instrumentations = InstrumentationConfiguration(rumConfig)
     internal var resourceAction: ResourceBuilder.() -> Unit = {}
-
-    /**
-     * Configures the [Clock] used for capturing telemetry. Defaults to [Clock.getDefault].
-     */
-    var clock: Clock = Clock.getDefault()
-
-    /**
-     * Configures the [Clock] used for capturing telemetry. Defaults to [Clock.getDefault].
-     */
-    var clock: Clock = Clock.getDefault()
 
     /**
      * Configures how OpenTelemetry should export telemetry over HTTP.

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/FakeClock.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/FakeClock.kt
@@ -1,0 +1,14 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent
+
+import io.opentelemetry.sdk.common.Clock
+
+class FakeClock : Clock {
+    override fun now(): Long = 0
+
+    override fun nanoTime(): Long = 0
+}

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/ClockConfigTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/ClockConfigTest.kt
@@ -5,25 +5,24 @@
 
 package io.opentelemetry.android.agent.dsl
 
-import io.opentelemetry.sdk.common.Clock
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.opentelemetry.android.OtelAndroidClock
+import io.opentelemetry.android.agent.FakeClock
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import org.junit.Test
+import org.junit.runner.RunWith
 
+@RunWith(AndroidJUnit4::class)
 class ClockConfigTest {
     @Test
     fun testDefaults() {
         val otelConfig = OpenTelemetryConfiguration()
-        assertThat(otelConfig.clock).isSameAs(Clock.getDefault())
+        assertThat(otelConfig.clock).isInstanceOf(OtelAndroidClock::class.java)
     }
 
     @Test
     fun testOverride() {
-        val fakeClock =
-            object : Clock {
-                override fun now(): Long = 0
-
-                override fun nanoTime(): Long = 0
-            }
+        val fakeClock = FakeClock()
         val otelConfig =
             OpenTelemetryConfiguration().apply {
                 clock = fakeClock

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/DiskBufferingConfigTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/DiskBufferingConfigTest.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.android.agent.dsl
 
+import io.opentelemetry.android.agent.FakeClock
 import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig
 import org.junit.Assert.assertFalse
@@ -14,14 +15,14 @@ import org.junit.Test
 class DiskBufferingConfigTest {
     @Test
     fun testDefaults() {
-        val otelConfig = OpenTelemetryConfiguration()
+        val otelConfig = OpenTelemetryConfiguration(clock = FakeClock())
         assertTrue(otelConfig.diskBufferingConfig.enabled)
         assertTrue(otelConfig.rumConfig.getDiskBufferingConfig().enabled)
     }
 
     @Test
     fun testOverride() {
-        val otelConfig = OpenTelemetryConfiguration()
+        val otelConfig = OpenTelemetryConfiguration(clock = FakeClock())
         otelConfig.diskBuffering {
             enabled(false)
         }
@@ -31,11 +32,15 @@ class DiskBufferingConfigTest {
 
     @Test
     fun testDefaultFromRumConfig() {
+        val diskBufferingConfig = DiskBufferingConfig.create(enabled = true)
+        val rumConfig = OtelRumConfig()
         val otelConfig =
             OpenTelemetryConfiguration(
-                OtelRumConfig().setDiskBufferingConfig(
-                    DiskBufferingConfig.create(enabled = true),
+                rumConfig.setDiskBufferingConfig(
+                    diskBufferingConfig,
                 ),
+                DiskBufferingConfigurationSpec(rumConfig),
+                FakeClock(),
             )
         assertTrue(otelConfig.diskBufferingConfig.enabled)
         assertTrue(otelConfig.rumConfig.getDiskBufferingConfig().enabled)

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/GlobalAttributesConfigTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/GlobalAttributesConfigTest.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.android.agent.dsl
 
+import io.opentelemetry.android.agent.FakeClock
 import io.opentelemetry.api.common.Attributes
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -12,7 +13,7 @@ import org.junit.Test
 class GlobalAttributesConfigTest {
     @Test
     fun testDefaults() {
-        val otelConfig = OpenTelemetryConfiguration()
+        val otelConfig = OpenTelemetryConfiguration(clock = FakeClock())
         val attrs = otelConfig.rumConfig.getGlobalAttributesSupplier().get()
         assertEquals(Attributes.empty(), attrs)
     }
@@ -21,7 +22,7 @@ class GlobalAttributesConfigTest {
     fun testOverride() {
         val expectedAttrs = Attributes.builder().put("key", "value").build()
         val otelConfig =
-            OpenTelemetryConfiguration().apply {
+            OpenTelemetryConfiguration(clock = FakeClock()).apply {
                 globalAttributes {
                     expectedAttrs
                 }

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/HttpExportConfigurationTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/HttpExportConfigurationTest.kt
@@ -5,15 +5,23 @@
 
 package io.opentelemetry.android.agent.dsl
 
+import io.opentelemetry.android.agent.FakeClock
 import io.opentelemetry.android.agent.connectivity.Compression
 import io.opentelemetry.android.agent.connectivity.HttpEndpointConnectivity
+import org.junit.Before
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 
 internal class HttpExportConfigurationTest {
+    private lateinit var otelConfig: OpenTelemetryConfiguration
+
+    @Before
+    fun setUp() {
+        otelConfig = OpenTelemetryConfiguration(clock = FakeClock())
+    }
+
     @Test
     fun testDefaults() {
-        val otelConfig = OpenTelemetryConfiguration()
         val config = otelConfig.exportConfig
         val expectedHeaders = emptyMap<String, String>()
         val expectedCompression = Compression.GZIP
@@ -31,7 +39,6 @@ internal class HttpExportConfigurationTest {
 
     @Test
     fun testBaseValueOverride() {
-        val otelConfig = OpenTelemetryConfiguration()
         val url = "http://localhost:4318/"
         val headers = mapOf("my-header" to "my-value")
         val config =
@@ -49,7 +56,6 @@ internal class HttpExportConfigurationTest {
 
     @Test
     fun testIndividualEndpointOverrides() {
-        val otelConfig = OpenTelemetryConfiguration()
         val baseUrl = "http://localhost:4318/"
         val baseHeaders = mapOf("my-header" to "my-value")
 
@@ -107,7 +113,6 @@ internal class HttpExportConfigurationTest {
 
     @Test
     fun testIndividualEndpointOverrides2() {
-        val otelConfig = OpenTelemetryConfiguration()
         val baseUrl = "http://localhost:4318/"
         val baseHeaders = mapOf("my-header" to "my-value")
 

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/SessionConfigurationTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/SessionConfigurationTest.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.android.agent.dsl
 
+import io.opentelemetry.android.agent.FakeClock
 import org.junit.Test
 import org.junit.jupiter.api.Assertions.assertEquals
 import kotlin.time.Duration.Companion.hours
@@ -13,7 +14,7 @@ import kotlin.time.Duration.Companion.minutes
 internal class SessionConfigurationTest {
     @Test
     fun testDefaults() {
-        val otelConfig = OpenTelemetryConfiguration()
+        val otelConfig = OpenTelemetryConfiguration(clock = FakeClock())
         assertEquals(15.minutes, otelConfig.sessionConfig.backgroundInactivityTimeout)
         assertEquals(4.hours, otelConfig.sessionConfig.maxLifetime)
     }
@@ -23,7 +24,7 @@ internal class SessionConfigurationTest {
         val customTimeout = 30.minutes
         val customLifetime = 2.hours
         val otelConfig =
-            OpenTelemetryConfiguration().apply {
+            OpenTelemetryConfiguration(clock = FakeClock()).apply {
                 session {
                     backgroundInactivityTimeout = customTimeout
                     maxLifetime = customLifetime

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -34,6 +34,12 @@ public final class io/opentelemetry/android/OpenTelemetryRumBuilder$Companion {
 	public final fun create (Landroid/content/Context;Lio/opentelemetry/android/config/OtelRumConfig;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 }
 
+public final class io/opentelemetry/android/OtelAndroidClock : io/opentelemetry/sdk/common/Clock {
+	public fun <init> ()V
+	public fun nanoTime ()J
+	public fun now ()J
+}
+
 public final class io/opentelemetry/android/RumBuilder {
 	public static final field INSTANCE Lio/opentelemetry/android/RumBuilder;
 	public static final fun builder (Landroid/content/Context;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.kt
@@ -92,7 +92,7 @@ class OpenTelemetryRumBuilder internal constructor(
         ): OpenTelemetryRumBuilder = OpenTelemetryRumBuilder(context, config)
     }
 
-    private var clock: Clock = Clock.getDefault()
+    private var clock: Clock = OtelAndroidClock()
     private val tracerProviderCustomizers: MutableList<BiFunction<SdkTracerProviderBuilder, Context, SdkTracerProviderBuilder>> =
         mutableListOf()
     private val meterProviderCustomizers: MutableList<BiFunction<SdkMeterProviderBuilder, Context, SdkMeterProviderBuilder>> =

--- a/core/src/main/java/io/opentelemetry/android/OtelAndroidClock.kt
+++ b/core/src/main/java/io/opentelemetry/android/OtelAndroidClock.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android
+
+import android.os.SystemClock
+import io.opentelemetry.sdk.common.Clock
+
+/**
+ * An implementation of [Clock] that takes a baseline by subtracting
+ * [SystemClock.elapsedRealtimeNanos] from [System.currentTimeMillis] and then
+ * adds that baseline to [SystemClock.elapsedRealtimeNanos] to provide a monotonic wall-clock time.
+ *
+ * This avoids the downside of [System.currentTimeMillis] not being monotonic on Android (i.e.
+ * the clock doesn't consistently tick when the process is in the backround or cached). It also
+ * avoids the problem of [SystemClock.elapsedRealtimeNanos] not providing wall-clock time.
+ */
+class OtelAndroidClock : Clock {
+    private val baseline = System.currentTimeMillis() - nanoTime()
+
+    override fun now(): Long = baseline + nanoTime()
+
+    override fun nanoTime(): Long = SystemClock.elapsedRealtimeNanos()
+}


### PR DESCRIPTION
## Goal

Builds on #1486 by altering the default `Clock` implementation used by `opentelemetry-android`. The approach used is to take a baseline time by subtracting `SystemClock.elapsedRealTimeNanos` from `System.currentTimeMillis`, then return the time by adding `elapsedRealTimeNanos`.

This approach works on all the API levels the SDK supports and provides a monotonic wall-clock time.