### PR TITLE
Renaming crash reporter event

### DIFF
--- a/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.kt
+++ b/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.kt
@@ -57,7 +57,7 @@ internal class CrashReporter(
         val eventBuilder =
             logger.logRecordBuilder()
         eventBuilder
-            .setEventName("device.crash")
+            .setEventName("app.crash")
             .setAllAttributes(attributesBuilder.build())
             .emit()
     }

--- a/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.kt
+++ b/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.kt
@@ -59,7 +59,7 @@ internal class CrashReporter(
         val eventBuilder =
             logger.logRecordBuilder()
         eventBuilder
-            .setEventName("device.crash")
+            .setEventName("app.crash")
             .setAllAttributes(attributesBuilder.build())
             .emit()
     }

--- a/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReportIntegrationTest.kt
+++ b/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReportIntegrationTest.kt
@@ -16,15 +16,15 @@ import io.opentelemetry.sdk.logs.data.LogRecordData
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
 import io.opentelemetry.semconv.ExceptionAttributes
 import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes
+import java.io.PrintWriter
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import java.io.PrintWriter
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.Executors
-import java.util.concurrent.TimeUnit
 
 internal class CrashReportIntegrationTest {
     private lateinit var rule: OpenTelemetryRule
@@ -188,7 +188,7 @@ internal class CrashReportIntegrationTest {
         expectedExcType: String,
         expectedExcMessage: String? = null,
     ) {
-        assertEquals("device.crash", eventName)
+        assertEquals("app.crash", eventName)
         assertEquals(Severity.UNDEFINED_SEVERITY_NUMBER, severity)
 
         val attrs = attributes.asMap().mapKeys { it.key.key }

--- a/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReportIntegrationTest.kt
+++ b/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReportIntegrationTest.kt
@@ -201,7 +201,7 @@ internal class CrashReportIntegrationTest {
         expectedExcType: String,
         expectedExcMessage: String? = null,
     ) {
-        assertEquals("device.crash", eventName)
+        assertEquals("app.crash", eventName)
         assertEquals(Severity.UNDEFINED_SEVERITY_NUMBER, severity)
 
         val attrs = attributes.asMap().mapKeys { it.key.key }


### PR DESCRIPTION
Following this semantic convention change: https://github.com/open-telemetry/semantic-conventions/pull/3448