### PR TITLE
Add proguard rule to avoid obfuscating fragment names

### DIFF
--- a/instrumentation/fragment/consumer-rules.pro
+++ b/instrumentation/fragment/consumer-rules.pro
@@ -1,0 +1,2 @@
+-keepnames class * extends androidx.fragment.app.Fragment
+-keepnames class * extends android.app.Fragment


### PR DESCRIPTION
## Goal

Adds a keep rule that avoids obfuscating Fragment class names but allows for shrinking of code.

Closes #459