### PR TITLE
Prepare 1.0.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # OpenTelemetry Android Changelog
 
+## Version 1.0.1 (2026-01-07)
+
+* Patch release to drop `-alpha` suffix for the agent module. Sorry for any
+  confusion this may have caused. 
+
 ## Version 1.0.0 (2026-01-07)
 
 ⭐ Promote rc.1 to v1.0.0.

--- a/android-agent/gradle.properties
+++ b/android-agent/gradle.properties
@@ -1,1 +1,1 @@
-otel.stable=false
+otel.stable=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,5 +23,5 @@ android.useAndroidX=true
 
 android.minSdk=21
 android.compileSdk=36
-version=1.0.0
+version=1.0.1
 group=io.opentelemetry.android


### PR DESCRIPTION
NOTE: This merges into the `release/v1.0.x` branch.

I forgot to mark the agent module as stable (non-alpha!), so this addresses that.