### PR TITLE
Use the sdk instead of the api to determine the core version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
                         sort | head -1)
           # otel-java core libs are transient deps thru instrumentation boms
           sdk_version=$(./gradlew --console=plain android-agent:dependencies | \
-                        grep 'io.opentelemetry:opentelemetry-api ' | \
+                        grep 'io.opentelemetry:opentelemetry-sdk ' | \
                         sed -e "s/.* -> //" | sed -e "s/ .*//" | \
                         sort | head -1)
           


### PR DESCRIPTION
Not entirely sure when this broke/change, but the last release templated the instrumentation version just fine, but failed to populate the java core version.

After some investigation into the gradle deps, I settled on this change here.

```
$ ./gradlew --console=plain android-agent:dependencies | \
> grep 'io.opentelemetry:opentelemetry-api ' | \
> sed -e "s/.* -> //" | \
> sed -e "s/ .*//" | sort | head -1
<nothing printed>
```

```
$ ./gradlew --console=plain android-agent:dependencies | \
> grep 'io.opentelemetry:opentelemetry-sdk ' | \
> sed -e "s/.* -> //" | \
> sed -e "s/ .*//" | sort | head -1
1.61.0
```