### PR TITLE
Add required platform dep

### DIFF
--- a/instrumentation/android-instrumentation/build.gradle.kts
+++ b/instrumentation/android-instrumentation/build.gradle.kts
@@ -14,6 +14,7 @@ android {
 }
 
 dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
     implementation(project(":services"))
     implementation(project(":session"))
     implementation(project(":agent-api"))


### PR DESCRIPTION
Note: This targets the release branch.

Once again, the build was broken very late in the process by sonatype determining that version information was missing, due to a missing platform dependency: https://github.com/open-telemetry/opentelemetry-android/actions/runs/21292906307/job/61291039899#step:9:1929

Need this to complete the release. Once the release is done, we can cherry pick this back to `main`.