### PR TITLE
Clarify release cadence schedule

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,7 @@ This documents describes the manual steps required to publish a release to maven
 ## Release cadence
 
 This repository roughly targets monthly minor releases from the `main` branch.
-These releases are generally cut on the Wednesday after the third Monday of the month, roughly a
+These releases are generally cut on the Tuesday after the third Monday of the month, roughly a
 week after the monthly minor release of [opentelemetry-java-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation).
 
 ## Update Milestones

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,9 +4,9 @@ This documents describes the manual steps required to publish a release to maven
 
 ## Release cadence
 
-This repository targets monthly minor releases from the `main` branch roughly a week after
-the monthly minor release
-of [opentelemetry-java-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation)).
+This repository roughly targets monthly minor releases from the `main` branch.
+These releases are generally cut on the Wednesday after the third Monday of the month, roughly a
+week after the monthly minor release of [opentelemetry-java-instrumentation](https://github.com/open-telemetry/opentelemetry-java-instrumentation).
 
 ## Update Milestones
 


### PR DESCRIPTION
Tweaks the release cadence wording. Because we follow upstream, and upstream roughly publishes on the Wednesday after the second Monday, we can say that we aim for the Tuesday after the third Monday. 

This helps with machine calculation/estimate.