### PR TITLE
Use kotlin published semconv instead of java

### DIFF
--- a/android-agent/build.gradle.kts
+++ b/android-agent/build.gradle.kts
@@ -30,8 +30,7 @@ dependencies {
     implementation(project(":instrumentation:sessions"))
     implementation(project(":instrumentation:screen-orientation"))
 
-    testImplementation(libs.opentelemetry.semconv)
-    testImplementation(libs.opentelemetry.semconv.incubating)
+    testImplementation(libs.opentelemetry.semconv.kotlin)
     testImplementation(libs.robolectric)
     testImplementation(libs.okhttp.mockwebserver)
     testImplementation(libs.androidx.test.core)

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/connectivity/HttpEndpointConnectivityTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/connectivity/HttpEndpointConnectivityTest.kt
@@ -6,9 +6,11 @@
 package io.opentelemetry.android.agent.connectivity
 
 import io.mockk.mockk
+import io.opentelemetry.android.Incubating
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
+@OptIn(Incubating::class)
 class HttpEndpointConnectivityTest {
     @Test
     fun `Validate exporter endpoint configuration`() {

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/ResourceConfigTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/ResourceConfigTest.kt
@@ -10,19 +10,20 @@ import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.opentelemetry.android.agent.OpenTelemetryRumInitializer
 import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.sdk.resources.ResourceBuilder
-import io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME
-import io.opentelemetry.semconv.TelemetryAttributes.TELEMETRY_SDK_LANGUAGE
-import io.opentelemetry.semconv.TelemetryAttributes.TELEMETRY_SDK_NAME
-import io.opentelemetry.semconv.TelemetryAttributes.TELEMETRY_SDK_VERSION
-import io.opentelemetry.semconv.incubating.AndroidIncubatingAttributes.ANDROID_OS_API_LEVEL
-import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MANUFACTURER
-import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MODEL_IDENTIFIER
-import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MODEL_NAME
-import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_DESCRIPTION
-import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_NAME
-import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_TYPE
-import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_VERSION
+import io.opentelemetry.kotlin.semconv.ServiceAttributes.SERVICE_NAME
+import io.opentelemetry.kotlin.semconv.TelemetryAttributes.TELEMETRY_SDK_LANGUAGE
+import io.opentelemetry.kotlin.semconv.TelemetryAttributes.TELEMETRY_SDK_NAME
+import io.opentelemetry.kotlin.semconv.TelemetryAttributes.TELEMETRY_SDK_VERSION
+import io.opentelemetry.kotlin.semconv.AndroidAttributes.ANDROID_OS_API_LEVEL
+import io.opentelemetry.kotlin.semconv.DeviceAttributes.DEVICE_MANUFACTURER
+import io.opentelemetry.kotlin.semconv.DeviceAttributes.DEVICE_MODEL_IDENTIFIER
+import io.opentelemetry.kotlin.semconv.DeviceAttributes.DEVICE_MODEL_NAME
+import io.opentelemetry.kotlin.semconv.OsAttributes.OS_DESCRIPTION
+import io.opentelemetry.kotlin.semconv.OsAttributes.OS_NAME
+import io.opentelemetry.kotlin.semconv.OsAttributes.OS_TYPE
+import io.opentelemetry.kotlin.semconv.OsAttributes.OS_VERSION
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
@@ -65,21 +66,21 @@ class ResourceConfigTest {
         val resource = builder.build()
         val attrs = resource.attributes.asMap()
         assertCommonResources(attrs)
-        assertEquals(customServiceName, attrs[SERVICE_NAME])
+        assertEquals(customServiceName, attrs[stringKey(SERVICE_NAME)])
         assertEquals("bar", attrs[AttributeKey.stringKey(customKey)])
     }
 
     private fun assertCommonResources(attrs: Map<AttributeKey<*>, Any>) {
-        assertEquals("23", attrs[ANDROID_OS_API_LEVEL])
-        assertEquals("unknown", attrs[DEVICE_MANUFACTURER])
-        assertEquals("robolectric", attrs[DEVICE_MODEL_IDENTIFIER])
-        assertEquals("robolectric", attrs[DEVICE_MODEL_NAME])
-        assertEquals("Android", attrs[OS_NAME])
-        assertEquals("linux", attrs[OS_TYPE])
-        assertEquals("6.0.1", attrs[OS_VERSION])
-        assertEquals("Android Version 6.0.1 (Build MMB29M API level 23)", attrs[OS_DESCRIPTION])
-        assertEquals("java", attrs[TELEMETRY_SDK_LANGUAGE])
-        assertEquals("opentelemetry", attrs[TELEMETRY_SDK_NAME])
-        assertNotNull(attrs[TELEMETRY_SDK_VERSION])
+        assertEquals("23", attrs[stringKey(ANDROID_OS_API_LEVEL)])
+        assertEquals("unknown", attrs[stringKey(DEVICE_MANUFACTURER)])
+        assertEquals("robolectric", attrs[stringKey(DEVICE_MODEL_IDENTIFIER)])
+        assertEquals("robolectric", attrs[stringKey(DEVICE_MODEL_NAME)])
+        assertEquals("Android", attrs[stringKey(OS_NAME)])
+        assertEquals("linux", attrs[stringKey(OS_TYPE)])
+        assertEquals("6.0.1", attrs[stringKey(OS_VERSION)])
+        assertEquals("Android Version 6.0.1 (Build MMB29M API level 23)", attrs[stringKey(OS_DESCRIPTION)])
+        assertEquals("java", attrs[stringKey(TELEMETRY_SDK_LANGUAGE)])
+        assertEquals("opentelemetry", attrs[stringKey(TELEMETRY_SDK_NAME)])
+        assertNotNull(attrs[stringKey(TELEMETRY_SDK_VERSION)])
     }
 }

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     implementation(project(":agent-api"))
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.instrumentation.api)
-    implementation(libs.opentelemetry.semconv.incubating)
+    implementation(libs.opentelemetry.semconv.kotlin)
     implementation(libs.androidx.core)
 
     testImplementation(libs.robolectric)

--- a/common/src/main/java/io/opentelemetry/android/common/internal/features/networkattributes/CurrentNetworkAttributesExtractor.kt
+++ b/common/src/main/java/io/opentelemetry/android/common/internal/features/networkattributes/CurrentNetworkAttributesExtractor.kt
@@ -7,28 +7,30 @@ package io.opentelemetry.android.common.internal.features.networkattributes
 
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
 import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes
+import io.opentelemetry.kotlin.semconv.IncubatingApi
+import io.opentelemetry.kotlin.semconv.NetworkAttributes
 
 class CurrentNetworkAttributesExtractor {
+    @OptIn(IncubatingApi::class)
     fun extract(network: CurrentNetwork): Attributes {
         val builder = Attributes.builder()
         network.state.humanName.let {
-            builder.put(NetworkIncubatingAttributes.NETWORK_CONNECTION_TYPE, it)
+            builder.put(NetworkAttributes.NETWORK_CONNECTION_TYPE, it)
         }
         network.subType.let {
-            builder.put(NetworkIncubatingAttributes.NETWORK_CONNECTION_SUBTYPE, it)
+            builder.put(NetworkAttributes.NETWORK_CONNECTION_SUBTYPE, it)
         }
         network.carrierName.let {
-            builder.put(NetworkIncubatingAttributes.NETWORK_CARRIER_NAME, it)
+            builder.put(NetworkAttributes.NETWORK_CARRIER_NAME, it)
         }
         network.carrierCountryCode.let {
-            builder.put(NetworkIncubatingAttributes.NETWORK_CARRIER_MCC, it)
+            builder.put(NetworkAttributes.NETWORK_CARRIER_MCC, it)
         }
         network.carrierNetworkCode.let {
-            builder.put(NetworkIncubatingAttributes.NETWORK_CARRIER_MNC, it)
+            builder.put(NetworkAttributes.NETWORK_CARRIER_MNC, it)
         }
         network.carrierIsoCountryCode.let {
-            builder.put(NetworkIncubatingAttributes.NETWORK_CARRIER_ICC, it)
+            builder.put(NetworkAttributes.NETWORK_CARRIER_ICC, it)
         }
         return builder.build()
     }

--- a/common/src/main/java/io/opentelemetry/android/common/internal/features/networkattributes/data/NetworkState.kt
+++ b/common/src/main/java/io/opentelemetry/android/common/internal/features/networkattributes/data/NetworkState.kt
@@ -5,7 +5,12 @@
 
 package io.opentelemetry.android.common.internal.features.networkattributes.data
 
-import io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes.NetworkConnectionTypeIncubatingValues
+import io.opentelemetry.kotlin.semconv.IncubatingApi
+import io.opentelemetry.kotlin.semconv.NetworkAttributes.NetworkConnectionTypeValues.UNAVAILABLE
+import io.opentelemetry.kotlin.semconv.NetworkAttributes.NetworkConnectionTypeValues.CELL
+import io.opentelemetry.kotlin.semconv.NetworkAttributes.NetworkConnectionTypeValues.WIFI
+import io.opentelemetry.kotlin.semconv.NetworkAttributes.NetworkConnectionTypeValues.WIRED
+import io.opentelemetry.kotlin.semconv.NetworkAttributes.NetworkConnectionTypeValues.UNKNOWN
 
 /**
  * This class is internal and not for public use. Its APIs are unstable and can change at any time.
@@ -13,11 +18,16 @@ import io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes.NetworkCo
 enum class NetworkState(
     val humanName: String,
 ) {
-    NO_NETWORK_AVAILABLE(NetworkConnectionTypeIncubatingValues.UNAVAILABLE),
-    TRANSPORT_CELLULAR(NetworkConnectionTypeIncubatingValues.CELL),
-    TRANSPORT_WIFI(NetworkConnectionTypeIncubatingValues.WIFI),
-    TRANSPORT_WIRED(NetworkConnectionTypeIncubatingValues.WIRED),
-    TRANSPORT_UNKNOWN(NetworkConnectionTypeIncubatingValues.UNKNOWN),
+    @OptIn(IncubatingApi::class)
+    NO_NETWORK_AVAILABLE(UNAVAILABLE.value),
+    @OptIn(IncubatingApi::class)
+    TRANSPORT_CELLULAR(CELL.value),
+    @OptIn(IncubatingApi::class)
+    TRANSPORT_WIFI(WIFI.value),
+    @OptIn(IncubatingApi::class)
+    TRANSPORT_WIRED(WIRED.value),
+    @OptIn(IncubatingApi::class)
+    TRANSPORT_UNKNOWN(UNKNOWN.value),
 
     // this one doesn't seem to have an otel value at this point.
     TRANSPORT_VPN("vpn"),

--- a/common/src/test/java/io/opentelemetry/android/common/internal/features/networkattributes/CurrentNetworkAttributesExtractorTest.kt
+++ b/common/src/test/java/io/opentelemetry/android/common/internal/features/networkattributes/CurrentNetworkAttributesExtractorTest.kt
@@ -8,10 +8,18 @@ package io.opentelemetry.android.common.internal.features.networkattributes
 import io.opentelemetry.android.common.internal.features.networkattributes.data.Carrier
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
 import io.opentelemetry.android.common.internal.features.networkattributes.data.NetworkState
-import io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes
+import io.opentelemetry.api.common.AttributeKey.stringKey
+import io.opentelemetry.kotlin.semconv.IncubatingApi
+import io.opentelemetry.kotlin.semconv.NetworkAttributes.NETWORK_CARRIER_ICC
+import io.opentelemetry.kotlin.semconv.NetworkAttributes.NETWORK_CARRIER_MCC
+import io.opentelemetry.kotlin.semconv.NetworkAttributes.NETWORK_CARRIER_MNC
+import io.opentelemetry.kotlin.semconv.NetworkAttributes.NETWORK_CARRIER_NAME
+import io.opentelemetry.kotlin.semconv.NetworkAttributes.NETWORK_CONNECTION_SUBTYPE
+import io.opentelemetry.kotlin.semconv.NetworkAttributes.NETWORK_CONNECTION_TYPE
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
+@OptIn(IncubatingApi::class)
 class CurrentNetworkAttributesExtractorTest {
     private val underTest: CurrentNetworkAttributesExtractor = CurrentNetworkAttributesExtractor()
 
@@ -27,12 +35,12 @@ class CurrentNetworkAttributesExtractorTest {
         val attributes = underTest.extract(currentNetwork).asMap()
         val expected =
             mapOf(
-                NetworkIncubatingAttributes.NETWORK_CONNECTION_TYPE to "cell",
-                NetworkIncubatingAttributes.NETWORK_CONNECTION_SUBTYPE to "aaa",
-                NetworkIncubatingAttributes.NETWORK_CARRIER_NAME to "ShadyTel",
-                NetworkIncubatingAttributes.NETWORK_CARRIER_ICC to "US",
-                NetworkIncubatingAttributes.NETWORK_CARRIER_MCC to "usa",
-                NetworkIncubatingAttributes.NETWORK_CARRIER_MNC to "omg",
+                stringKey(NETWORK_CONNECTION_TYPE) to "cell",
+                stringKey(NETWORK_CONNECTION_SUBTYPE) to "aaa",
+                stringKey(NETWORK_CARRIER_NAME) to "ShadyTel",
+                stringKey(NETWORK_CARRIER_ICC) to "US",
+                stringKey(NETWORK_CARRIER_MCC) to "usa",
+                stringKey(NETWORK_CARRIER_MNC) to "omg",
             )
         assertEquals(expected, attributes)
     }
@@ -44,8 +52,8 @@ class CurrentNetworkAttributesExtractorTest {
         val attributes = underTest.extract(currentNetwork).asMap()
         val expected =
             mapOf(
-                NetworkIncubatingAttributes.NETWORK_CONNECTION_SUBTYPE to "aaa",
-                NetworkIncubatingAttributes.NETWORK_CONNECTION_TYPE to "cell",
+                stringKey(NETWORK_CONNECTION_SUBTYPE) to "aaa",
+                stringKey(NETWORK_CONNECTION_TYPE) to "cell",
             )
         assertEquals(expected, attributes)
     }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -68,7 +68,7 @@ dependencies {
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.exporter.logging)
     implementation(libs.opentelemetry.instrumentation.api)
-    implementation(libs.opentelemetry.semconv.incubating)
+    implementation(libs.opentelemetry.semconv.kotlin)
     implementation(libs.opentelemetry.diskBuffering)
     implementation(libs.opentelemetry.processors)
     implementation(libs.kotlinx.coroutines)

--- a/core/src/main/java/io/opentelemetry/android/AndroidResource.kt
+++ b/core/src/main/java/io/opentelemetry/android/AndroidResource.kt
@@ -9,24 +9,26 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Build
 import io.opentelemetry.sdk.resources.Resource
-import io.opentelemetry.semconv.ServiceAttributes.SERVICE_NAME
-import io.opentelemetry.semconv.ServiceAttributes.SERVICE_VERSION
-import io.opentelemetry.semconv.TelemetryAttributes.TELEMETRY_SDK_VERSION
-import io.opentelemetry.semconv.incubating.AndroidIncubatingAttributes.ANDROID_OS_API_LEVEL
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_INSTALLATION_ID
-import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MANUFACTURER
-import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MODEL_IDENTIFIER
-import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes.DEVICE_MODEL_NAME
-import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_DESCRIPTION
-import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_NAME
-import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_TYPE
-import io.opentelemetry.semconv.incubating.OsIncubatingAttributes.OS_VERSION
+import io.opentelemetry.kotlin.semconv.ServiceAttributes.SERVICE_NAME
+import io.opentelemetry.kotlin.semconv.ServiceAttributes.SERVICE_VERSION
+import io.opentelemetry.kotlin.semconv.TelemetryAttributes.TELEMETRY_SDK_VERSION
+import io.opentelemetry.kotlin.semconv.AndroidAttributes.ANDROID_OS_API_LEVEL
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_INSTALLATION_ID
+import io.opentelemetry.kotlin.semconv.DeviceAttributes.DEVICE_MANUFACTURER
+import io.opentelemetry.kotlin.semconv.DeviceAttributes.DEVICE_MODEL_IDENTIFIER
+import io.opentelemetry.kotlin.semconv.DeviceAttributes.DEVICE_MODEL_NAME
+import io.opentelemetry.kotlin.semconv.IncubatingApi
+import io.opentelemetry.kotlin.semconv.OsAttributes.OS_DESCRIPTION
+import io.opentelemetry.kotlin.semconv.OsAttributes.OS_NAME
+import io.opentelemetry.kotlin.semconv.OsAttributes.OS_TYPE
+import io.opentelemetry.kotlin.semconv.OsAttributes.OS_VERSION
 import java.util.UUID
 
 private const val SHARED_PREF_FILE = "opentelemetry-android"
 private const val DEFAULT_APP_NAME = "unknown_service:android"
 
 object AndroidResource {
+    @OptIn(IncubatingApi::class)
     @JvmStatic
     fun createDefault(context: Context): Resource {
         val appName = readAppName(context)
@@ -49,15 +51,16 @@ object AndroidResource {
             .build()
     }
 
+    @OptIn(IncubatingApi::class)
     @SuppressLint("UseKtx")
     private fun readInstallId(context: Context): String {
         // install ID is persisted using the app.installation.id semconv as its key
         val prefs = context.getSharedPreferences(SHARED_PREF_FILE, 0)
-        val installId = prefs.getString(APP_INSTALLATION_ID.key, null)
+        val installId = prefs.getString(APP_INSTALLATION_ID, null)
 
         if (installId == null) {
             val id = UUID.randomUUID().toString()
-            prefs.edit().putString(APP_INSTALLATION_ID.key, id).apply()
+            prefs.edit().putString(APP_INSTALLATION_ID, id).apply()
             return id
         }
         return installId

--- a/core/src/main/java/io/opentelemetry/android/SessionIdSpanAppender.kt
+++ b/core/src/main/java/io/opentelemetry/android/SessionIdSpanAppender.kt
@@ -6,23 +6,28 @@
 package io.opentelemetry.android
 
 import io.opentelemetry.android.session.SessionProvider
+import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.context.Context
+import io.opentelemetry.kotlin.semconv.IncubatingApi
 import io.opentelemetry.sdk.trace.ReadWriteSpan
 import io.opentelemetry.sdk.trace.ReadableSpan
 import io.opentelemetry.sdk.trace.SpanProcessor
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes.SESSION_ID
+import io.opentelemetry.kotlin.semconv.SessionAttributes.SESSION_ID
 
 /**
  * A [SpanProcessor] that sets the `session.id` attribute to the current span when the span is started.
  */
+@OptIn(IncubatingApi::class)
 internal class SessionIdSpanAppender(
     private val sessionProvider: SessionProvider,
 ) : SpanProcessor {
+    private val sessionId = stringKey(SESSION_ID)
+    @OptIn(IncubatingApi::class)
     override fun onStart(
         parentContext: Context,
         span: ReadWriteSpan,
     ) {
-        span.setAttribute(SESSION_ID, sessionProvider.getSessionId())
+        span.setAttribute(sessionId, sessionProvider.getSessionId())
     }
 
     override fun isStartRequired(): Boolean = true

--- a/core/src/main/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppender.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppender.kt
@@ -6,18 +6,23 @@
 package io.opentelemetry.android.internal.processors
 
 import io.opentelemetry.android.session.SessionProvider
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.context.Context
+import io.opentelemetry.kotlin.semconv.IncubatingApi
 import io.opentelemetry.sdk.logs.LogRecordProcessor
 import io.opentelemetry.sdk.logs.ReadWriteLogRecord
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes.SESSION_ID
+import io.opentelemetry.kotlin.semconv.SessionAttributes.SESSION_ID
 
 internal class SessionIdLogRecordAppender(
     private val sessionProvider: SessionProvider,
 ) : LogRecordProcessor {
+    @OptIn(IncubatingApi::class)
+    val sessionIdKey: AttributeKey<String?> = stringKey(SESSION_ID)
     override fun onEmit(
         context: Context,
         logRecord: ReadWriteLogRecord,
     ) {
-        logRecord.setAttribute(SESSION_ID, sessionProvider.getSessionId())
+        logRecord.setAttribute(sessionIdKey, sessionProvider.getSessionId())
     }
 }

--- a/core/src/test/java/io/opentelemetry/android/AndroidResourceTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/AndroidResourceTest.kt
@@ -15,14 +15,16 @@ import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.mockk
 import io.mockk.slot
 import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.resources.ResourceBuilder
-import io.opentelemetry.semconv.ServiceAttributes
-import io.opentelemetry.semconv.TelemetryAttributes
-import io.opentelemetry.semconv.incubating.AndroidIncubatingAttributes
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes
-import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes
-import io.opentelemetry.semconv.incubating.OsIncubatingAttributes
+import io.opentelemetry.kotlin.semconv.TelemetryAttributes
+import io.opentelemetry.kotlin.semconv.AndroidAttributes
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_INSTALLATION_ID
+import io.opentelemetry.kotlin.semconv.DeviceAttributes
+import io.opentelemetry.kotlin.semconv.IncubatingApi
+import io.opentelemetry.kotlin.semconv.OsAttributes
+import io.opentelemetry.kotlin.semconv.ServiceAttributes.SERVICE_NAME
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -48,6 +50,7 @@ internal class AndroidResourceTest {
     private lateinit var expectedResourceBuilder: ResourceBuilder
     private lateinit var appInfo: ApplicationInfo
 
+    @OptIn(IncubatingApi::class)
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
@@ -55,7 +58,7 @@ internal class AndroidResourceTest {
             mockk {
                 every {
                     getString(
-                        AppIncubatingAttributes.APP_INSTALLATION_ID.key,
+                        APP_INSTALLATION_ID,
                         null,
                     )
                 } returns installId
@@ -72,19 +75,19 @@ internal class AndroidResourceTest {
         expectedResourceBuilder =
             Resource
                 .builder()
-                .put(ServiceAttributes.SERVICE_NAME, appName)
+                .put(SERVICE_NAME, appName)
                 .put(TelemetryAttributes.TELEMETRY_SDK_VERSION, rumSdkVersion)
-                .put(DeviceIncubatingAttributes.DEVICE_MODEL_NAME, Build.MODEL)
-                .put(DeviceIncubatingAttributes.DEVICE_MODEL_IDENTIFIER, Build.MODEL)
-                .put(DeviceIncubatingAttributes.DEVICE_MANUFACTURER, Build.MANUFACTURER)
-                .put(OsIncubatingAttributes.OS_NAME, "Android")
-                .put(OsIncubatingAttributes.OS_TYPE, "linux")
-                .put(OsIncubatingAttributes.OS_VERSION, Build.VERSION.RELEASE)
+                .put(DeviceAttributes.DEVICE_MODEL_NAME, Build.MODEL)
+                .put(DeviceAttributes.DEVICE_MODEL_IDENTIFIER, Build.MODEL)
+                .put(DeviceAttributes.DEVICE_MANUFACTURER, Build.MANUFACTURER)
+                .put(OsAttributes.OS_NAME, "Android")
+                .put(OsAttributes.OS_TYPE, "linux")
+                .put(OsAttributes.OS_VERSION, Build.VERSION.RELEASE)
                 .put(
-                    AndroidIncubatingAttributes.ANDROID_OS_API_LEVEL,
+                    AndroidAttributes.ANDROID_OS_API_LEVEL,
                     Build.VERSION.SDK_INT.toString(),
-                ).put(OsIncubatingAttributes.OS_DESCRIPTION, osDescription)
-                .put(AppIncubatingAttributes.APP_INSTALLATION_ID, installId)
+                ).put(OsAttributes.OS_DESCRIPTION, osDescription)
+                .put(APP_INSTALLATION_ID, installId)
     }
 
     @Test
@@ -102,7 +105,7 @@ internal class AndroidResourceTest {
         every { ctx.applicationContext.applicationInfo } returns appInfo
 
         assertResourceMatches(
-            extraAttributes = mapOf(ServiceAttributes.SERVICE_NAME to "shim sham"),
+            extraAttributes = mapOf(stringKey(SERVICE_NAME) to "shim sham"),
         )
     }
 
@@ -112,10 +115,11 @@ internal class AndroidResourceTest {
         every { ctx.applicationContext.resources } throws SecurityException("boom")
 
         assertResourceMatches(
-            extraAttributes = mapOf(ServiceAttributes.SERVICE_NAME to "unknown_service:android"),
+            extraAttributes = mapOf(stringKey(SERVICE_NAME) to "unknown_service:android"),
         )
     }
 
+    @OptIn(IncubatingApi::class)
     @Test
     fun `test install id generated if none available`() {
         val slot = slot<String>()
@@ -125,7 +129,7 @@ internal class AndroidResourceTest {
             mockk {
                 every {
                     getString(
-                        AppIncubatingAttributes.APP_INSTALLATION_ID.key,
+                        APP_INSTALLATION_ID,
                         null,
                     )
                 } returns null
@@ -134,14 +138,14 @@ internal class AndroidResourceTest {
 
         every {
             editor.putString(
-                AppIncubatingAttributes.APP_INSTALLATION_ID.key,
+                APP_INSTALLATION_ID,
                 capture(slot),
             )
         } returns editor
 
         assertResourceMatches(
             resource = AndroidResource.createDefault(ctx),
-            extraAttributes = mapOf(AppIncubatingAttributes.APP_INSTALLATION_ID to slot.captured),
+            extraAttributes = mapOf(stringKey(APP_INSTALLATION_ID) to slot.captured),
         )
         assertNotNull(UUID.fromString(slot.captured))
     }

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.kt
@@ -34,11 +34,13 @@ import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTra
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.context.propagation.TextMapGetter
 import io.opentelemetry.context.propagation.TextMapPropagator
 import io.opentelemetry.contrib.disk.buffering.exporters.SpanToDiskExporter
+import io.opentelemetry.kotlin.semconv.IncubatingApi
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.common.CompletableResultCode
 import io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder
@@ -63,7 +65,7 @@ import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
 import io.opentelemetry.sdk.trace.SdkTracerProviderBuilder
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
 import io.opentelemetry.sdk.trace.export.SpanExporter
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import io.opentelemetry.kotlin.semconv.SessionAttributes.SESSION_ID
 import java.io.IOException
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicBoolean
@@ -77,6 +79,7 @@ import org.junit.Ignore
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@OptIn(IncubatingApi::class)
 @RunWith(AndroidJUnit4::class)
 class OpenTelemetryRumBuilderTest {
     private val resource: Resource =
@@ -153,7 +156,7 @@ class OpenTelemetryRumBuilderTest {
                     .hasResource(resource)
                     .hasAttributesSatisfyingExactly(
                         OpenTelemetryAssertions.equalTo(
-                            SessionIncubatingAttributes.SESSION_ID,
+                            stringKey(SESSION_ID),
                             sessionId,
                         ),
                         OpenTelemetryAssertions.equalTo(
@@ -191,7 +194,7 @@ class OpenTelemetryRumBuilderTest {
             .assertThat(logs[0])
             .hasAttributesSatisfyingExactly(
                 OpenTelemetryAssertions.equalTo(
-                    SessionIncubatingAttributes.SESSION_ID,
+                    stringKey(SESSION_ID),
                     openTelemetryRum.sessionProvider.getSessionId(),
                 ),
                 OpenTelemetryAssertions.equalTo(SCREEN_NAME_KEY, CUR_SCREEN_NAME),
@@ -465,7 +468,7 @@ class OpenTelemetryRumBuilderTest {
                 OpenTelemetryAssertions.equalTo(AttributeKey.stringKey("bing"), "bang"),
                 OpenTelemetryAssertions.equalTo(SCREEN_NAME_KEY, CUR_SCREEN_NAME),
                 OpenTelemetryAssertions.equalTo(
-                    SessionIncubatingAttributes.SESSION_ID,
+                    stringKey(SESSION_ID),
                     rum.sessionProvider.getSessionId(),
                 ),
             ).hasSeverity(Severity.FATAL3)
@@ -586,7 +589,7 @@ class OpenTelemetryRumBuilderTest {
         val otelRumConfig = buildConfig()
         otelRumConfig.setGlobalAttributes {
             Attributes.of(
-                AttributeKey.stringKey("someGlobalKey"),
+                stringKey("someGlobalKey"),
                 "someGlobalValue",
             )
         }
@@ -619,7 +622,7 @@ class OpenTelemetryRumBuilderTest {
             .hasAttributes(
                 Attributes
                     .builder()
-                    .put(SessionIncubatingAttributes.SESSION_ID, rum.sessionProvider.getSessionId())
+                    .put(SESSION_ID, rum.sessionProvider.getSessionId())
                     .put("someGlobalKey", "someGlobalValue")
                     .put("localAttrKey", "localAttrValue")
                     .put(SCREEN_NAME_KEY, CUR_SCREEN_NAME)

--- a/core/src/test/java/io/opentelemetry/android/SessionIdSpanAppenderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/SessionIdSpanAppenderTest.kt
@@ -11,14 +11,17 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.verify
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.context.Context
+import io.opentelemetry.kotlin.semconv.IncubatingApi
 import io.opentelemetry.sdk.trace.ReadWriteSpan
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
+import io.opentelemetry.kotlin.semconv.SessionAttributes.SESSION_ID
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
+@OptIn(IncubatingApi::class)
 internal class SessionIdSpanAppenderTest {
     @MockK
     lateinit var sessionProvider: SessionProvider
@@ -40,7 +43,7 @@ internal class SessionIdSpanAppenderTest {
         assertTrue(underTest.isStartRequired)
         underTest.onStart(Context.root(), span)
 
-        verify { span.setAttribute(SessionIncubatingAttributes.SESSION_ID, "42") }
+        verify { span.setAttribute(stringKey(SESSION_ID), "42") }
 
         assertFalse(underTest.isEndRequired)
     }

--- a/core/src/test/java/io/opentelemetry/android/internal/features/networkattrs/NetworkAttributesSpanAppenderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/features/networkattrs/NetworkAttributesSpanAppenderTest.kt
@@ -13,14 +13,18 @@ import io.mockk.verify
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
 import io.opentelemetry.android.common.internal.features.networkattributes.data.NetworkState
 import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
+import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.context.Context
+import io.opentelemetry.kotlin.semconv.IncubatingApi
+import io.opentelemetry.kotlin.semconv.NetworkAttributes.NETWORK_CONNECTION_SUBTYPE
+import io.opentelemetry.kotlin.semconv.NetworkAttributes.NETWORK_CONNECTION_TYPE
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.trace.ReadWriteSpan
-import io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
+@OptIn(IncubatingApi::class)
 internal class NetworkAttributesSpanAppenderTest {
     @MockK
     lateinit var currentNetworkProvider: CurrentNetworkProvider
@@ -48,9 +52,9 @@ internal class NetworkAttributesSpanAppenderTest {
         verify {
             span.setAllAttributes(
                 Attributes.of(
-                    NetworkIncubatingAttributes.NETWORK_CONNECTION_TYPE,
+                    stringKey(NETWORK_CONNECTION_TYPE),
                     "cell",
-                    NetworkIncubatingAttributes.NETWORK_CONNECTION_SUBTYPE,
+                    stringKey(NETWORK_CONNECTION_SUBTYPE),
                     "LTE",
                 ),
             )

--- a/core/src/test/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppenderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppenderTest.kt
@@ -11,14 +11,17 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.verify
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.context.Context
+import io.opentelemetry.kotlin.semconv.IncubatingApi
+import io.opentelemetry.kotlin.semconv.SessionAttributes.SESSION_ID
 import io.opentelemetry.sdk.logs.ReadWriteLogRecord
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 private const val SESSION_ID_VALUE = "0666"
 
+@OptIn(IncubatingApi::class)
 class SessionIdLogRecordAppenderTest {
     @MockK
     lateinit var sessionProvider: SessionProvider
@@ -39,6 +42,6 @@ class SessionIdLogRecordAppenderTest {
 
         underTest.onEmit(Context.root(), log)
 
-        verify { log.setAttribute(SessionIncubatingAttributes.SESSION_ID, SESSION_ID_VALUE) }
+        verify { log.setAttribute(stringKey(SESSION_ID), SESSION_ID_VALUE) }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,8 @@
 [versions]
 opentelemetry-instrumentation-alpha = "2.28.1-alpha"
 #opentelemetry-instrumentation = "2.9.0" // alpha bom includes non-alpha bom
-opentelemetry-semconv = "1.41.1"
-opentelemetry-semconv-alpha = "1.41.1-alpha"
 opentelemetry-contrib = "1.57.0-alpha"
+opentelemetry-semconv-kotlin = "0.4.0"
 junit = "6.1.0"
 byteBuddy = "1.18.8"
 okhttp = "5.3.2"
@@ -40,8 +39,7 @@ okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 opentelemetry-instrumentation-api = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api" }
 opentelemetry-instrumentation-apiSemconv = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator", version.ref = "opentelemetry-instrumentation-alpha" }
 opentelemetry-instrumentation-okhttp = { module = "io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0", version.ref = "opentelemetry-instrumentation-alpha" }
-opentelemetry-semconv = { module = "io.opentelemetry.semconv:opentelemetry-semconv", version.ref = "opentelemetry-semconv" }
-opentelemetry-semconv-incubating = { module = "io.opentelemetry.semconv:opentelemetry-semconv-incubating", version.ref = "opentelemetry-semconv-alpha" }
+opentelemetry-semconv-kotlin = { module = "io.opentelemetry.kotlin:semconv-android", version.ref = "opentelemetry-semconv-kotlin"}
 opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api" }
 opentelemetry-api-incubator = { module = "io.opentelemetry:opentelemetry-api-incubator" }
 opentelemetry-sdk-extension-incubator = { module = "io.opentelemetry:opentelemetry-sdk-extension-incubator" }

--- a/instrumentation/anr/build.gradle.kts
+++ b/instrumentation/anr/build.gradle.kts
@@ -24,8 +24,7 @@ dependencies {
     implementation(project(":instrumentation:common-api"))
     implementation(project(":common"))
     implementation(libs.androidx.core)
-    implementation(libs.opentelemetry.semconv)
+    implementation(libs.opentelemetry.semconv.kotlin)
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.instrumentation.api)
-    implementation(libs.opentelemetry.semconv.incubating)
 }

--- a/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrWatcher.kt
+++ b/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrWatcher.kt
@@ -11,9 +11,10 @@ import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.context.Context
-import io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE
-import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID
-import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME
+import io.opentelemetry.kotlin.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE
+import io.opentelemetry.kotlin.semconv.IncubatingApi
+import io.opentelemetry.kotlin.semconv.ThreadAttributes.THREAD_ID
+import io.opentelemetry.kotlin.semconv.ThreadAttributes.THREAD_NAME
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.SECONDS
@@ -73,6 +74,7 @@ internal class AnrWatcher(
         }
     }
 
+    @OptIn(IncubatingApi::class)
     private fun emitAnrEvent(stackTrace: Array<StackTraceElement>) {
         @Suppress("DEPRECATION")
         val id = mainThread.threadIdCompat

--- a/instrumentation/compose/click/build.gradle.kts
+++ b/instrumentation/compose/click/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
         exclude(group = "androidx.savedstate")
     }
     implementation(libs.opentelemetry.instrumentation.apiSemconv)
-    implementation(libs.opentelemetry.semconv.incubating)
+    implementation(libs.opentelemetry.semconv.kotlin)
 
     testImplementation(project(":test-common"))
     testImplementation(project(":session"))

--- a/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGenerator.kt
+++ b/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGenerator.kt
@@ -13,10 +13,11 @@ import androidx.compose.ui.node.LayoutNode
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.LogRecordBuilder
 import io.opentelemetry.api.logs.Logger
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_X
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_Y
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_ID
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_NAME
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_COORDINATE_X
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_COORDINATE_Y
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_WIDGET_ID
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_WIDGET_NAME
+import io.opentelemetry.kotlin.semconv.IncubatingApi
 import java.lang.ref.WeakReference
 import kotlin.let
 
@@ -33,6 +34,7 @@ internal class ComposeClickEventGenerator(
         window.callback = WindowCallbackWrapper(currentCallback, this)
     }
 
+    @OptIn(IncubatingApi::class)
     fun generateClick(motionEvent: MotionEvent?) {
         windowRef?.get()?.let { window ->
             if (motionEvent != null && motionEvent.actionMasked == MotionEvent.ACTION_UP) {
@@ -65,6 +67,7 @@ internal class ComposeClickEventGenerator(
             .logRecordBuilder()
             .setEventName(name)
 
+    @OptIn(IncubatingApi::class)
     private fun createNodeAttributes(node: LayoutNode): Attributes {
         val builder = Attributes.builder()
         builder.put(APP_WIDGET_NAME, composeTapTargetDetector.nodeToName(node))

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGeneratorTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGeneratorTest.kt
@@ -29,18 +29,22 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockkClass
+import io.opentelemetry.api.common.AttributeKey.longKey
+import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_X
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_Y
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_ID
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_NAME
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_COORDINATE_X
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_COORDINATE_Y
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_WIDGET_ID
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_WIDGET_NAME
+import io.opentelemetry.kotlin.semconv.IncubatingApi
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@OptIn(IncubatingApi::class)
 @RunWith(AndroidJUnit4::class)
 internal class ComposeClickEventGeneratorTest {
     private lateinit var openTelemetryRule: OpenTelemetryRule
@@ -111,16 +115,16 @@ internal class ComposeClickEventGeneratorTest {
             .assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, motionEvent.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), motionEvent.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), motionEvent.y.toLong()),
             )
 
         event = events[1]
         assertThat(event)
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfying(
-                equalTo(APP_WIDGET_ID, "2"),
-                equalTo(APP_WIDGET_NAME, "click"),
+                equalTo(stringKey(APP_WIDGET_ID), "2"),
+                equalTo(stringKey(APP_WIDGET_NAME), "click"),
             )
     }
 
@@ -148,16 +152,16 @@ internal class ComposeClickEventGeneratorTest {
             .assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, motionEvent.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), motionEvent.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), motionEvent.y.toLong()),
             )
 
         event = events[1]
         assertThat(event)
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfying(
-                equalTo(APP_WIDGET_ID, "3"),
-                equalTo(APP_WIDGET_NAME, "click"),
+                equalTo(stringKey(APP_WIDGET_ID), "3"),
+                equalTo(stringKey(APP_WIDGET_NAME), "click"),
             )
     }
 
@@ -186,16 +190,16 @@ internal class ComposeClickEventGeneratorTest {
             .assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, motionEvent.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), motionEvent.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), motionEvent.y.toLong()),
             )
 
         event = events[1]
         assertThat(event)
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfying(
-                equalTo(APP_WIDGET_ID, "3"),
-                equalTo(APP_WIDGET_NAME, "clickMe"),
+                equalTo(stringKey(APP_WIDGET_ID), "3"),
+                equalTo(stringKey(APP_WIDGET_NAME), "clickMe"),
             )
     }
 

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
@@ -41,18 +41,22 @@ import io.mockk.slot
 import io.mockk.verify
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.session.SessionProvider
+import io.opentelemetry.api.common.AttributeKey.longKey
+import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_X
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_Y
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_ID
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_NAME
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_COORDINATE_X
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_COORDINATE_Y
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_WIDGET_ID
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_WIDGET_NAME
+import io.opentelemetry.kotlin.semconv.IncubatingApi
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
+@OptIn(IncubatingApi::class)
 @RunWith(AndroidJUnit4::class)
 internal class ComposeInstrumentationTest {
     private lateinit var openTelemetryRule: OpenTelemetryRule
@@ -152,16 +156,16 @@ internal class ComposeInstrumentationTest {
         assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, motionEvent.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), motionEvent.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), motionEvent.y.toLong()),
             )
 
         event = events[1]
         assertThat(event)
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfying(
-                equalTo(APP_WIDGET_ID, mockLayoutNode.semanticsId.toString()),
-                equalTo(APP_WIDGET_NAME, "clickMe"),
+                equalTo(stringKey(APP_WIDGET_ID), mockLayoutNode.semanticsId.toString()),
+                equalTo(stringKey(APP_WIDGET_NAME), "clickMe"),
             )
     }
 

--- a/instrumentation/crash/build.gradle.kts
+++ b/instrumentation/crash/build.gradle.kts
@@ -22,7 +22,7 @@ dependencies {
     implementation(project(":instrumentation:common-api"))
     implementation(project(":agent-api"))
     implementation(libs.androidx.core)
-    implementation(libs.opentelemetry.semconv.incubating)
+    implementation(libs.opentelemetry.semconv.kotlin)
     implementation(libs.opentelemetry.instrumentation.api)
     testImplementation(libs.awaitility)
     testImplementation(libs.robolectric)

--- a/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.kt
+++ b/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.kt
@@ -10,11 +10,12 @@ import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.context.Context
-import io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_MESSAGE
-import io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE
-import io.opentelemetry.semconv.ExceptionAttributes.EXCEPTION_TYPE
-import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_ID
-import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes.THREAD_NAME
+import io.opentelemetry.kotlin.semconv.ExceptionAttributes.EXCEPTION_MESSAGE
+import io.opentelemetry.kotlin.semconv.ExceptionAttributes.EXCEPTION_STACKTRACE
+import io.opentelemetry.kotlin.semconv.ExceptionAttributes.EXCEPTION_TYPE
+import io.opentelemetry.kotlin.semconv.IncubatingApi
+import io.opentelemetry.kotlin.semconv.ThreadAttributes.THREAD_ID
+import io.opentelemetry.kotlin.semconv.ThreadAttributes.THREAD_NAME
 
 internal class CrashReporter(
     additionalExtractors: List<EventAttributesExtractor<CrashDetails>>,
@@ -33,6 +34,7 @@ internal class CrashReporter(
         Thread.setDefaultUncaughtExceptionHandler(handler)
     }
 
+    @OptIn(IncubatingApi::class)
     private fun processCrash(
         openTelemetry: OpenTelemetry,
         crashDetails: CrashDetails,

--- a/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReportIntegrationTest.kt
+++ b/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReportIntegrationTest.kt
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+@file:OptIn(IncubatingApi::class)
+
 package io.opentelemetry.android.instrumentation.crash
 
 import android.app.Application
@@ -17,8 +19,9 @@ import io.opentelemetry.api.logs.Severity
 import io.opentelemetry.context.Context
 import io.opentelemetry.sdk.logs.data.LogRecordData
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
-import io.opentelemetry.semconv.ExceptionAttributes
-import io.opentelemetry.semconv.incubating.ThreadIncubatingAttributes
+import io.opentelemetry.kotlin.semconv.ExceptionAttributes
+import io.opentelemetry.kotlin.semconv.IncubatingApi
+import io.opentelemetry.kotlin.semconv.ThreadAttributes
 import java.io.PrintWriter
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
@@ -202,11 +205,11 @@ internal class CrashReportIntegrationTest {
         assertEquals(Severity.UNDEFINED_SEVERITY_NUMBER, severity)
 
         val attrs = attributes.asMap().mapKeys { it.key.key }
-        assertEquals(expectedStacktrace, attrs[ExceptionAttributes.EXCEPTION_STACKTRACE.key])
-        assertEquals(expectedExcType, attrs[ExceptionAttributes.EXCEPTION_TYPE.key])
-        assertEquals(expectedExcMessage, attrs[ExceptionAttributes.EXCEPTION_MESSAGE.key])
-        assertEquals(thread.threadIdCompat, attrs[ThreadIncubatingAttributes.THREAD_ID.key])
-        assertEquals(thread.name, attrs[ThreadIncubatingAttributes.THREAD_NAME.key])
+        assertEquals(expectedStacktrace, attrs[ExceptionAttributes.EXCEPTION_STACKTRACE])
+        assertEquals(expectedExcType, attrs[ExceptionAttributes.EXCEPTION_TYPE])
+        assertEquals(expectedExcMessage, attrs[ExceptionAttributes.EXCEPTION_MESSAGE])
+        assertEquals(thread.threadIdCompat, attrs[ThreadAttributes.THREAD_ID])
+        assertEquals(thread.name, attrs[ThreadAttributes.THREAD_NAME])
         assertNotNull(attrs["heap.free"])
         assertNotNull(attrs["storage.free"])
     }

--- a/instrumentation/network/build.gradle.kts
+++ b/instrumentation/network/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     implementation(project(":common"))
     implementation(project(":agent-api"))
     implementation(libs.androidx.core)
-    implementation(libs.opentelemetry.semconv.incubating)
+    implementation(libs.opentelemetry.semconv.kotlin)
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.instrumentation.api)
     testImplementation(project(":test-common"))

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeAttributesExtractor.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeAttributesExtractor.kt
@@ -9,11 +9,13 @@ import io.opentelemetry.android.common.internal.features.networkattributes.Curre
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
 import io.opentelemetry.android.common.internal.features.networkattributes.data.NetworkState
 import io.opentelemetry.api.common.AttributesBuilder
-import io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes
+import io.opentelemetry.kotlin.semconv.IncubatingApi
+import io.opentelemetry.kotlin.semconv.NetworkAttributes
 
 internal class NetworkChangeAttributesExtractor : NetworkAttributesExtractor {
     private val networkAttributesExtractor = CurrentNetworkAttributesExtractor()
 
+    @OptIn(IncubatingApi::class)
     override fun invoke(
         attributesBuilder: AttributesBuilder,
         currentNetwork: CurrentNetwork,
@@ -27,7 +29,7 @@ internal class NetworkChangeAttributesExtractor : NetworkAttributesExtractor {
         attributesBuilder.put(NETWORK_STATUS_KEY, status)
         if (currentNetwork.state == NetworkState.NO_NETWORK_AVAILABLE) {
             attributesBuilder.put(
-                NetworkIncubatingAttributes.NETWORK_CONNECTION_TYPE,
+                NetworkAttributes.NETWORK_CONNECTION_TYPE,
                 currentNetwork.state.humanName,
             )
         } else {

--- a/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentationTest.kt
+++ b/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentationTest.kt
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+@file:OptIn(IncubatingApi::class)
+
 package io.opentelemetry.android.instrumentation.network
 
 import android.app.Application
@@ -25,11 +27,18 @@ import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateL
 import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
 import io.opentelemetry.android.internal.services.network.NetworkChangeListener
 import io.opentelemetry.android.session.SessionProvider
+import io.opentelemetry.api.common.AttributeKey.stringKey
+import io.opentelemetry.kotlin.semconv.IncubatingApi
 import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
-import io.opentelemetry.semconv.incubating.NetworkIncubatingAttributes
+import io.opentelemetry.kotlin.semconv.NetworkAttributes.NETWORK_CARRIER_ICC
+import io.opentelemetry.kotlin.semconv.NetworkAttributes.NETWORK_CARRIER_MCC
+import io.opentelemetry.kotlin.semconv.NetworkAttributes.NETWORK_CARRIER_MNC
+import io.opentelemetry.kotlin.semconv.NetworkAttributes.NETWORK_CARRIER_NAME
+import io.opentelemetry.kotlin.semconv.NetworkAttributes.NETWORK_CONNECTION_SUBTYPE
+import io.opentelemetry.kotlin.semconv.NetworkAttributes.NETWORK_CONNECTION_TYPE
 import org.junit.Before
 import org.junit.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -74,7 +83,7 @@ class NetworkChangeInstrumentationTest {
             .hasEventName("network.change")
             .hasAttributesSatisfyingExactly(
                 equalTo(NETWORK_STATUS_KEY, "available"),
-                equalTo(NetworkIncubatingAttributes.NETWORK_CONNECTION_TYPE, "wifi"),
+                equalTo(stringKey(NETWORK_CONNECTION_TYPE), "wifi"),
             )
     }
 
@@ -105,12 +114,12 @@ class NetworkChangeInstrumentationTest {
             .hasEventName("network.change")
             .hasAttributesSatisfyingExactly(
                 equalTo(NETWORK_STATUS_KEY, "available"),
-                equalTo(NetworkIncubatingAttributes.NETWORK_CONNECTION_TYPE, "cell"),
-                equalTo(NetworkIncubatingAttributes.NETWORK_CONNECTION_SUBTYPE, "LTE"),
-                equalTo(NetworkIncubatingAttributes.NETWORK_CARRIER_NAME, "ShadyTel"),
-                equalTo(NetworkIncubatingAttributes.NETWORK_CARRIER_ICC, "US"),
-                equalTo(NetworkIncubatingAttributes.NETWORK_CARRIER_MCC, "usa"),
-                equalTo(NetworkIncubatingAttributes.NETWORK_CARRIER_MNC, "omg"),
+                equalTo(stringKey(NETWORK_CONNECTION_TYPE), "cell"),
+                equalTo(stringKey(NETWORK_CONNECTION_SUBTYPE), "LTE"),
+                equalTo(stringKey(NETWORK_CARRIER_NAME), "ShadyTel"),
+                equalTo(stringKey(NETWORK_CARRIER_ICC), "US"),
+                equalTo(stringKey(NETWORK_CARRIER_MCC), "usa"),
+                equalTo(stringKey(NETWORK_CARRIER_MNC), "omg"),
             )
     }
 
@@ -134,7 +143,7 @@ class NetworkChangeInstrumentationTest {
             .hasEventName("network.change")
             .hasAttributesSatisfyingExactly(
                 equalTo(NETWORK_STATUS_KEY, "lost"),
-                equalTo(NetworkIncubatingAttributes.NETWORK_CONNECTION_TYPE, "unavailable"),
+                equalTo(stringKey(NETWORK_CONNECTION_TYPE), "unavailable"),
             )
     }
 
@@ -174,7 +183,7 @@ class NetworkChangeInstrumentationTest {
             .hasEventName("network.change")
             .hasAttributesSatisfyingExactly(
                 equalTo(NETWORK_STATUS_KEY, "lost"),
-                equalTo(NetworkIncubatingAttributes.NETWORK_CONNECTION_TYPE, "unavailable"),
+                equalTo(stringKey(NETWORK_CONNECTION_TYPE), "unavailable"),
             )
     }
 

--- a/instrumentation/sessions/build.gradle.kts
+++ b/instrumentation/sessions/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     implementation(project(":agent-api"))
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(libs.opentelemetry.sdk)
-    implementation(libs.opentelemetry.semconv.incubating)
+    implementation(libs.opentelemetry.semconv.kotlin)
     implementation(project(":core"))
     implementation(project(":common"))
     implementation(project(":session"))

--- a/instrumentation/sessions/src/main/kotlin/io/opentelemetry/android/instrumentation/sessions/SessionIdEventSender.kt
+++ b/instrumentation/sessions/src/main/kotlin/io/opentelemetry/android/instrumentation/sessions/SessionIdEventSender.kt
@@ -8,8 +8,8 @@ package io.opentelemetry.android.instrumentation.sessions
 import io.opentelemetry.android.session.Session
 import io.opentelemetry.android.session.SessionObserver
 import io.opentelemetry.api.logs.Logger
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes.SESSION_ID
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes.SESSION_PREVIOUS_ID
+import io.opentelemetry.kotlin.semconv.SessionAttributes.SESSION_ID
+import io.opentelemetry.kotlin.semconv.SessionAttributes.SESSION_PREVIOUS_ID
 
 /**
  * This class is responsible for generating the session related events as

--- a/instrumentation/sessions/src/test/kotlin/io/opentelemetry/android/instrumentation/sessions/SessionIdEventSenderTest.kt
+++ b/instrumentation/sessions/src/test/kotlin/io/opentelemetry/android/instrumentation/sessions/SessionIdEventSenderTest.kt
@@ -8,16 +8,19 @@ package io.opentelemetry.android.instrumentation.sessions
 import io.opentelemetry.android.instrumentation.sessions.SessionIdEventSender.Companion.EVENT_SESSION_END
 import io.opentelemetry.android.instrumentation.sessions.SessionIdEventSender.Companion.EVENT_SESSION_START
 import io.opentelemetry.android.session.Session
+import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.api.logs.Logger
+import io.opentelemetry.kotlin.semconv.IncubatingApi
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes.SESSION_ID
-import io.opentelemetry.semconv.incubating.SessionIncubatingAttributes.SESSION_PREVIOUS_ID
+import io.opentelemetry.kotlin.semconv.SessionAttributes.SESSION_ID
+import io.opentelemetry.kotlin.semconv.SessionAttributes.SESSION_PREVIOUS_ID
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
+@OptIn(IncubatingApi::class)
 class SessionIdEventSenderTest {
     private lateinit var logger: Logger
 
@@ -45,8 +48,8 @@ class SessionIdEventSenderTest {
         assertThat(otelTesting.logRecords).hasSize(1)
         val event = otelTesting.logRecords[0]
         assertThat(event.eventName).isEqualTo(EVENT_SESSION_START)
-        assertThat(event.attributes.get(SESSION_ID)).isEqualTo(newSession.id)
-        assertThat(event.attributes.get(SESSION_PREVIOUS_ID)).isNull()
+        assertThat(event.attributes.get(stringKey(SESSION_ID))).isEqualTo(newSession.id)
+        assertThat(event.attributes.get(stringKey(SESSION_PREVIOUS_ID))).isNull()
     }
 
     @Test
@@ -58,8 +61,8 @@ class SessionIdEventSenderTest {
         assertThat(otelTesting.logRecords).hasSize(1)
         val event = otelTesting.logRecords[0]
         assertThat(event.eventName).isEqualTo(EVENT_SESSION_START)
-        assertThat(event.attributes.get(SESSION_ID)).isEqualTo(newSession.id)
-        assertThat(event.attributes.get(SESSION_PREVIOUS_ID)).isEqualTo(previousSession.id)
+        assertThat(event.attributes.get(stringKey(SESSION_ID))).isEqualTo(newSession.id)
+        assertThat(event.attributes.get(stringKey(SESSION_PREVIOUS_ID))).isEqualTo(previousSession.id)
     }
 
     @Test
@@ -70,8 +73,8 @@ class SessionIdEventSenderTest {
         assertThat(otelTesting.logRecords).hasSize(1)
         val event = otelTesting.logRecords[0]
         assertThat(event.eventName).isEqualTo(EVENT_SESSION_END)
-        assertThat(event.attributes.get(SESSION_ID)).isEqualTo(session.id)
-        assertThat(event.attributes.get(SESSION_PREVIOUS_ID)).isNull()
+        assertThat(event.attributes.get(stringKey(SESSION_ID))).isEqualTo(session.id)
+        assertThat(event.attributes.get(stringKey(SESSION_PREVIOUS_ID))).isNull()
     }
 
     @Test

--- a/instrumentation/slowrendering/build.gradle.kts
+++ b/instrumentation/slowrendering/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
     implementation(project(":common"))
     implementation(project(":agent-api"))
     implementation(libs.androidx.core)
-    implementation(libs.opentelemetry.semconv)
+    implementation(libs.opentelemetry.semconv.kotlin)
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.instrumentation.api)
     testImplementation(libs.robolectric)

--- a/instrumentation/startup/build.gradle.kts
+++ b/instrumentation/startup/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation(project(":services"))
     implementation(project(":session"))
     implementation(libs.androidx.core)
-    implementation(libs.opentelemetry.semconv)
+    implementation(libs.opentelemetry.semconv.kotlin)
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.instrumentation.api)
     testImplementation(project(":test-common"))

--- a/instrumentation/view-click/build.gradle.kts
+++ b/instrumentation/view-click/build.gradle.kts
@@ -20,7 +20,7 @@ dependencies {
     implementation(project(":instrumentation:android-instrumentation"))
 
     implementation(libs.opentelemetry.instrumentation.apiSemconv)
-    implementation(libs.opentelemetry.semconv.incubating)
+    implementation(libs.opentelemetry.semconv.kotlin)
 
     testImplementation(project(":test-common"))
     testImplementation(project(":session"))

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
@@ -18,10 +18,11 @@ import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_LONG_PR
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.LogRecordBuilder
 import io.opentelemetry.api.logs.Logger
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_X
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_Y
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_ID
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_NAME
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_COORDINATE_X
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_COORDINATE_Y
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_WIDGET_ID
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_WIDGET_NAME
+import io.opentelemetry.kotlin.semconv.IncubatingApi
 import java.lang.ref.WeakReference
 import java.util.LinkedList
 
@@ -30,6 +31,7 @@ internal class ViewClickEventGenerator(
 ) {
     private var windowRef: WeakReference<Window>? = null
 
+    @OptIn(IncubatingApi::class)
     private val gestureListener = object : GestureDetector.SimpleOnGestureListener() {
 
 
@@ -128,6 +130,7 @@ internal class ViewClickEventGenerator(
     }
 
 
+    @OptIn(IncubatingApi::class)
     private fun createViewAttributes(view: View): Attributes {
         val builder = Attributes.builder()
         builder.put(APP_WIDGET_NAME, viewToName(view))

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+@file:OptIn(IncubatingApi::class)
+
 package io.opentelemetry.android.instrumentation.view.click
 
 import android.app.Activity
@@ -38,10 +40,11 @@ import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_X
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_Y
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_ID
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_NAME
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_COORDINATE_X
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_COORDINATE_Y
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_WIDGET_ID
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_WIDGET_NAME
+import io.opentelemetry.kotlin.semconv.IncubatingApi
 import mockView
 import org.junit.Before
 import org.junit.Test
@@ -126,8 +129,8 @@ class ViewClickInstrumentationTest {
         assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, motionEvent.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), motionEvent.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), motionEvent.y.toLong()),
                 equalTo(clicksKey, 1.toLong()),
                 equalTo(toolTypeKey, "finger")
             )
@@ -136,10 +139,10 @@ class ViewClickInstrumentationTest {
         assertThat(event)
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, mockView.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, mockView.y.toLong()),
-                equalTo(APP_WIDGET_ID, mockView.id.toString()),
-                equalTo(APP_WIDGET_NAME, "10012"),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
+                equalTo(stringKey(APP_WIDGET_ID), mockView.id.toString()),
+                equalTo(stringKey(APP_WIDGET_NAME), "10012"),
                 equalTo(clicksKey, 1.toLong()),
                 equalTo(toolTypeKey, "finger")
             )
@@ -197,8 +200,8 @@ class ViewClickInstrumentationTest {
         assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, motionEvent.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), motionEvent.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), motionEvent.y.toLong()),
                 equalTo(clicksKey, 1.toLong()),
                 equalTo(toolTypeKey, "finger")
             )
@@ -207,10 +210,10 @@ class ViewClickInstrumentationTest {
         assertThat(event)
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, mockView.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, mockView.y.toLong()),
-                equalTo(APP_WIDGET_ID, mockView.id.toString()),
-                equalTo(APP_WIDGET_NAME, "10012"),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
+                equalTo(stringKey(APP_WIDGET_ID), mockView.id.toString()),
+                equalTo(stringKey(APP_WIDGET_NAME), "10012"),
                 equalTo(clicksKey, 1.toLong()),
                 equalTo(toolTypeKey, "finger")
             )
@@ -271,8 +274,8 @@ class ViewClickInstrumentationTest {
         assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, motionEvent.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), motionEvent.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), motionEvent.y.toLong()),
                 equalTo(clicksKey, 1.toLong()),
                 equalTo(toolTypeKey, "finger")
             )
@@ -367,8 +370,8 @@ class ViewClickInstrumentationTest {
         OpenTelemetryAssertions.assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, initialDownEvent.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, initialDownEvent.y.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), initialDownEvent.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), initialDownEvent.y.toLong()),
                 equalTo(clicksKey, 2.toLong()),
                 equalTo(toolTypeKey, "finger")
             )
@@ -377,10 +380,10 @@ class ViewClickInstrumentationTest {
         OpenTelemetryAssertions.assertThat(event)
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, mockView.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, mockView.y.toLong()),
-                equalTo(APP_WIDGET_ID, mockView.id.toString()),
-                equalTo(APP_WIDGET_NAME, "10012"),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
+                equalTo(stringKey(APP_WIDGET_ID), mockView.id.toString()),
+                equalTo(stringKey(APP_WIDGET_NAME), "10012"),
                 equalTo(clicksKey, 2.toLong()),
                 equalTo(toolTypeKey, "finger")
             )
@@ -434,8 +437,8 @@ class ViewClickInstrumentationTest {
         OpenTelemetryAssertions.assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, initialDownEvent.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, initialDownEvent.y.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), initialDownEvent.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), initialDownEvent.y.toLong()),
                 equalTo(clicksKey, 2.toLong()),
                 equalTo(toolTypeKey, "mouse"),
                 equalTo(buttonKey, "primary")
@@ -445,10 +448,10 @@ class ViewClickInstrumentationTest {
         OpenTelemetryAssertions.assertThat(event)
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, mockView.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, mockView.y.toLong()),
-                equalTo(APP_WIDGET_ID, mockView.id.toString()),
-                equalTo(APP_WIDGET_NAME, "10012"),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
+                equalTo(stringKey(APP_WIDGET_ID), mockView.id.toString()),
+                equalTo(stringKey(APP_WIDGET_NAME), "10012"),
                 equalTo(clicksKey, 2.toLong()),
                 equalTo(toolTypeKey, "mouse"),
                 equalTo(buttonKey, "primary")
@@ -503,8 +506,8 @@ class ViewClickInstrumentationTest {
         assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, motionEvent.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), motionEvent.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), motionEvent.y.toLong()),
                 equalTo(clicksKey, 1.toLong()),
                 equalTo(toolTypeKey, "stylus"),
                 equalTo(buttonKey, "secondary")
@@ -514,10 +517,10 @@ class ViewClickInstrumentationTest {
         assertThat(event)
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, mockView.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, mockView.y.toLong()),
-                equalTo(APP_WIDGET_ID, mockView.id.toString()),
-                equalTo(APP_WIDGET_NAME, "10012"),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
+                equalTo(stringKey(APP_WIDGET_ID), mockView.id.toString()),
+                equalTo(stringKey(APP_WIDGET_NAME), "10012"),
                 equalTo(clicksKey, 1.toLong()),
                 equalTo(toolTypeKey, "stylus"),
                 equalTo(buttonKey, "secondary")
@@ -577,8 +580,8 @@ class ViewClickInstrumentationTest {
         assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, initialDownEvent.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, initialDownEvent.y.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), initialDownEvent.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), initialDownEvent.y.toLong()),
                 equalTo(clicksKey, 1.toLong()),
                 equalTo(toolTypeKey, "finger")
             )
@@ -587,10 +590,10 @@ class ViewClickInstrumentationTest {
         assertThat(event)
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, mockView.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, mockView.y.toLong()),
-                equalTo(APP_WIDGET_ID, mockView.id.toString()),
-                equalTo(APP_WIDGET_NAME, "10012"),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
+                equalTo(stringKey(APP_WIDGET_ID), mockView.id.toString()),
+                equalTo(stringKey(APP_WIDGET_NAME), "10012"),
                 equalTo(clicksKey, 1.toLong()),
                 equalTo(toolTypeKey, "finger")
             )
@@ -649,8 +652,8 @@ class ViewClickInstrumentationTest {
         OpenTelemetryAssertions.assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, initialDownEvent.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, initialDownEvent.y.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), initialDownEvent.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), initialDownEvent.y.toLong()),
                 equalTo(clicksKey, 2.toLong()),
                 equalTo(toolTypeKey, "finger")
             )
@@ -709,8 +712,8 @@ class ViewClickInstrumentationTest {
         OpenTelemetryAssertions.assertThat(event)
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, initialDownEvent.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, initialDownEvent.y.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), initialDownEvent.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), initialDownEvent.y.toLong()),
                 equalTo(clicksKey, 2.toLong()),
                 equalTo(toolTypeKey, "finger")
             )
@@ -719,10 +722,10 @@ class ViewClickInstrumentationTest {
         OpenTelemetryAssertions.assertThat(event)
             .hasEventName(VIEW_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, mockView.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, mockView.y.toLong()),
-                equalTo(APP_WIDGET_ID, mockView.id.toString()),
-                equalTo(APP_WIDGET_NAME, "10012"),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
+                equalTo(stringKey(APP_WIDGET_ID), mockView.id.toString()),
+                equalTo(stringKey(APP_WIDGET_NAME), "10012"),
                 equalTo(clicksKey, 2.toLong()),
                 equalTo(toolTypeKey, "finger")
             )

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewLongPressInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewLongPressInstrumentationTest.kt
@@ -26,22 +26,25 @@ import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_L
 import io.opentelemetry.android.instrumentation.view.click.internal.HARDWARE_POINTER_TYPE
 import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_LONG_PRESS_EVENT_NAME
 import io.opentelemetry.android.session.SessionProvider
+import io.opentelemetry.api.common.AttributeKey.longKey
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_X
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_SCREEN_COORDINATE_Y
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_ID
-import io.opentelemetry.semconv.incubating.AppIncubatingAttributes.APP_WIDGET_NAME
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_COORDINATE_X
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_COORDINATE_Y
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_WIDGET_ID
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_WIDGET_NAME
+import io.opentelemetry.kotlin.semconv.IncubatingApi
 import mockView
 import org.junit.Before
 import org.junit.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.runner.RunWith
 
+@OptIn(IncubatingApi::class)
 @RunWith(AndroidJUnit4::class)
 @ExtendWith(MockKExtension::class)
 class ViewLongPressInstrumentationTest {
@@ -119,8 +122,8 @@ class ViewLongPressInstrumentationTest {
         assertThat(event)
             .hasEventName(APP_SCREEN_LONG_PRESS_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, motionEvent.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), motionEvent.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), motionEvent.y.toLong()),
                 equalTo(toolTypeKey, "finger")
             )
 
@@ -128,10 +131,10 @@ class ViewLongPressInstrumentationTest {
         assertThat(event)
             .hasEventName(VIEW_LONG_PRESS_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, mockView.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, mockView.y.toLong()),
-                equalTo(APP_WIDGET_ID, mockView.id.toString()),
-                equalTo(APP_WIDGET_NAME, "10012"),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
+                equalTo(stringKey(APP_WIDGET_ID), mockView.id.toString()),
+                equalTo(stringKey(APP_WIDGET_NAME), "10012"),
                 equalTo(toolTypeKey, "finger")
             )
     }
@@ -187,8 +190,8 @@ class ViewLongPressInstrumentationTest {
         assertThat(event)
             .hasEventName(APP_SCREEN_LONG_PRESS_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, initialDownEvent.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, initialDownEvent.y.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), initialDownEvent.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), initialDownEvent.y.toLong()),
                 equalTo(toolTypeKey, "finger")
             )
 
@@ -196,10 +199,10 @@ class ViewLongPressInstrumentationTest {
         assertThat(event)
             .hasEventName(VIEW_LONG_PRESS_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, mockView.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, mockView.y.toLong()),
-                equalTo(APP_WIDGET_ID, mockView.id.toString()),
-                equalTo(APP_WIDGET_NAME, "10012"),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
+                equalTo(stringKey(APP_WIDGET_ID), mockView.id.toString()),
+                equalTo(stringKey(APP_WIDGET_NAME), "10012"),
                 equalTo(toolTypeKey, "finger")
             )
     }
@@ -257,8 +260,8 @@ class ViewLongPressInstrumentationTest {
         OpenTelemetryAssertions.assertThat(event)
             .hasEventName(APP_SCREEN_LONG_PRESS_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, initialDownEvent.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, initialDownEvent.y.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), initialDownEvent.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), initialDownEvent.y.toLong()),
                 equalTo(toolTypeKey, "finger")
             )
 
@@ -266,10 +269,10 @@ class ViewLongPressInstrumentationTest {
         OpenTelemetryAssertions.assertThat(event)
             .hasEventName(VIEW_LONG_PRESS_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(APP_SCREEN_COORDINATE_X, mockView.x.toLong()),
-                equalTo(APP_SCREEN_COORDINATE_Y, mockView.y.toLong()),
-                equalTo(APP_WIDGET_ID, mockView.id.toString()),
-                equalTo(APP_WIDGET_NAME, "10012"),
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
+                equalTo(stringKey(APP_WIDGET_ID), mockView.id.toString()),
+                equalTo(stringKey(APP_WIDGET_NAME), "10012"),
                 equalTo(toolTypeKey, "finger")
             )
     }


### PR DESCRIPTION
I'm not 100% sure we're ready for this, but I wanted to see what it would look like to start using the semconv that are published from the [kotlin project](https://github.com/open-telemetry/opentelemetry-kotlin). Sorry that this (obviously) touches a lot of files, but most of them are just import changes.

There are two things for the reviewer to note:

1. Kotlin doesn't currently publish separate artifacts nor use packages for incubating attributes. Instead, it uses an `@IncubatingApi` annotation.
2. Kotlin attribute keys are not typed like Java's `AttributeKey<T>` classes, they are simply strings. This means that several places require the use of `stringKey()` or `longKey()` to get the type info back into place. This may change eventually when this android project uses the kotlin api instead of the java api.