### PR TITLE
Treat empty fullUrl as null/missing

### DIFF
--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/HttpExportConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/HttpExportConfiguration.kt
@@ -77,9 +77,9 @@ class HttpExportConfiguration internal constructor() {
         )
 
     private fun chooseUrlSource(cfg: EndpointConfiguration): String =
-        cfg.fullUrl ?: cfg.url.ifBlank { baseUrl }
+        cfg.fullUrl?.takeUnless { it.isBlank() } ?: cfg.url.ifBlank { baseUrl }
 
-    private fun isFullUrl(cfg: EndpointConfiguration): Boolean = cfg.fullUrl != null
+    private fun isFullUrl(cfg: EndpointConfiguration): Boolean = !cfg.fullUrl.isNullOrBlank()
 
     private fun chooseCompression(signalConfigCompression: Compression?): Compression =
         signalConfigCompression ?: this.compression

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/HttpExportConfigurationTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/HttpExportConfigurationTest.kt
@@ -325,4 +325,21 @@ internal class HttpExportConfigurationTest {
 
         config.logsEndpoint().assertEndpointConfig(customFullUrl, emptyMap(), Compression.GZIP, null)
     }
+
+    @Test
+    fun testBlankFullUrlFallsBackToUrl() {
+        val baseUrl = "http://localhost:4318/"
+        val signalUrl = "http://localhost:4319/logs/"
+
+        val config =
+            otelConfig.exportConfig.apply {
+                this.baseUrl = baseUrl
+                logs {
+                    url = signalUrl
+                    fullUrl = ""
+                }
+            }
+
+        config.logsEndpoint().assertEndpointConfig("${signalUrl}v1/logs", emptyMap(), Compression.GZIP, null)
+    }
 }


### PR DESCRIPTION
Minor improvement after #1723, which slightly changed how an empty configuration string would be handled.

Prior to #1723 we would check for empty before falling back. This same approach needs to also happen with the fullUrl, so that if a user configures an empty string as a fullUrl, we still just use the locally scoped url.