### PR TITLE
feat: support fullUrl in EndpointConfiguration to bypass default signal path appending

### DIFF
--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/connectivity/HttpEndpointConnectivity.kt
@@ -2,7 +2,6 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-
 package io.opentelemetry.android.agent.connectivity
 
 internal class HttpEndpointConnectivity private constructor(
@@ -15,12 +14,13 @@ internal class HttpEndpointConnectivity private constructor(
     companion object {
         fun forTraces(
             baseUrl: String,
+            fullUrl: Boolean = false,
             headers: Map<String, String>,
             compression: Compression,
             sslContext: SSLContextConnectivity?,
             clientTls: ClientTlsConnectivity?
         ): HttpEndpointConnectivity = HttpEndpointConnectivity(
-            baseUrl.trimEnd('/') + "/v1/traces",
+            if (fullUrl) baseUrl else baseUrl.trimEnd('/') + "/v1/traces",
             headers,
             compression,
             sslContext,
@@ -29,12 +29,13 @@ internal class HttpEndpointConnectivity private constructor(
 
         fun forLogs(
             baseUrl: String,
+            fullUrl: Boolean = false,
             headers: Map<String, String>,
             compression: Compression,
             sslContext: SSLContextConnectivity?,
             clientTls: ClientTlsConnectivity?
         ): HttpEndpointConnectivity = HttpEndpointConnectivity(
-            baseUrl.trimEnd('/') + "/v1/logs",
+            if (fullUrl) baseUrl else baseUrl.trimEnd('/') + "/v1/logs",
             headers,
             compression,
             sslContext,
@@ -43,12 +44,13 @@ internal class HttpEndpointConnectivity private constructor(
 
         fun forMetrics(
             baseUrl: String,
+            fullUrl: Boolean = false,
             headers: Map<String, String>,
             compression: Compression,
             sslContext: SSLContextConnectivity?,
             clientTls: ClientTlsConnectivity?
         ): HttpEndpointConnectivity = HttpEndpointConnectivity(
-            baseUrl.trimEnd('/') + "/v1/metrics",
+            if (fullUrl) baseUrl else baseUrl.trimEnd('/') + "/v1/metrics",
             headers,
             compression,
             sslContext,
@@ -57,12 +59,8 @@ internal class HttpEndpointConnectivity private constructor(
     }
 
     override fun getUrl(): String = url
-
     override fun getHeaders(): Map<String, String> = headers
-
     override fun getCompression(): Compression = compression
-
     override fun getSslContext(): SSLContextConnectivity? = sslContext
-
     override fun getClientTls(): ClientTlsConnectivity? = clientTls
 }

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/EndpointConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/EndpointConfiguration.kt
@@ -2,7 +2,6 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-
 package io.opentelemetry.android.agent.dsl
 
 import io.opentelemetry.android.agent.connectivity.Compression
@@ -13,9 +12,16 @@ import io.opentelemetry.android.agent.connectivity.Compression
 @OpenTelemetryDslMarker
 class EndpointConfiguration internal constructor(
     /**
-     * URL for HTTP export requests.
+     * Base URL for HTTP export requests. The signal-specific path (e.g. /v1/logs) will be
+     * appended automatically.
      */
     var url: String,
+    /**
+     * Full URL for HTTP export requests. When set, this URL is used as-is without appending
+     * any signal-specific path. Use this to specify a completely custom endpoint path,
+     * for example "https://example.com/v2/logs".
+     */
+    var fullUrl: String? = null,
     /**
      * Headers that should be attached to HTTP export requests.
      */

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/HttpExportConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/HttpExportConfiguration.kt
@@ -2,7 +2,6 @@
  * Copyright The OpenTelemetry Authors
  * SPDX-License-Identifier: Apache-2.0
  */
-
 package io.opentelemetry.android.agent.dsl
 
 import io.opentelemetry.android.Incubating
@@ -50,31 +49,36 @@ class HttpExportConfiguration internal constructor() {
     internal fun spansEndpoint(): HttpEndpointConnectivity =
         HttpEndpointConnectivity.forTraces(
             chooseUrlSource(spansConfig),
+            isFullUrl(spansConfig),
             spansConfig.headers + baseHeaders,
             chooseCompression(spansConfig.compression),
             sslContext,
-            clientTls
+            clientTls,
         )
 
     internal fun logsEndpoint(): HttpEndpointConnectivity =
         HttpEndpointConnectivity.forLogs(
             chooseUrlSource(logsConfig),
+            isFullUrl(logsConfig),
             logsConfig.headers + baseHeaders,
             chooseCompression(logsConfig.compression),
             sslContext,
-            clientTls
+            clientTls,
         )
 
     internal fun metricsEndpoint(): HttpEndpointConnectivity =
         HttpEndpointConnectivity.forMetrics(
             chooseUrlSource(metricsConfig),
+            isFullUrl(metricsConfig),
             metricsConfig.headers + baseHeaders,
             chooseCompression(metricsConfig.compression),
             sslContext,
-            clientTls
+            clientTls,
         )
 
-    private fun chooseUrlSource(cfg: EndpointConfiguration): String = cfg.url.ifBlank { baseUrl }
+    private fun chooseUrlSource(cfg: EndpointConfiguration): String = cfg.fullUrl ?: cfg.url.ifBlank { baseUrl }
+
+    private fun isFullUrl(cfg: EndpointConfiguration): Boolean = cfg.fullUrl != null
 
     private fun chooseCompression(signalConfigCompression: Compression?): Compression = signalConfigCompression ?: this.compression
 

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/HttpExportConfigurationTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/HttpExportConfigurationTest.kt
@@ -316,4 +316,103 @@ internal class HttpExportConfigurationTest {
         return ClientTlsConnectivity(privateKeyPem, certificatePem)
     }
 
+  @Test
+    fun testFullUrlOverrideForLogs() {
+        val baseUrl = "http://localhost:4318/"
+        val customLogsUrl = "http://localhost:4318/v2/logs"
+
+        val config =
+            otelConfig.exportConfig.apply {
+                this.baseUrl = baseUrl
+                logs {
+                    fullUrl = customLogsUrl
+                }
+            }
+
+        // logs should use the full custom URL without appending /v1/logs
+        config.logsEndpoint().assertEndpointConfig(
+            customLogsUrl,
+            emptyMap(),
+            Compression.GZIP,
+            null
+        )
+        // spans and metrics should still use baseUrl + default path
+        config.spansEndpoint().assertEndpointConfig(
+            "${baseUrl}v1/traces",
+            emptyMap(),
+            Compression.GZIP,
+            null
+        )
+        config.metricsEndpoint().assertEndpointConfig(
+            "${baseUrl}v1/metrics",
+            emptyMap(),
+            Compression.GZIP,
+            null
+        )
+    }
+
+    @Test
+    fun testFullUrlOverrideForAllSignals() {
+        val customSpansUrl = "http://traces.example.com/v2/traces"
+        val customLogsUrl = "http://logs.example.com/v2/logs"
+        val customMetricsUrl = "http://metrics.example.com/v2/metrics"
+
+        val config =
+            otelConfig.exportConfig.apply {
+                spans {
+                    fullUrl = customSpansUrl
+                }
+                logs {
+                    fullUrl = customLogsUrl
+                }
+                metrics {
+                    fullUrl = customMetricsUrl
+                }
+            }
+
+        config.spansEndpoint().assertEndpointConfig(
+            customSpansUrl,
+            emptyMap(),
+            Compression.GZIP,
+            null
+        )
+        config.logsEndpoint().assertEndpointConfig(
+            customLogsUrl,
+            emptyMap(),
+            Compression.GZIP,
+            null
+        )
+        config.metricsEndpoint().assertEndpointConfig(
+            customMetricsUrl,
+            emptyMap(),
+            Compression.GZIP,
+            null
+        )
+    }
+
+    @Test
+    fun testFullUrlTakesPrecedenceOverUrl() {
+        val baseUrl = "http://localhost:4318/"
+        val signalUrl = "http://localhost:4318/logs/"
+        val customFullUrl = "http://localhost:4318/v2/logs"
+
+        val config =
+            otelConfig.exportConfig.apply {
+                this.baseUrl = baseUrl
+                logs {
+                    url = signalUrl
+                    fullUrl = customFullUrl
+                }
+            }
+
+        // fullUrl should take precedence over url
+        config.logsEndpoint().assertEndpointConfig(
+            customFullUrl,
+            emptyMap(),
+            Compression.GZIP,
+            null
+        )
+    }
+
+
 }


### PR DESCRIPTION
Fixes #1712

## Summary

When using `HttpExportConfiguration`, the signal-specific paths (`/v1/logs`, `/v1/traces`, `/v1/metrics`) are always appended to the base URL. This makes it impossible to use a custom endpoint path like `/v2/logs`.

This PR adds a `fullUrl` property to `EndpointConfiguration` that, when set, bypasses the automatic path appending and uses the provided URL as-is.

## Usage

```kotlin
httpExport {
    baseUrl = "https://example.com"
    logs {
        fullUrl = "https://example.com/v2/logs"  // used as-is, no path appended
    }
    // traces still uses: https://example.com/v1/traces
    // metrics still uses: https://example.com/v1/metrics
}
```

## Changes

- Added `fullUrl: String?` property to `EndpointConfiguration`
- Updated `HttpExportConfiguration` to use `fullUrl` when set, falling back to existing `url` + path behaviour
- Updated `HttpEndpointConnectivity.forTraces/forLogs/forMetrics` to accept a `fullUrl` flag
- Added tests covering the new behaviour
