### PR TITLE
feat(demo-app): OkHttp build-time instrumentation and demo screen

### DIFF
--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -3,6 +3,7 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 plugins {
     alias(rootLibs.plugins.androidApp)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.byteBuddy)
 }
 
 android {
@@ -69,6 +70,9 @@ dependencies {
     implementation("io.opentelemetry.android:android-agent")    //parent dir
     implementation("io.opentelemetry.android.instrumentation:compose-click")
     implementation("io.opentelemetry.android.instrumentation:sessions")
+    implementation("io.opentelemetry.android.instrumentation:okhttp3-library")
+    byteBuddy("io.opentelemetry.android.instrumentation:okhttp3-agent")
+    implementation(libs.okhttp)
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/demo-app/gradle/libs.versions.toml
+++ b/demo-app/gradle/libs.versions.toml
@@ -1,4 +1,6 @@
 [versions]
+byteBuddy = "1.18.8"
+okhttp = "5.3.2"
 opentelemetry = "1.61.0"
 opentelemetry-alpha = "1.61.0-alpha"
 junit = "6.0.3"
@@ -11,6 +13,7 @@ androidx-appcompat = "androidx.appcompat:appcompat:1.7.1"
 opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp", version.ref = "opentelemetry" }
 opentelemetry-api-incubator = { module = "io.opentelemetry:opentelemetry-api-incubator", version.ref = "opentelemetry-alpha" }
 gson = "com.google.code.gson:gson:2.13.2"
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 
 #Test tools
 androidx-junit = "androidx.test.ext:junit:1.3.0"
@@ -47,3 +50,4 @@ junit = ["junit-jupiter-api", "junit-jupiter-engine", "junit-vintage-engine"]
 [plugins]
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+byteBuddy = { id = "net.bytebuddy.byte-buddy-gradle-plugin", version.ref = "byteBuddy" }

--- a/demo-app/settings.gradle.kts
+++ b/demo-app/settings.gradle.kts
@@ -28,5 +28,9 @@ includeBuild("..") {
             .using(project(":instrumentation:compose:click"))
         substitute(module("io.opentelemetry.android.instrumentation:sessions"))
             .using(project(":instrumentation:sessions"))
+        substitute(module("io.opentelemetry.android.instrumentation:okhttp3-library"))
+            .using(project(":instrumentation:okhttp3:library"))
+        substitute(module("io.opentelemetry.android.instrumentation:okhttp3-agent"))
+            .using(project(":instrumentation:okhttp3:agent"))
     }
 }

--- a/demo-app/src/main/AndroidManifest.xml
+++ b/demo-app/src/main/AndroidManifest.xml
@@ -30,6 +30,12 @@
             android:label="About OpenTelemetry Android"
             />
         <activity
+            android:name=".OkHttpDemoActivity"
+            android:exported="false"
+            android:label="OkHttp instrumentation"
+            android:theme="@style/Theme.DemoApp"
+            />
+        <activity
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/MainActivity.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/MainActivity.kt
@@ -12,12 +12,16 @@ import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Alignment
@@ -41,21 +45,28 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         setContent {
             DemoAppTheme {
                 // A surface container using the 'background' color from the theme
                 Surface(
-                    modifier = Modifier.fillMaxSize(),
+                    modifier = Modifier.fillMaxSize().safeDrawingPadding(),
                     color = MaterialTheme.colorScheme.background,
                 ) {
                     Column(
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .verticalScroll(rememberScrollState())
+                                .padding(horizontal = 20.dp, vertical = 16.dp),
                         horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.SpaceEvenly,
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
                     ) {
                         Row(
-                            Modifier.padding(all = 20.dp),
+                            Modifier.padding(vertical = 4.dp),
                             horizontalArrangement = Arrangement.Center,
                         ) {
+                            val onBackground = MaterialTheme.colorScheme.onBackground
                             CenterText(
                                 fontSize = 40.sp,
                                 text =
@@ -66,7 +77,7 @@ class MainActivity : ComponentActivity() {
                                         withStyle(style = SpanStyle(color = Color(0xFF425CC7))) {
                                             append("Telemetry")
                                         }
-                                        withStyle(style = SpanStyle(color = Color.Black)) {
+                                        withStyle(style = SpanStyle(color = onBackground)) {
                                             append(" Android Demo")
                                         }
                                         toAnnotatedString()
@@ -78,6 +89,9 @@ class MainActivity : ComponentActivity() {
                             painterResource(id = R.drawable.otel_icon),
                         )
                         val context = LocalContext.current
+                        LauncherButton(text = "OkHttp instrumentation", onClick = {
+                            context.startActivity(Intent(this@MainActivity, OkHttpDemoActivity::class.java))
+                        })
                         LauncherButton(text = "Go shopping", onClick = {
                             context.startActivity(Intent(this@MainActivity, AstronomyShopActivity::class.java))
                         })

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/OkHttpDemoActivity.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/OkHttpDemoActivity.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.demo
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import io.opentelemetry.android.demo.theme.DemoAppTheme
+
+class OkHttpDemoActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContent {
+            DemoAppTheme {
+                OkHttpDemoScreen(onBack = { finish() })
+            }
+        }
+    }
+}

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/OkHttpDemoScreen.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/OkHttpDemoScreen.kt
@@ -85,7 +85,7 @@ fun OkHttpDemoScreen(onBack: () -> Unit) {
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Spacer(modifier = Modifier.height(8.dp))
-            OutlinedButton(
+            OkHttpDemoActionButton(
                 onClick = {
                     scope.launch {
                         val msg =
@@ -102,17 +102,9 @@ fun OkHttpDemoScreen(onBack: () -> Unit) {
                         }
                     }
                 },
-                modifier = Modifier.fillMaxWidth().height(56.dp),
-                border = BorderStroke(1.dp, DemoAccentBlue),
-                colors =
-                    ButtonDefaults.outlinedButtonColors(
-                        containerColor = Color.Transparent,
-                        contentColor = DemoAccentBlue,
-                    ),
-            ) {
-                Text("GET known 200")
-            }
-            OutlinedButton(
+                text = "GET known 200",
+            )
+            OkHttpDemoActionButton(
                 onClick = {
                     scope.launch {
                         val msg =
@@ -129,17 +121,9 @@ fun OkHttpDemoScreen(onBack: () -> Unit) {
                         }
                     }
                 },
-                modifier = Modifier.fillMaxWidth().height(56.dp),
-                border = BorderStroke(1.dp, DemoAccentBlue),
-                colors =
-                    ButtonDefaults.outlinedButtonColors(
-                        containerColor = Color.Transparent,
-                        contentColor = DemoAccentBlue,
-                    ),
-            ) {
-                Text("GET known 404")
-            }
-            OutlinedButton(
+                text = "GET known 404",
+            )
+            OkHttpDemoActionButton(
                 onClick = {
                     scope.launch {
                         val msg =
@@ -156,17 +140,9 @@ fun OkHttpDemoScreen(onBack: () -> Unit) {
                         }
                     }
                 },
-                modifier = Modifier.fillMaxWidth().height(56.dp),
-                border = BorderStroke(1.dp, DemoAccentBlue),
-                colors =
-                    ButtonDefaults.outlinedButtonColors(
-                        containerColor = Color.Transparent,
-                        contentColor = DemoAccentBlue,
-                    ),
-            ) {
-                Text("GET connection failure")
-            }
-            OutlinedButton(
+                text = "GET connection failure",
+            )
+            OkHttpDemoActionButton(
                 onClick = {
                     scope.launch {
                         val msg =
@@ -186,17 +162,9 @@ fun OkHttpDemoScreen(onBack: () -> Unit) {
                         }
                     }
                 },
-                modifier = Modifier.fillMaxWidth().height(56.dp),
-                border = BorderStroke(1.dp, DemoAccentBlue),
-                colors =
-                    ButtonDefaults.outlinedButtonColors(
-                        containerColor = Color.Transparent,
-                        contentColor = DemoAccentBlue,
-                    ),
-            ) {
-                Text("POST JSON payload")
-            }
-            OutlinedButton(
+                text = "POST JSON payload",
+            )
+            OkHttpDemoActionButton(
                 onClick = {
                     scope.launch {
                         val msg =
@@ -213,16 +181,27 @@ fun OkHttpDemoScreen(onBack: () -> Unit) {
                         }
                     }
                 },
-                modifier = Modifier.fillMaxWidth().height(56.dp),
-                border = BorderStroke(1.dp, DemoAccentBlue),
-                colors =
-                    ButtonDefaults.outlinedButtonColors(
-                        containerColor = Color.Transparent,
-                        contentColor = DemoAccentBlue,
-                    ),
-            ) {
-                Text("GET slow response (3s)")
-            }
+                text = "GET slow response (3s)",
+            )
         }
+    }
+}
+
+@Composable
+private fun OkHttpDemoActionButton(
+    text: String,
+    onClick: () -> Unit,
+) {
+    OutlinedButton(
+        onClick = onClick,
+        modifier = Modifier.fillMaxWidth().height(56.dp),
+        border = BorderStroke(1.dp, DemoAccentBlue),
+        colors =
+            ButtonDefaults.outlinedButtonColors(
+                containerColor = Color.Transparent,
+                contentColor = DemoAccentBlue,
+            ),
+    ) {
+        Text(text)
     }
 }

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/OkHttpDemoScreen.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/OkHttpDemoScreen.kt
@@ -1,0 +1,228 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.demo
+
+import android.widget.Toast
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+
+private val DemoAccentBlue = Color(0xFF425CC7)
+
+/**
+ * Full-screen OkHttp instrumentation demo (issue #419). Sample HTTP calls produce traced client spans.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun OkHttpDemoScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val client = remember { OkHttpClient() }
+
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBar(
+                title = { Text("Instrumentation testing") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.Filled.ArrowBack,
+                            contentDescription = "Back",
+                        )
+                    }
+                },
+            )
+        },
+    ) { innerPadding ->
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 20.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            Text(
+                text = "OkHttp sample calls (GET, POST, delayed GET); each should produce a traced client span in your collector.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            OutlinedButton(
+                onClick = {
+                    scope.launch {
+                        val msg =
+                            runCatching {
+                                withContext(Dispatchers.IO) {
+                                    val request =
+                                        Request.Builder().url("https://httpbin.org/status/200").get().build()
+                                    val code = client.newCall(request).execute().use { it.code }
+                                    "OkHttp: HTTP $code"
+                                }
+                            }.getOrElse { e -> "OkHttp 200 demo: ${e.message}" }
+                        withContext(Dispatchers.Main) {
+                            Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                },
+                modifier = Modifier.fillMaxWidth().height(56.dp),
+                border = BorderStroke(1.dp, DemoAccentBlue),
+                colors =
+                    ButtonDefaults.outlinedButtonColors(
+                        containerColor = Color.Transparent,
+                        contentColor = DemoAccentBlue,
+                    ),
+            ) {
+                Text("GET known 200")
+            }
+            OutlinedButton(
+                onClick = {
+                    scope.launch {
+                        val msg =
+                            runCatching {
+                                withContext(Dispatchers.IO) {
+                                    val request =
+                                        Request.Builder().url("https://httpbin.org/status/404").get().build()
+                                    val code = client.newCall(request).execute().use { it.code }
+                                    "OkHttp: HTTP $code"
+                                }
+                            }.getOrElse { e -> "OkHttp 404 demo: ${e.message}" }
+                        withContext(Dispatchers.Main) {
+                            Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                },
+                modifier = Modifier.fillMaxWidth().height(56.dp),
+                border = BorderStroke(1.dp, DemoAccentBlue),
+                colors =
+                    ButtonDefaults.outlinedButtonColors(
+                        containerColor = Color.Transparent,
+                        contentColor = DemoAccentBlue,
+                    ),
+            ) {
+                Text("GET known 404")
+            }
+            OutlinedButton(
+                onClick = {
+                    scope.launch {
+                        val msg =
+                            runCatching {
+                                withContext(Dispatchers.IO) {
+                                    val request =
+                                        Request.Builder().url("http://127.0.0.1:1/").get().build()
+                                    client.newCall(request).execute().use { it.code }
+                                    "OkHttp: unexpected success"
+                                }
+                            }.getOrElse { e -> "OkHttp failure demo: ${e.javaClass.simpleName}" }
+                        withContext(Dispatchers.Main) {
+                            Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                },
+                modifier = Modifier.fillMaxWidth().height(56.dp),
+                border = BorderStroke(1.dp, DemoAccentBlue),
+                colors =
+                    ButtonDefaults.outlinedButtonColors(
+                        containerColor = Color.Transparent,
+                        contentColor = DemoAccentBlue,
+                    ),
+            ) {
+                Text("GET connection failure")
+            }
+            OutlinedButton(
+                onClick = {
+                    scope.launch {
+                        val msg =
+                            runCatching {
+                                withContext(Dispatchers.IO) {
+                                    val json = """{"event":"otel-android-demo","source":"okhttp"}"""
+                                    val body =
+                                        json.toRequestBody("application/json; charset=utf-8".toMediaType())
+                                    val request =
+                                        Request.Builder().url("https://httpbin.org/post").post(body).build()
+                                    val code = client.newCall(request).execute().use { it.code }
+                                    "OkHttp POST: HTTP $code"
+                                }
+                            }.getOrElse { e -> "OkHttp POST demo: ${e.message}" }
+                        withContext(Dispatchers.Main) {
+                            Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                },
+                modifier = Modifier.fillMaxWidth().height(56.dp),
+                border = BorderStroke(1.dp, DemoAccentBlue),
+                colors =
+                    ButtonDefaults.outlinedButtonColors(
+                        containerColor = Color.Transparent,
+                        contentColor = DemoAccentBlue,
+                    ),
+            ) {
+                Text("POST JSON payload")
+            }
+            OutlinedButton(
+                onClick = {
+                    scope.launch {
+                        val msg =
+                            runCatching {
+                                withContext(Dispatchers.IO) {
+                                    val request =
+                                        Request.Builder().url("https://httpbin.org/delay/3").get().build()
+                                    val code = client.newCall(request).execute().use { it.code }
+                                    "OkHttp slow GET: HTTP $code (~3s)"
+                                }
+                            }.getOrElse { e -> "OkHttp slow demo: ${e.message}" }
+                        withContext(Dispatchers.Main) {
+                            Toast.makeText(context, msg, Toast.LENGTH_SHORT).show()
+                        }
+                    }
+                },
+                modifier = Modifier.fillMaxWidth().height(56.dp),
+                border = BorderStroke(1.dp, DemoAccentBlue),
+                colors =
+                    ButtonDefaults.outlinedButtonColors(
+                        containerColor = Color.Transparent,
+                        contentColor = DemoAccentBlue,
+                    ),
+            ) {
+                Text("GET slow response (3s)")
+            }
+        }
+    }
+}

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/theme/Theme.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/theme/Theme.kt
@@ -15,9 +15,11 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
+import androidx.core.graphics.ColorUtils
 import androidx.core.view.WindowCompat
 
 private val DarkColorScheme =
@@ -64,8 +66,13 @@ fun DemoAppTheme(
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+            val insetsController = WindowCompat.getInsetsController(window, view)
+            val backgroundArgb = colorScheme.background.toArgb()
+            window.statusBarColor = Color.Transparent.toArgb()
+            window.navigationBarColor = Color.Transparent.toArgb()
+            val useDarkSystemIcons = ColorUtils.calculateLuminance(backgroundArgb) > 0.5
+            insetsController.isAppearanceLightStatusBars = useDarkSystemIcons
+            insetsController.isAppearanceLightNavigationBars = useDarkSystemIcons
         }
     }
 


### PR DESCRIPTION
## Summary
Implements [issue #419](https://github.com/open-telemetry/opentelemetry-android/issues/419): the demo app now uses **build-time OkHttp autoinstrumentation** (ByteBuddy + okhttp3 agent/library) and includes a dedicated screen to fire sample HTTP traffic for manual verification in a collector.

## Changes
### Gradle / composite build (`demo-app/`)
- Apply **`net.bytebuddy.byte-buddy-gradle-plugin`** (version aligned with repo catalog in `demo-app/gradle/libs.versions.toml`).
- Add **`implementation`** `io.opentelemetry.android.instrumentation:okhttp3-library` and **`byteBuddy`** `okhttp3-agent`, plus **`okhttp`** for app code.
- Extend **`demo-app/settings.gradle.kts`** `dependencySubstitution` for `okhttp3-library` and `okhttp3-agent` when using the composite `includeBuild("..")`.

### App behavior
- **`OkHttpDemoActivity`** + **`OkHttpDemoScreen`**: Material3 **Scaffold** / **TopAppBar**, back navigation, **56dp**-tall **OutlinedButton** actions:
  - GET `httpbin` **200** and **404**
  - GET **connection failure** (`127.0.0.1:1`)
  - **POST** JSON to `https://httpbin.org/post`
  - **Slow GET** `https://httpbin.org/delay/3`
- **`MainActivity`**: **`enableEdgeToEdge()`**, root **`safeDrawingPadding()`**, scroll + **`spacedBy`** layout; **“OkHttp instrumentation”** opens the new activity; title uses **`onBackground`** for dark theme.
- **`DemoAppTheme`**: **transparent** status and navigation bar colors; **`isAppearanceLightStatusBars`** / **`isAppearanceLightNavigationBars`** from **background luminance** so system bar icons stay readable in light/dark/dynamic color.

## Issue
Fixes https://github.com/open-telemetry/opentelemetry-android/issues/419