### PR TITLE
Enhancing instrumentation manual install

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,12 @@ There are also other
 [additional instrumentation modules](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation)
 that application developers can include through a gradle dependency. 
 Instrumentations are detected at runtime via the classpath, and
-are installed automatically.
+are installed automatically. Instrumentations can also be installed manually
+after initialization using the `OpenTelemetryRum.install()` method:
+
+```kotlin
+openTelemetryRum.install(MyInstrumentation())
+```
 
 ## Additional Documentation
 

--- a/agent-api/api/agent-api.api
+++ b/agent-api/api/agent-api.api
@@ -3,6 +3,7 @@ public abstract interface class io/opentelemetry/android/OpenTelemetryRum {
 	public static synthetic fun emitEvent$default (Lio/opentelemetry/android/OpenTelemetryRum;Ljava/lang/String;Ljava/lang/String;Lio/opentelemetry/api/common/Attributes;ILjava/lang/Object;)V
 	public abstract fun getOpenTelemetry ()Lio/opentelemetry/api/OpenTelemetry;
 	public abstract fun getRumSessionId ()Ljava/lang/String;
+	public abstract fun install (Lio/opentelemetry/android/instrumentation/AndroidInstrumentation;)V
 	public abstract fun shutdown ()V
 }
 

--- a/agent-api/build.gradle.kts
+++ b/agent-api/build.gradle.kts
@@ -16,4 +16,5 @@ android {
 dependencies {
     api(platform(libs.opentelemetry.platform.alpha))
     api(libs.opentelemetry.api)
+    api(project(":instrumentation:android-instrumentation"))
 }

--- a/agent-api/src/main/java/io/opentelemetry/android/OpenTelemetryRum.kt
+++ b/agent-api/src/main/java/io/opentelemetry/android/OpenTelemetryRum.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.android
 
+import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
 
@@ -39,6 +40,15 @@ interface OpenTelemetryRum {
         body: String = "",
         attributes: Attributes = Attributes.empty(),
     )
+
+    /**
+     * Installs an [AndroidInstrumentation] using the internal context of this [OpenTelemetryRum]
+     * instance. This creates the appropriate [io.opentelemetry.android.instrumentation.InstallationContext]
+     * with the correct context objects that were used to build this instance.
+     *
+     * @param instrumentation The instrumentation to install.
+     */
+    fun installInstrumentation(instrumentation: AndroidInstrumentation)
 
     /**
      * Initiates orderly shutdown of this OpenTelemetryRum instance. After this method completes,

--- a/agent-api/src/main/java/io/opentelemetry/android/OpenTelemetryRum.kt
+++ b/agent-api/src/main/java/io/opentelemetry/android/OpenTelemetryRum.kt
@@ -48,7 +48,7 @@ interface OpenTelemetryRum {
      *
      * @param instrumentation The instrumentation to install.
      */
-    fun installInstrumentation(instrumentation: AndroidInstrumentation)
+    fun install(instrumentation: AndroidInstrumentation)
 
     /**
      * Initiates orderly shutdown of this OpenTelemetryRum instance. After this method completes,

--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -48,7 +48,6 @@ public final class io/opentelemetry/android/agent/dsl/HttpExportConfiguration {
 }
 
 public final class io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration {
-	public fun <init> ()V
 	public final fun diskBuffering (Lkotlin/jvm/functions/Function1;)V
 	public final fun getClock ()Lio/opentelemetry/sdk/common/Clock;
 	public final fun globalAttributes (Lkotlin/jvm/functions/Function0;)V

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -16,6 +16,7 @@ public final class io/opentelemetry/android/OpenTelemetryRumBuilder {
 	public final fun addSpanExporterCustomizer (Ljava/util/function/Function;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public final fun addTracerProviderCustomizer (Ljava/util/function/BiFunction;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public final fun build ()Lio/opentelemetry/android/OpenTelemetryRum;
+	public final fun getInstrumentationLoader ()Lio/opentelemetry/android/instrumentation/AndroidInstrumentationLoader;
 	public final fun mergeResource (Lio/opentelemetry/sdk/resources/Resource;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public final fun setClock (Lio/opentelemetry/sdk/common/Clock;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public final fun setExportScheduleHandler (Lio/opentelemetry/android/features/diskbuffering/scheduler/ExportScheduleHandler;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
@@ -37,7 +38,6 @@ public final class io/opentelemetry/android/RumBuilder {
 	public static final field INSTANCE Lio/opentelemetry/android/RumBuilder;
 	public static final fun builder (Landroid/content/Context;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public static final fun builder (Landroid/content/Context;Lio/opentelemetry/android/config/OtelRumConfig;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
-	public static final fun builder (Landroid/content/Context;Lio/opentelemetry/sdk/OpenTelemetrySdk;Lio/opentelemetry/android/config/OtelRumConfig;Lio/opentelemetry/android/session/SessionProvider;)Lio/opentelemetry/android/SdkPreconfiguredRumBuilder;
 	public static synthetic fun builder$default (Landroid/content/Context;Lio/opentelemetry/android/config/OtelRumConfig;ILjava/lang/Object;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public static final fun noop ()Lio/opentelemetry/android/OpenTelemetryRum;
 }
@@ -203,16 +203,8 @@ public abstract interface class io/opentelemetry/android/features/diskbuffering/
 }
 
 public abstract interface class io/opentelemetry/android/instrumentation/AndroidInstrumentationLoader {
-	public static final field Companion Lio/opentelemetry/android/instrumentation/AndroidInstrumentationLoader$Companion;
-	public static fun get ()Lio/opentelemetry/android/instrumentation/AndroidInstrumentationLoader;
 	public abstract fun getAll ()Ljava/util/Collection;
 	public abstract fun getByType (Ljava/lang/Class;)Lio/opentelemetry/android/instrumentation/AndroidInstrumentation;
-	public static fun resetForTest ()V
-}
-
-public final class io/opentelemetry/android/instrumentation/AndroidInstrumentationLoader$Companion {
-	public final fun get ()Lio/opentelemetry/android/instrumentation/AndroidInstrumentationLoader;
-	public final fun resetForTest ()V
 }
 
 public final class io/opentelemetry/android/internal/features/networkattrs/NetworkAttributesLogRecordAppender : io/opentelemetry/sdk/logs/LogRecordProcessor {

--- a/core/src/main/java/io/opentelemetry/android/NoopOpenTelemetryRum.kt
+++ b/core/src/main/java/io/opentelemetry/android/NoopOpenTelemetryRum.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.android
 
+import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.TraceId
@@ -22,6 +23,9 @@ internal object NoopOpenTelemetryRum : OpenTelemetryRum {
         body: String,
         attributes: Attributes,
     ) {
+    }
+
+    override fun installInstrumentation(instrumentation: AndroidInstrumentation) {
     }
 
     override fun shutdown() {

--- a/core/src/main/java/io/opentelemetry/android/NoopOpenTelemetryRum.kt
+++ b/core/src/main/java/io/opentelemetry/android/NoopOpenTelemetryRum.kt
@@ -25,7 +25,7 @@ internal object NoopOpenTelemetryRum : OpenTelemetryRum {
     ) {
     }
 
-    override fun installInstrumentation(instrumentation: AndroidInstrumentation) {
+    override fun install(instrumentation: AndroidInstrumentation) {
     }
 
     override fun shutdown() {

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumImpl.kt
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumImpl.kt
@@ -5,21 +5,29 @@
 
 package io.opentelemetry.android
 
+import android.content.Context
+import io.opentelemetry.android.instrumentation.AndroidInstrumentation
+import io.opentelemetry.android.instrumentation.InstallationContext
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.common.Clock
 
 internal class OpenTelemetryRumImpl(
     private val openTelemetrySdk: OpenTelemetrySdk,
     private val sessionProvider: SessionProvider,
+    private val context: Context,
+    private val clock: Clock,
     private val onShutdown: Runnable,
 ) : OpenTelemetryRum {
     private val logger: Logger =
         openTelemetrySdk.logsBridge
             .loggerBuilder("io.opentelemetry.rum.events")
             .build()
+
+    private val manuallyInstalledInstrumentations = mutableListOf<AndroidInstrumentation>()
 
     override val openTelemetry: OpenTelemetry = openTelemetrySdk
 
@@ -38,7 +46,17 @@ internal class OpenTelemetryRumImpl(
             .emit()
     }
 
+    override fun installInstrumentation(instrumentation: AndroidInstrumentation) {
+        val ctx = InstallationContext(context, openTelemetrySdk, sessionProvider, clock)
+        instrumentation.install(ctx)
+        manuallyInstalledInstrumentations.add(instrumentation)
+    }
+
     override fun shutdown() {
+        val ctx = InstallationContext(context, openTelemetrySdk, sessionProvider, clock)
+        for (instrumentation in manuallyInstalledInstrumentations) {
+            instrumentation.uninstall(ctx)
+        }
         onShutdown.run()
     }
 }

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumImpl.kt
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumImpl.kt
@@ -46,7 +46,7 @@ internal class OpenTelemetryRumImpl(
             .emit()
     }
 
-    override fun installInstrumentation(instrumentation: AndroidInstrumentation) {
+    override fun install(instrumentation: AndroidInstrumentation) {
         val ctx = InstallationContext(context, openTelemetrySdk, sessionProvider, clock)
         instrumentation.install(ctx)
         manuallyInstalledInstrumentations.add(instrumentation)

--- a/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
@@ -74,7 +74,7 @@ class SdkPreconfiguredRumBuilder internal constructor(
             sdk.shutdown()
             onShutdown.run()
         }
-        val openTelemetryRum = OpenTelemetryRumImpl(sdk, sessionProvider, onShutdown)
+        val openTelemetryRum = OpenTelemetryRumImpl(sdk, sessionProvider, context, clock, onShutdown)
 
         // Install instrumentations
         for (instrumentation in enabledInstrumentations) {

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumImplTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumImplTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android
+
+import android.content.Context
+import io.mockk.Called
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import io.opentelemetry.android.instrumentation.AndroidInstrumentation
+import io.opentelemetry.android.instrumentation.InstallationContext
+import io.opentelemetry.android.session.SessionProvider
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.common.Clock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class OpenTelemetryRumImplTest {
+    private val sdk: OpenTelemetrySdk = OpenTelemetrySdk.builder().build()
+    private val sessionProvider: SessionProvider = mockk()
+    private val context: Context = mockk()
+    private val clock: Clock = mockk()
+    private val onShutdown: Runnable = mockk(relaxed = true)
+
+    private lateinit var rum: OpenTelemetryRumImpl
+
+    @BeforeEach
+    fun setUp() {
+        every { sessionProvider.getSessionId() } returns "test-session-id"
+        rum = OpenTelemetryRumImpl(sdk, sessionProvider, context, clock, onShutdown)
+    }
+
+    @Test
+    fun `install delegates to instrumentation with correct context`() {
+        val instrumentation = mockk<AndroidInstrumentation>(relaxed = true)
+
+        rum.install(instrumentation)
+
+        verify {
+            instrumentation.install(
+                match<InstallationContext> {
+                    it.openTelemetry === sdk && it.sessionProvider === sessionProvider
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `shutdown uninstalls manually installed instrumentations`() {
+        val instrumentation1 = mockk<AndroidInstrumentation>(relaxed = true)
+        val instrumentation2 = mockk<AndroidInstrumentation>(relaxed = true)
+
+        rum.install(instrumentation1)
+        rum.install(instrumentation2)
+        rum.shutdown()
+
+        verifyOrder {
+            instrumentation1.uninstall(any())
+            instrumentation2.uninstall(any())
+            onShutdown.run()
+        }
+    }
+
+    @Test
+    fun `shutdown without manually installed instrumentations only runs onShutdown`() {
+        val instrumentation = mockk<AndroidInstrumentation>(relaxed = true)
+
+        rum.shutdown()
+
+        verify { instrumentation wasNot Called }
+        verify { onShutdown.run() }
+    }
+
+    @Test
+    fun `getRumSessionId returns session id from provider`() {
+        assertThat(rum.getRumSessionId()).isEqualTo("test-session-id")
+    }
+
+    @Test
+    fun `openTelemetry returns the sdk`() {
+        assertThat(rum.openTelemetry).isSameAs(sdk)
+    }
+}

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumNoopTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumNoopTest.kt
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.android
 
+import io.mockk.mockk
+import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.api.OpenTelemetry
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -18,6 +20,7 @@ internal class OpenTelemetryRumNoopTest {
 
         // assert no exceptions thrown
         noop.emitEvent("event")
+        noop.install(mockk<AndroidInstrumentation>())
         noop.shutdown()
     }
 }

--- a/instrumentation/android-instrumentation/build.gradle.kts
+++ b/instrumentation/android-instrumentation/build.gradle.kts
@@ -15,8 +15,6 @@ android {
 
 dependencies {
     api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
-    implementation(project(":services"))
-    implementation(project(":session"))
-    implementation(project(":agent-api"))
-    implementation(libs.opentelemetry.sdk)
+    api(project(":session"))
+    api(libs.opentelemetry.sdk)
 }

--- a/instrumentation/compose/click/api/click.api
+++ b/instrumentation/compose/click/api/click.api
@@ -3,3 +3,4 @@ public final class io/opentelemetry/instrumentation/compose/click/ComposeClickIn
 	public fun getName ()Ljava/lang/String;
 	public fun install (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
 }
+

--- a/instrumentation/view-click/api/view-click.api
+++ b/instrumentation/view-click/api/view-click.api
@@ -3,3 +3,4 @@ public final class io/opentelemetry/android/instrumentation/view/click/ViewClick
 	public fun getName ()Ljava/lang/String;
 	public fun install (Lio/opentelemetry/android/instrumentation/InstallationContext;)V
 }
+

--- a/session/build.gradle.kts
+++ b/session/build.gradle.kts
@@ -15,6 +15,5 @@ android {
 
 dependencies {
     api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
-    implementation(project(":agent-api"))
     implementation(libs.opentelemetry.sdk)
 }


### PR DESCRIPTION
Related to: https://github.com/open-telemetry/opentelemetry-android/issues/1541

These changes are intended to address "_challenge 1_", as explained in [this comment](https://github.com/open-telemetry/opentelemetry-android/issues/1541#issuecomment-3812235676). By making the `OpenTelemetryRum` implementation take care of the creation of an `InstallationContext` object, which contains the proper contextual dependencies that were used to create the `OpenTelemetry` instance.