### PR TITLE
Fix smoke test log assertion

### DIFF
--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/OpenTelemetryRumSmokeTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/OpenTelemetryRumSmokeTest.kt
@@ -46,20 +46,27 @@ class OpenTelemetryRumSmokeTest {
         )
 
         val logRequest =
-            server.awaitLogRequest {
-                it
-                    .getResourceLogs(0)
-                    .scopeLogsList
-                    .find { scopeLogs ->
-                        scopeLogs.scope.name == logScopeName
-                    }?.logRecordsList
-                    .orEmpty()
-                    .map { logRecord ->
-                        logRecord.body.stringValue
-                    }.contains(logMessage)
-            }
+            server.awaitLogRequest(findLogBodyWithinScope(logScopeName, logMessage))
+
         assertLogRequestReceived(logRequest)
     }
+
+    private fun findLogBodyWithinScope(
+        logScopeName: String,
+        logMessage: String,
+    ): (ExportLogsServiceRequest) -> Boolean =
+        {
+            it
+                .getResourceLogs(0)
+                .scopeLogsList
+                .find { scopeLogs ->
+                    scopeLogs.scope.name == logScopeName
+                }?.logRecordsList
+                .orEmpty()
+                .map { logRecord ->
+                    logRecord.body.stringValue
+                }.contains(logMessage)
+        }
 
     @Test
     fun testTraceExported() {


### PR DESCRIPTION
This follows #1510 which didn't quite fix the build. 

The issue was that the result set of logs contains 3 different scopes! Our custom "logger" scope was the second one (like `scopeLogs[1]` not `[0]`), so the assertion always failed.

This does a bit more by finding the exact scope logs that we expect, and then finding our log body within the list of all log bodies for that scope.