### PR TITLE
Add a one-off release workflow for the v1.0.0 release.

### DIFF
--- a/.github/workflows/release-1.0.0.yml
+++ b/.github/workflows/release-1.0.0.yml
@@ -1,0 +1,56 @@
+---
+name: "Special one-off 1.0.0 release"
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release-1-0-0:
+    permissions:
+      contents: write # for creating the release
+    name: "release v1.0.0"
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if [[ $GITHUB_REF_NAME != release/v1.0.x ]]; then
+            echo This workflow can only be run against release/v1.0.x branch
+            exit 1
+          fi
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+      - name: Set environment variables
+        run: |
+          # otel instrumentation version comes in through alpha bom
+          inst_version=$(./gradlew --console=plain android-agent:dependencies | \
+                        grep 'io.opentelemetry.instrumentation:opentelemetry-instrumentation-api ' | \
+                        sed -e "s/.* -> //" | sed -e "s/ .*//" | grep '^\d' | \
+                        sort | head -1)
+          # otel-java core libs are transient deps thru instrumentation boms
+          sdk_version=$(./gradlew --console=plain android-agent:dependencies | \
+                        grep 'io.opentelemetry:opentelemetry-api ' | \
+                        sed -e "s/.* -> //" | sed -e "s/ .*//" | \
+                        sort | head -1)
+          
+          echo "VERSION=1.0.0" >> $GITHUB_ENV
+          echo "INST_VERSION=$inst_version" >> $GITHUB_ENV
+          echo "OTEL_SDK_VERSION=$sdk_version" >> $GITHUB_ENV
+
+
+      - name: Set up JDK for running Gradle
+        uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e # v5.1.0
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Build and publish artifacts
+        run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -Pfinal=true --no-build-cache --no-configuration-cache --no-parallel
+        env:
+          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+          SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+
+      - name: "Great success!"
+        run: echo "v1.0.0 release complete"


### PR DESCRIPTION
I have concluded that it's better just to do this one-off special release for v1.0.0 rather than attempt to make all of the release pipeline steps support the `-rc.1` suffix. It's too different from the other patch release workflows, and there are definitely too many moving pieces to be confident in getting this correct.

So...

The process will be this:

* merge this PR
* manually create an merge a prepare-release branch PR into `release/v1.0.x` (#1498)
* run this workflow to release v1.0.0
* manually create the GH release
* manually update `main` branch with PR to update changelog and readmes to 1.1.0
* delete this one-off workflow with another PR

after that we can put the `-rc.1` complications behind us....until the next time. 🙈 