### PR TITLE
Add agent DSL to add session observers

### DIFF
--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -71,6 +71,7 @@ public final class io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration
 public final class io/opentelemetry/android/agent/dsl/SessionConfiguration {
 	public final fun getBackgroundInactivityTimeout-UwyO8pc ()J
 	public final fun getMaxLifetime-UwyO8pc ()J
+	public final fun observers ([Lio/opentelemetry/android/session/SessionObserver;)V
 	public final fun setBackgroundInactivityTimeout-LRDsOJo (J)V
 	public final fun setMaxLifetime-LRDsOJo (J)V
 }

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
@@ -136,6 +136,8 @@ object OpenTelemetryRumInitializer {
         val clock = cfg.clock
         val timeoutHandler = SessionIdTimeoutHandler(sessionConfig, clock)
         Services.get(context).appLifecycle.registerListener(timeoutHandler)
-        return SessionManager.create(timeoutHandler, sessionConfig, clock)
+        val sessionManager = SessionManager.create(timeoutHandler, sessionConfig, clock)
+        cfg.sessionConfig.getObservers().forEach { sessionManager.addObserver(it) }
+        return sessionManager
     }
 }

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/SessionConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/SessionConfiguration.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.android.agent.dsl
 
+import io.opentelemetry.android.session.SessionObserver
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
@@ -24,4 +25,14 @@ class SessionConfiguration internal constructor() {
      * The maximum duration which a session can remain open before it automatically expires.
      */
     var maxLifetime: Duration = 4.hours
+
+    private var observersList: MutableList<SessionObserver> = mutableListOf()
+
+    internal fun getObservers(): List<SessionObserver> {
+        return observersList.toList()
+    }
+
+    fun observers(vararg observers: SessionObserver ) {
+        observersList.addAll(observers)
+    }
 }

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
@@ -6,13 +6,16 @@
 package io.opentelemetry.android.agent
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import io.opentelemetry.android.Incubating
 import io.opentelemetry.android.agent.session.SessionIdTimeoutHandler
 import io.opentelemetry.android.internal.services.Services
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle
+import io.opentelemetry.android.session.SessionObserver
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -27,24 +30,7 @@ class OpenTelemetryRumInitializerTest {
     @Before
     fun setUp() {
         appLifecycle = mockk(relaxed = true)
-    }
-
-    @Test
-    fun `Verify timeoutHandler initialization 2`() {
         createAndSetServiceManager()
-
-        OpenTelemetryRumInitializer.initialize(
-            context = RuntimeEnvironment.getApplication(),
-            configuration = {
-                httpExport {
-                    baseUrl = "http://127.0.0.1:4318"
-                }
-            },
-        )
-
-        verify {
-            appLifecycle.registerListener(any<SessionIdTimeoutHandler>())
-        }
     }
 
     @After
@@ -52,11 +38,58 @@ class OpenTelemetryRumInitializerTest {
         Services.set(null)
     }
 
+    @Test
+    fun `Verify timeoutHandler initialization 2`() {
+        val rum = OpenTelemetryRumInitializer.initialize(
+            context = RuntimeEnvironment.getApplication(),
+            configuration = {
+                httpExport {
+                    baseUrl = "http://127.0.0.1:4318"
+                }
+            },
+        )
+        rum.shutdown()
+
+        verify {
+            appLifecycle.registerListener(any<SessionIdTimeoutHandler>())
+        }
+    }
+
+    @Test
+    fun `Verify session observers are applied`() {
+        val o1: SessionObserver = mockk()
+        val o2: SessionObserver = mockk()
+        every { o1.onSessionStarted(any(), any()) } just Runs
+        every { o1.onSessionEnded(any()) } just Runs
+        every { o2.onSessionStarted(any(), any()) } just Runs
+        every { o2.onSessionEnded(any()) } just Runs
+
+        val rum = OpenTelemetryRumInitializer.initialize(
+            context = RuntimeEnvironment.getApplication(),
+            configuration = {
+                httpExport {
+                    baseUrl = "http://127.0.0.1:4318"
+                }
+                session {
+                    observers(o1, o2)
+                }
+            },
+        )
+        rum.shutdown()
+
+        verify {
+            o1.onSessionStarted(any(), any())
+            o2.onSessionStarted(any(), any())
+        }
+    }
+
     private fun createAndSetServiceManager(): Services {
         val services = mockk<Services>()
         every { services.appLifecycle }.returns(appLifecycle)
         every { services.currentNetworkProvider }.returns(mockk(relaxed = true))
         every { services.visibleScreenTracker }.returns(mockk(relaxed = true))
+        every { services.cacheStorage }.returns(mockk(relaxed = true))
+        every { services.close() } just Runs
         Services.set(services)
         return services
     }

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/SessionConfigurationTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/SessionConfigurationTest.kt
@@ -5,8 +5,11 @@
 
 package io.opentelemetry.android.agent.dsl
 
+import io.mockk.mockk
 import io.opentelemetry.android.agent.FakeClock
 import io.opentelemetry.android.agent.FakeInstrumentationLoader
+import io.opentelemetry.android.session.SessionObserver
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import org.junit.Before
@@ -44,4 +47,17 @@ internal class SessionConfigurationTest {
         assertEquals(customTimeout, otelConfig.sessionConfig.backgroundInactivityTimeout)
         assertEquals(customLifetime, otelConfig.sessionConfig.maxLifetime)
     }
+
+    @Test
+    fun `can add session observers`() {
+        val o1: SessionObserver = mockk()
+        val o2: SessionObserver = mockk()
+        val otelConfig = otelConfig.apply {
+            session {
+                observers(o1, o2)
+            }
+        }
+        assertThat(otelConfig.sessionConfig.getObservers()).containsExactly(o1, o2)
+    }
+
 }


### PR DESCRIPTION
Resolves #328.

As discussed in SIG earlier this week, we think there is room now to allow users to provide session observers via the DSL.