### PR TITLE
Remove deprecated sdk ready listeners.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### ⚠️⚠️ Breaking changes
+
+- Remove deprecated sdk ready listeners. Users should use the otel ready listeners instead.
+  ([#1731](https://github.com/open-telemetry/opentelemetry-android/pull/1731)) 
+
 ## Version 1.3.0 (2026-04-22)
 
 ### ⚠️⚠️ Breaking changes

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -11,7 +11,6 @@ public final class io/opentelemetry/android/OpenTelemetryRumBuilder {
 	public final fun addMeterProviderCustomizer (Ljava/util/function/BiFunction;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public final fun addMetricExporterCustomizer (Ljava/util/function/Function;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public final fun addOtelReadyListener (Lkotlin/jvm/functions/Function1;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
-	public final fun addOtelSdkReadyListener (Ljava/util/function/Consumer;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public final fun addPropagatorCustomizer (Ljava/util/function/Function;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public final fun addSpanExporterCustomizer (Ljava/util/function/Function;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;
 	public final fun addTracerProviderCustomizer (Ljava/util/function/BiFunction;)Lio/opentelemetry/android/OpenTelemetryRumBuilder;

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.kt
@@ -107,9 +107,6 @@ class OpenTelemetryRumBuilder internal constructor(
 
     val instrumentationLoader: AndroidInstrumentationLoader = AndroidInstrumentationLoaderImpl()
 
-    @Deprecated("SDK listeners are deprecated, use otelReadyListeners instead")
-    private val otelSdkReadyListeners: MutableList<Consumer<OpenTelemetrySdk>> = mutableListOf()
-
     private val otelReadyListeners: MutableList<(OpenTelemetry) -> Unit> = mutableListOf()
 
     private var spanExporterCustomizer: (SpanExporter) -> SpanExporter = { it }
@@ -280,22 +277,6 @@ class OpenTelemetryRumBuilder internal constructor(
     }
 
     /**
-     * Adds a callback to be invoked after the OpenTelemetry SDK has been initialized. This can be
-     * used to defer some early lifecycle functionality until the working SDK is ready.
-     *
-     * @param callback - A callback that receives the OpenTelemetry SDK instance.
-     * @return this
-     */
-    @Deprecated(
-        message = "OtelSdkReadyListeners will be removed in a future release",
-        replaceWith = ReplaceWith("addOtelReadyListener(callback)"),
-    )
-    fun addOtelSdkReadyListener(callback: Consumer<OpenTelemetrySdk>): OpenTelemetryRumBuilder {
-        otelSdkReadyListeners.add(callback)
-        return this
-    }
-
-    /**
      * Adds a callback to be invoked after the OpenTelemetry instance has been initialized. This can be
      * used to defer some early lifecycle functionality until the OpenTelemetry instance is ready.
      *
@@ -358,11 +339,6 @@ class OpenTelemetryRumBuilder internal constructor(
                 ).setPropagators(buildFinalPropagators())
                 .build()
 
-        otelSdkReadyListeners.forEach(
-            Consumer {
-                it.accept(sdk)
-            },
-        )
         otelReadyListeners.forEach { it(sdk) }
 
         val delegate =

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.kt
@@ -538,18 +538,6 @@ class OpenTelemetryRumBuilderTest {
     }
 
     @Test
-    fun sdkReadyListeners() {
-        val config = buildConfig()
-        val seen = AtomicReference<OpenTelemetrySdk>()
-        createAndSetServiceManager()
-        RumBuilder
-            .builder(application, config)
-            .addOtelSdkReadyListener { newValue: OpenTelemetrySdk -> seen.set(newValue) }
-            .build()
-        assertThat(seen.get()).isNotNull()
-    }
-
-    @Test
     fun otelReadyListeners() {
         val config = buildConfig()
         val seen = AtomicReference<OpenTelemetry>()


### PR DESCRIPTION
Users should migrate to the otel ready listeners instead, and use the api instead of sdk.