### PR TITLE
Bump dependency versions

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -33,7 +33,7 @@ jobs:
       # uploads of run results in SARIF format to the repository Actions tab.
       # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
       - name: "Upload artifact"
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: SARIF file
           path: results.sarif

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ byteBuddy = "1.18.8-jdk5"
 okhttp = "5.3.2"
 spotless = "8.4.0"
 kotlin = "2.3.10"
-androidPlugin = "9.1.0"
+androidPlugin = "9.1.1"
 kspPlugin = "2.3.6"
 junitKtx = "1.3.0"
 autoServiceProcessor = "1.2.0"
@@ -77,7 +77,7 @@ protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version.ref 
 
 #Compilation tools
 desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.1.5"
-nullaway = "com.uber.nullaway:nullaway:0.13.1"
+nullaway = "com.uber.nullaway:nullaway:0.13.2"
 errorprone-core = "com.google.errorprone:error_prone_core:2.48.0"
 spotless-plugin = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless" }
 errorprone-plugin = "net.ltgt.gradle:gradle-errorprone-plugin:5.1.0"


### PR DESCRIPTION
## Goal

Takes the changes in #1676 _without_ updating the Kotlin version, as CodeQL fails the CI workflow for Kotlin alone.