### PR TITLE
Tighten test assertion for OpenTelemetryRumSmokeTest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: touch local props
         run: touch demo-app/local.properties
       - name: run gradle check
-        run: ./gradlew check -x detekt detektDebug detektDebugUnitTest detektDebugAndroidTest
+        run: ./gradlew check -x detekt detektDebug detektDebugUnitTest detektDebugAndroidTest --stacktrace
       - name: create test coverage report
         run: ./gradlew koverXmlReport
       - name: Upload coverage reports to Codecov
@@ -36,7 +36,7 @@ jobs:
 
       - name: build demo app
         working-directory: ./demo-app
-        run: ./gradlew check assemble
+        run: ./gradlew check assemble --stacktrace
       - name: publish snapshot
         run: ./gradlew publishToSonatype
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -50,7 +50,7 @@ jobs:
         # --no-build-cache is required for codeql to analyze all modules
         # --no-daemon is required for codeql to observe the compilation
         # (see https://docs.github.com/en/code-security/codeql-cli/getting-started-with-the-codeql-cli/preparing-your-code-for-codeql-analysis#specifying-build-commands)
-        run: ./gradlew assemble --no-build-cache --no-daemon
+        run: ./gradlew assemble --no-build-cache --no-daemon --stacktrace
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@cdefb33c0f6224e58673d9004f47f7cb3e328b89 # v4.31.10
@@ -65,4 +65,4 @@ jobs:
         uses: reactivecircus/android-emulator-runner@b530d96654c385303d652368551fb075bc2f0b6b # v2.35.0
         with:
           api-level: 29
-          script: ./gradlew connectedCheck
+          script: ./gradlew connectedCheck --stacktrace

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: touch local props
         run: touch demo-app/local.properties
       - name: run gradle
-        run: ./gradlew check -x detekt detektDebug detektDebugUnitTest detektDebugAndroidTest koverXmlReport
+        run: ./gradlew check -x detekt detektDebug detektDebugUnitTest detektDebugAndroidTest koverXmlReport --stacktrace
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
@@ -30,7 +30,7 @@ jobs:
           slug: open-telemetry/opentelemetry-android
       - name: build demo app
         working-directory: ./demo-app
-        run: ./gradlew assembleRelease
+        run: ./gradlew assembleRelease --stacktrace
 
   required-status-check:
     needs:

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/FakeOpenTelemetryServer.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/FakeOpenTelemetryServer.kt
@@ -47,6 +47,7 @@ internal class FakeOpenTelemetryServer {
                             },
                         )
                     }
+
                     else -> error("Unsupported request path: ${request.target}")
                 }
                 return MockResponse(200)
@@ -64,13 +65,13 @@ internal class FakeOpenTelemetryServer {
     /**
      * Waits for a trace request or throws after a timeout.
      */
-    fun awaitTraceRequest(predicate: (ExportTraceServiceRequest) -> Boolean = { true }): ExportTraceServiceRequest =
+    fun awaitTraceRequest(predicate: (ExportTraceServiceRequest) -> Boolean): ExportTraceServiceRequest =
         awaitRequestMatchingPredicate(traceRequests, predicate)
 
     /**
      * Waits for a log request or throws after a timeout.
      */
-    fun awaitLogRequest(predicate: (ExportLogsServiceRequest) -> Boolean = { true }): ExportLogsServiceRequest =
+    fun awaitLogRequest(predicate: (ExportLogsServiceRequest) -> Boolean): ExportLogsServiceRequest =
         awaitRequestMatchingPredicate(logRequests, predicate)
 
     private fun readRequestBodyAsStream(request: RecordedRequest): InputStream {
@@ -101,6 +102,9 @@ internal class FakeOpenTelemetryServer {
                 countDownLatch.await(checkIntervalMs.toLong(), TimeUnit.MILLISECONDS)
             }
         }
-        throw TimeoutException("Timed out waiting for HTTP request.")
+        throw TimeoutException(
+            "Timed out waiting for HTTP request. " +
+                "Received ${logRequests.size} log requests and ${traceRequests.size} trace requests.",
+        )
     }
 }

--- a/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.android-library-conventions.gradle.kts
@@ -1,4 +1,5 @@
 import io.gitlab.arturbosch.detekt.Detekt
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
@@ -50,6 +51,7 @@ android {
     testOptions {
         unitTests {
             all { test ->
+                test.testLogging.exceptionFormat = TestExceptionFormat.FULL
                 test.maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2) + 1
             }
         }


### PR DESCRIPTION
## Goal

Tightens a test assertion for `OpenTelemetryRumSmokeTest`. I believe this might be the cause of a [flaky test on CI](https://github.com/open-telemetry/opentelemetry-android/actions/runs/21014913071/job/60417939533?pr=1509#step:6:1526) where `testLogExported` fails to find the correct log.

The way the assertion was written before just grabbed the first log, whereas now it specifically waits until a log matching the body is received by the fake server. This should handle the case where the agent emits multiple logs and the test case just grabs whatever is sent first.

I've also tweaked the github workflows so that [`--stacktrace` is passed as an argument ](https://docs.gradle.org/current/userguide/logging.html#stacktraces) and that exceptions during tests have their full stacktrace logged out which should aid debugging . 