### PR TITLE
Agent is marked stable.

### DIFF
--- a/android-agent/gradle.properties
+++ b/android-agent/gradle.properties
@@ -1,1 +1,1 @@
-otel.stable=false
+otel.stable=true


### PR DESCRIPTION
This was supposed to be cherry picked from the 1.0.x branch, but was forgotten over the holidays. Going forward, the agent should not have an alpha suffix in the 1.x line.