### PR TITLE
docs: align HTTP client READMEs with stable semantic conventions

### DIFF
--- a/instrumentation/httpurlconnection/README.md
+++ b/instrumentation/httpurlconnection/README.md
@@ -34,14 +34,15 @@ the following occurs: the response stream is fully read, the stream is closed,
 - Name: Determined by the HTTP span name extractor (typically `HTTP {method}` or derived from the URL)
 - Description: Client-side HTTP request
 - Attributes (following OpenTelemetry [HTTP semantic conventions](https://opentelemetry.io/docs/specs/semconv/http/http-spans/)):
-  - `http.method` — request method (GET, POST, etc.)
-  - `http.url` — full URL
-  - `http.target`, `http.host`, `http.scheme` — parts of the request URL when available
-  - `http.status_code` — response status code
-  - `http.flavor` — protocol (e.g. `1.1`)
-  - `net.peer.name` — server host
-  - `net.peer.port` — server port
-  - Request and response headers captured according to configuration: `http.request.header.*` / `http.response.header.*`
+  - `http.request.method` — request method (GET, POST, etc.)
+  - `url.full` — full request URL
+  - `url.scheme`, `url.path`, `url.query` — parts of the request URL when available
+  - `http.response.status_code` — response status code
+  - `network.protocol.version` — protocol version (e.g. `1.1`, `2` for HTTP/2)
+  - `server.address` — logical server host
+  - `server.port` — logical server port
+  - `network.peer.address` / `network.peer.port` — connection endpoint, when available
+  - Request and response headers captured according to configuration: `http.request.header.<name>` / `http.response.header.<name>`
 
 If the request throws an IOException, the span is ended and the exception is recorded.
 

--- a/instrumentation/okhttp3/README.md
+++ b/instrumentation/okhttp3/README.md
@@ -18,13 +18,14 @@ are provided by the OkHttp attributes getter.
 * Name: Determined by the HTTP span name extractor (typically `HTTP {method}` or derived from the URL)
 * Description: Client-side HTTP request
 * Common attributes (following OpenTelemetry HTTP semantic conventions):
-  * `http.method` — request method (GET, POST, etc.)
-  * `http.url` — full URL
-  * `http.status_code` — response status code
-  * `http.flavor` — protocol (e.g. `1.1`)
-  * `net.peer.name` — server host
-  * `net.peer.port` — server port
-  * Captured request/response headers per configuration
+  * `http.request.method` — request method (GET, POST, etc.)
+  * `url.full` — full request URL
+  * `http.response.status_code` — response status code
+  * `network.protocol.version` — protocol version (e.g. `1.1`, `2` for HTTP/2)
+  * `server.address` — logical server host
+  * `server.port` — logical server port
+  * `network.peer.address` / `network.peer.port` — connection endpoint, when available
+  * Captured request/response headers per configuration (`http.request.header.<name>` / `http.response.header.<name>`)
 
 If a request fails, the span is ended and the error is recorded.
 


### PR DESCRIPTION
## Summary

We debugged and tested client HTTP spans from a sample app and confirmed the instrumentation stack **already emits the latest stable HTTP semantic conventions** (for example `http.response.status_code`, `http.request.method`, and `url.full`). **No code changes** were required.

This PR only **updates READMEs** so the documented attribute names match what we saw at runtime:

- `instrumentation/okhttp3/README.md`
- `instrumentation/httpurlconnection/README.md`

Fixes #1393

## Verification

See screenshot below: client span attributes from a real request (e.g. HTTPS GET) showing stable keys including **`http.response.status_code`** and related HTTP / network fields.

<img width="935" height="582" alt="Screenshot 2026-04-13 at 4 34 49 PM" src="https://github.com/user-attachments/assets/f641ec33-8d4f-48c3-84be-519ef81bca85" />