### PR TITLE
Add codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%


### PR DESCRIPTION
We end up having a lot of PRs that show up with ❌ because codecov detects a sub-1% change, often for minor or unimportant things (like deleting old code, or just adding some comments or whatever). This hopes to start limiting some of that.

The thing is that we'll want to keep this in check while we continue increasing our coverage...and not let it get much worse. 