### PR TITLE
Add ability to customize some aspects of the otel sdk creation

### DIFF
--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -39,6 +39,18 @@ public final class io/opentelemetry/android/agent/dsl/HttpExportConfiguration {
 	public final fun spans (Lkotlin/jvm/functions/Function1;)V
 }
 
+public abstract interface class io/opentelemetry/android/agent/dsl/TracerProviderCustomizer {
+	public abstract fun customize (Lio/opentelemetry/sdk/trace/SdkTracerProviderBuilder;)Lio/opentelemetry/sdk/trace/SdkTracerProviderBuilder;
+}
+
+public abstract interface class io/opentelemetry/android/agent/dsl/LoggerProviderCustomizer {
+	public abstract fun customize (Lio/opentelemetry/sdk/logs/SdkLoggerProviderBuilder;)Lio/opentelemetry/sdk/logs/SdkLoggerProviderBuilder;
+}
+
+public abstract interface class io/opentelemetry/android/agent/dsl/MeterProviderCustomizer {
+	public abstract fun customize (Lio/opentelemetry/sdk/metrics/SdkMeterProviderBuilder;)Lio/opentelemetry/sdk/metrics/SdkMeterProviderBuilder;
+}
+
 public final class io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration {
 	public fun <init> ()V
 	public final fun diskBuffering (Lkotlin/jvm/functions/Function1;)V
@@ -46,9 +58,16 @@ public final class io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration
 	public final fun globalAttributes (Lkotlin/jvm/functions/Function0;)V
 	public final fun httpExport (Lkotlin/jvm/functions/Function1;)V
 	public final fun instrumentations (Lkotlin/jvm/functions/Function1;)V
+	public final fun otelSdkCustomizations (Lkotlin/jvm/functions/Function1;)V
 	public final fun resource (Lkotlin/jvm/functions/Function1;)V
 	public final fun session (Lkotlin/jvm/functions/Function1;)V
 	public final fun setClock (Lio/opentelemetry/sdk/common/Clock;)V
+}
+
+public final class io/opentelemetry/android/agent/dsl/OtelSdkCustomizationsSpec {
+	public final fun customizeLoggerProvider (Lio/opentelemetry/android/agent/dsl/LoggerProviderCustomizer;)V
+	public final fun customizeMeterProvider (Lio/opentelemetry/android/agent/dsl/MeterProviderCustomizer;)V
+	public final fun customizeTracerProvider (Lio/opentelemetry/android/agent/dsl/TracerProviderCustomizer;)V
 }
 
 public final class io/opentelemetry/android/agent/dsl/SessionConfiguration {

--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -39,14 +39,6 @@ public final class io/opentelemetry/android/agent/dsl/HttpExportConfiguration {
 	public final fun spans (Lkotlin/jvm/functions/Function1;)V
 }
 
-public abstract interface class io/opentelemetry/android/agent/dsl/LoggerProviderCustomizer {
-	public abstract fun customize (Lio/opentelemetry/sdk/logs/SdkLoggerProviderBuilder;)Lio/opentelemetry/sdk/logs/SdkLoggerProviderBuilder;
-}
-
-public abstract interface class io/opentelemetry/android/agent/dsl/MeterProviderCustomizer {
-	public abstract fun customize (Lio/opentelemetry/sdk/metrics/SdkMeterProviderBuilder;)Lio/opentelemetry/sdk/metrics/SdkMeterProviderBuilder;
-}
-
 public final class io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration {
 	public fun <init> ()V
 	public final fun diskBuffering (Lkotlin/jvm/functions/Function1;)V
@@ -61,9 +53,9 @@ public final class io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration
 }
 
 public final class io/opentelemetry/android/agent/dsl/OtelSdkCustomizationsSpec {
-	public final fun customizeLoggerProvider (Lio/opentelemetry/android/agent/dsl/LoggerProviderCustomizer;)V
-	public final fun customizeMeterProvider (Lio/opentelemetry/android/agent/dsl/MeterProviderCustomizer;)V
-	public final fun customizeTracerProvider (Lio/opentelemetry/android/agent/dsl/TracerProviderCustomizer;)V
+	public final fun customizeLoggerProvider (Lkotlin/jvm/functions/Function1;)V
+	public final fun customizeMeterProvider (Lkotlin/jvm/functions/Function1;)V
+	public final fun customizeTracerProvider (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/opentelemetry/android/agent/dsl/SessionConfiguration {
@@ -71,10 +63,6 @@ public final class io/opentelemetry/android/agent/dsl/SessionConfiguration {
 	public final fun getMaxLifetime-UwyO8pc ()J
 	public final fun setBackgroundInactivityTimeout-LRDsOJo (J)V
 	public final fun setMaxLifetime-LRDsOJo (J)V
-}
-
-public abstract interface class io/opentelemetry/android/agent/dsl/TracerProviderCustomizer {
-	public abstract fun customize (Lio/opentelemetry/sdk/trace/SdkTracerProviderBuilder;)Lio/opentelemetry/sdk/trace/SdkTracerProviderBuilder;
 }
 
 public final class io/opentelemetry/android/agent/dsl/instrumentation/ActivityLifecycleConfiguration : io/opentelemetry/android/agent/dsl/instrumentation/CanBeEnabledAndDisabled, io/opentelemetry/android/agent/dsl/instrumentation/ScreenLifecycleConfigurable {

--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -39,10 +39,6 @@ public final class io/opentelemetry/android/agent/dsl/HttpExportConfiguration {
 	public final fun spans (Lkotlin/jvm/functions/Function1;)V
 }
 
-public abstract interface class io/opentelemetry/android/agent/dsl/TracerProviderCustomizer {
-	public abstract fun customize (Lio/opentelemetry/sdk/trace/SdkTracerProviderBuilder;)Lio/opentelemetry/sdk/trace/SdkTracerProviderBuilder;
-}
-
 public abstract interface class io/opentelemetry/android/agent/dsl/LoggerProviderCustomizer {
 	public abstract fun customize (Lio/opentelemetry/sdk/logs/SdkLoggerProviderBuilder;)Lio/opentelemetry/sdk/logs/SdkLoggerProviderBuilder;
 }
@@ -75,6 +71,10 @@ public final class io/opentelemetry/android/agent/dsl/SessionConfiguration {
 	public final fun getMaxLifetime-UwyO8pc ()J
 	public final fun setBackgroundInactivityTimeout-LRDsOJo (J)V
 	public final fun setMaxLifetime-LRDsOJo (J)V
+}
+
+public abstract interface class io/opentelemetry/android/agent/dsl/TracerProviderCustomizer {
+	public abstract fun customize (Lio/opentelemetry/sdk/trace/SdkTracerProviderBuilder;)Lio/opentelemetry/sdk/trace/SdkTracerProviderBuilder;
 }
 
 public final class io/opentelemetry/android/agent/dsl/instrumentation/ActivityLifecycleConfiguration : io/opentelemetry/android/agent/dsl/instrumentation/CanBeEnabledAndDisabled, io/opentelemetry/android/agent/dsl/instrumentation/ScreenLifecycleConfigurable {

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
@@ -59,7 +59,7 @@ object OpenTelemetryRumInitializer {
         cfg.resourceAction(resourceBuilder)
         val resource = resourceBuilder.build()
 
-        var builder =
+        val builder =
             RumBuilder
                 .builder(ctx, cfg.rumConfig)
                 .setSessionProvider(createSessionProvider(ctx, cfg))
@@ -88,13 +88,13 @@ object OpenTelemetryRumInitializer {
                         .build()
                 }
         cfg.sdkCustomizations.tracerProviderCustomizers.forEach {
-            builder.addTracerProviderCustomizer { builder, _ -> it.customize(builder) }
+            builder.addTracerProviderCustomizer { builder, _ -> it.invoke(builder) }
         }
         cfg.sdkCustomizations.loggerProviderCustomizers.forEach {
-            builder.addLoggerProviderCustomizer { builder, _ -> it.customize(builder) }
+            builder.addLoggerProviderCustomizer { builder, _ -> it.invoke(builder) }
         }
         cfg.sdkCustomizations.meterProviderCustomizers.forEach {
-            builder.addMeterProviderCustomizer { builder, _ -> it.customize(builder) }
+            builder.addMeterProviderCustomizer { builder, _ -> it.invoke(builder) }
         }
         return builder.build()
     }

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
@@ -25,6 +25,7 @@ class OpenTelemetryConfiguration internal constructor(
      * Configures the [Clock] used for capturing telemetry.
      */
     var clock: Clock = OtelAndroidClock(),
+    internal val sdkCustomizations: OtelSdkCustomizationsSpec = OtelSdkCustomizationsSpec(),
 ) {
     internal val exportConfig = HttpExportConfiguration()
     internal val sessionConfig = SessionConfiguration()
@@ -57,6 +58,14 @@ class OpenTelemetryConfiguration internal constructor(
      */
     fun globalAttributes(action: () -> Attributes) {
         rumConfig.setGlobalAttributes(action())
+    }
+
+    /**
+     * You can use this to customize additional nonstandard aspects of the OpenTelemetry SDK.
+     * Most users should not need to provide any customizations here.
+     */
+    fun otelSdkCustomizations(action: OtelSdkCustomizationsSpec.() -> Unit) {
+        sdkCustomizations.action()
     }
 
     /**

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OtelSdkCustomizationsSpec.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OtelSdkCustomizationsSpec.kt
@@ -9,6 +9,10 @@ import io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder
 
+typealias TracerProviderCustomizer = Function1<SdkTracerProviderBuilder, SdkTracerProviderBuilder>
+typealias LoggerProviderCustomizer = Function1<SdkLoggerProviderBuilder, SdkLoggerProviderBuilder>
+typealias MeterProviderCustomizer = Function1<SdkMeterProviderBuilder, SdkMeterProviderBuilder>
+
 @OpenTelemetryDslMarker
 class OtelSdkCustomizationsSpec internal constructor() {
     internal val tracerProviderCustomizers: MutableList<TracerProviderCustomizer> = mutableListOf()
@@ -50,16 +54,4 @@ class OtelSdkCustomizationsSpec internal constructor() {
     fun customizeMeterProvider(customizer: MeterProviderCustomizer) {
         meterProviderCustomizers.add(customizer)
     }
-}
-
-fun interface TracerProviderCustomizer {
-    fun customize(builder: SdkTracerProviderBuilder): SdkTracerProviderBuilder
-}
-
-fun interface LoggerProviderCustomizer {
-    fun customize(builder: SdkLoggerProviderBuilder): SdkLoggerProviderBuilder
-}
-
-fun interface MeterProviderCustomizer {
-    fun customize(builder: SdkMeterProviderBuilder): SdkMeterProviderBuilder
 }

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OtelSdkCustomizationsSpec.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OtelSdkCustomizationsSpec.kt
@@ -40,7 +40,7 @@ class OtelSdkCustomizationsSpec internal constructor() {
     }
 
     /**
-     * Modify the creation of the OpenTelemetry LoggerProvider by providing
+     * Modify the creation of the OpenTelemetry MeterProvider by providing
      * your own customizer here. The customizer is a function
      * that receives an instance of [SdkMeterProviderBuilder] and returns an
      * instance of [SdkMeterProviderBuilder], which should almost always be

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OtelSdkCustomizationsSpec.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OtelSdkCustomizationsSpec.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl
+
+import io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder
+import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder
+import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder
+
+@OpenTelemetryDslMarker
+class OtelSdkCustomizationsSpec internal constructor() {
+    internal val tracerProviderCustomizers: MutableList<TracerProviderCustomizer> = mutableListOf()
+    internal val loggerProviderCustomizers: MutableList<LoggerProviderCustomizer> = mutableListOf()
+    internal val meterProviderCustomizers: MutableList<MeterProviderCustomizer> = mutableListOf()
+
+    /**
+     * Modify the creation of the OpenTelemetry TracerProvider by providing
+     * your own customizer here. The customizer is a function
+     * that receives an instance of [SdkTracerProviderBuilder] and returns an
+     * instance of [SdkTracerProviderBuilder], which should almost always be
+     * the same instance. If a new instance is returned, the operation can be
+     * destructive.
+     */
+    fun customizeTracerProvider(customizer: TracerProviderCustomizer) {
+        tracerProviderCustomizers.add(customizer)
+    }
+
+    /**
+     * Modify the creation of the OpenTelemetry LoggerProvider by providing
+     * your own customizer here. The customizer is a function
+     * that receives an instance of [SdkLoggerProviderBuilder] and returns an
+     * instance of [SdkLoggerProviderBuilder], which should almost always be
+     * the same instance. If a new instance is returned, the operation can be
+     * destructive.
+     */
+    fun customizeLoggerProvider(customizer: LoggerProviderCustomizer) {
+        loggerProviderCustomizers.add(customizer)
+    }
+
+    /**
+     * Modify the creation of the OpenTelemetry LoggerProvider by providing
+     * your own customizer here. The customizer is a function
+     * that receives an instance of [SdkMeterProviderBuilder] and returns an
+     * instance of [SdkMeterProviderBuilder], which should almost always be
+     * the same instance. If a new instance is returned, the operation can be
+     * destructive.
+     */
+    fun customizeMeterProvider(customizer: MeterProviderCustomizer) {
+        meterProviderCustomizers.add(customizer)
+    }
+}
+
+fun interface TracerProviderCustomizer {
+    fun customize(builder: SdkTracerProviderBuilder): SdkTracerProviderBuilder
+}
+
+fun interface LoggerProviderCustomizer {
+    fun customize(builder: SdkLoggerProviderBuilder): SdkLoggerProviderBuilder
+}
+
+fun interface MeterProviderCustomizer {
+    fun customize(builder: SdkMeterProviderBuilder): SdkMeterProviderBuilder
+}

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/OtelSdkCustomizationsSpecTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/OtelSdkCustomizationsSpecTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.opentelemetry.android.agent.OpenTelemetryRumInitializer
+import io.opentelemetry.sdk.trace.IdGenerator
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RuntimeEnvironment
+import java.util.concurrent.atomic.AtomicBoolean
+
+@RunWith(AndroidJUnit4::class)
+class OtelSdkCustomizationsSpecTest {
+    @Test
+    fun `can configure tracer provider`() {
+        val traceId = "b9a654847cb3514b6e5bd80cb168ed1c"
+        val spanId = "0666666666666666"
+        val idGen =
+            object : IdGenerator {
+                override fun generateSpanId(): String? = spanId
+
+                override fun generateTraceId(): String? = traceId
+            }
+        val agent =
+            OpenTelemetryRumInitializer.initialize(
+                context = RuntimeEnvironment.getApplication(),
+                configuration = {
+                    otelSdkCustomizations {
+                        customizeTracerProvider { _ ->
+                            SdkTracerProvider.builder().setIdGenerator(idGen)
+                        }
+                    }
+                },
+            )
+        val tracer =
+            agent.openTelemetry.tracerProvider
+                .tracerBuilder("test")
+                .build()
+        val span = tracer.spanBuilder("test").startSpan()
+        assertThat(span.spanContext.spanId).isEqualTo(spanId)
+    }
+
+    @Test
+    fun `can configure logger provider`() {
+        val seen = AtomicBoolean(false)
+        val agent =
+            OpenTelemetryRumInitializer.initialize(
+                context = RuntimeEnvironment.getApplication(),
+                configuration = {
+                    otelSdkCustomizations {
+                        customizeLoggerProvider { builder ->
+                            builder.addLogRecordProcessor { _, _ ->
+                                run {
+                                    seen.set(true)
+                                }
+                            }
+                        }
+                    }
+                },
+            )
+        val logger =
+            agent.openTelemetry.logsBridge
+                .loggerBuilder("test")
+                .build()
+        logger.logRecordBuilder().setBody("howdy").emit()
+        assertThat(seen.get()).isTrue
+    }
+
+    @Test
+    fun `can configure meter provider`() {
+        val seen = AtomicBoolean(false)
+        val agent =
+            OpenTelemetryRumInitializer.initialize(
+                context = RuntimeEnvironment.getApplication(),
+                configuration = {
+                    otelSdkCustomizations {
+                        customizeMeterProvider { builder ->
+                            run {
+                                seen.set(true)
+                                builder
+                            }
+                        }
+                    }
+                },
+            )
+        val counter =
+            agent.openTelemetry.meterProvider
+                .get("test")
+                .counterBuilder("test")
+                .build()
+        counter.add(1)
+        assertThat(seen.get()).isTrue
+    }
+}

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/OtelDemoApplication.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/OtelDemoApplication.kt
@@ -17,6 +17,11 @@ import io.opentelemetry.api.logs.LogRecordBuilder
 import io.opentelemetry.api.logs.LoggerProvider
 import io.opentelemetry.api.metrics.LongCounter
 import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.context.Context
+import io.opentelemetry.sdk.trace.ReadWriteSpan
+import io.opentelemetry.sdk.trace.ReadableSpan
+import io.opentelemetry.sdk.trace.SpanProcessor
+import kotlin.random.Random
 
 const val TAG = "otel.demo"
 
@@ -39,6 +44,18 @@ class OtelDemoApplication : Application() {
                     }
                     globalAttributes {
                         Attributes.of(stringKey("toolkit"), "jetpack compose")
+                    }
+                    otelSdkCustomizations {
+                        customizeTracerProvider { builder ->
+                            builder.addSpanProcessor(OtelDemoCustomSpanProcessor())
+                        }
+                        customizeLoggerProvider { builder ->
+                            builder.addLogRecordProcessor { _, logRecord ->
+                                // onEmit()
+                                logRecord.setAttribute(stringKey("awesome"), "sauce-" + Random.nextInt())
+                            }
+                        }
+                        customizeMeterProvider { builder -> builder /* customize as you like! */ }
                     }
                 }
             )
@@ -67,5 +84,22 @@ class OtelDemoApplication : Application() {
             val logger = rum!!.openTelemetry.logsBridge.loggerBuilder(scopeName).build()
             return logger.logRecordBuilder().setEventName(eventName)
         }
+    }
+}
+
+class OtelDemoCustomSpanProcessor: SpanProcessor {
+    override fun onStart(
+        parentContext: Context,
+        span: ReadWriteSpan
+    ) {
+        span.setAttribute("my.custom.attribute", Random.nextLong())
+    }
+
+    override fun isStartRequired(): Boolean = true
+
+    override fun isEndRequired(): Boolean = false
+
+    override fun onEnd(span: ReadableSpan) {
+        //no-op
     }
 }


### PR DESCRIPTION
Related to #1577

This adds some additional customization capabilities to the initialization DSL. We've had users ask for similar things quite a few times now...and rather than always having to resort to using the `OpenTelemetryRumBuilder` I figured we could try and find some middle ground -- something that allows users to get the benefits of the initializer while still being able to do niche/bespoke customizations when needed.

This does change the api by adding functionality, but is backwards compatible and thus non-breaking.