### PR TITLE
Added scroll and fling to view-click. References #1576

### DIFF
--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
@@ -11,10 +11,14 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.Window
 import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_CLICK_EVENT_NAME
+import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_FLING_EVENT_NAME
 import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_LONG_PRESS_EVENT_NAME
+import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_SCROLL_EVENT_NAME
 import io.opentelemetry.android.instrumentation.view.click.internal.Gesture
 import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_CLICK_EVENT_NAME
+import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_FLING_EVENT_NAME
 import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_LONG_PRESS_EVENT_NAME
+import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_SCROLL_EVENT_NAME
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.LogRecordBuilder
 import io.opentelemetry.api.logs.Logger
@@ -38,19 +42,21 @@ internal class ViewClickEventGenerator(
         override fun onDoubleTap(motionEvent: MotionEvent): Boolean {
             windowRef?.get()?.let { window ->
 
-
+                val safeEvent = MotionEvent.obtain(motionEvent)
                 val gesture = Gesture.Click(motionEvent, 2)
 
                 createEvent(APP_SCREEN_CLICK_EVENT_NAME, gesture)
-                    .setAttribute(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong())
-                    .setAttribute(APP_SCREEN_COORDINATE_X, motionEvent.x.toLong())
+                    .setAttribute(APP_SCREEN_COORDINATE_Y, safeEvent.y.toLong())
+                    .setAttribute(APP_SCREEN_COORDINATE_X, safeEvent.x.toLong())
                     .emit()
 
-                findTargetForTap(window.decorView, motionEvent.x, motionEvent.y)?.let { view ->
+                findTargetForTap(window.decorView, safeEvent.x, safeEvent.y)?.let { view ->
                     createEvent(VIEW_CLICK_EVENT_NAME, gesture)
                         .setAllAttributes(createViewAttributes(view))
                         .emit()
                 }
+
+                safeEvent.recycle()
 
             }
             return false
@@ -59,19 +65,20 @@ internal class ViewClickEventGenerator(
         override fun onSingleTapConfirmed(motionEvent: MotionEvent): Boolean {
             windowRef?.get()?.let { window ->
 
-
-                val gesture = Gesture.Click(motionEvent, 1)
+                val safeEvent = MotionEvent.obtain(motionEvent)
+                val gesture = Gesture.Click(safeEvent, 1)
 
                 createEvent(APP_SCREEN_CLICK_EVENT_NAME, gesture)
-                    .setAttribute(APP_SCREEN_COORDINATE_Y, motionEvent.y.toLong())
-                    .setAttribute(APP_SCREEN_COORDINATE_X, motionEvent.x.toLong())
+                    .setAttribute(APP_SCREEN_COORDINATE_Y, safeEvent.y.toLong())
+                    .setAttribute(APP_SCREEN_COORDINATE_X, safeEvent.x.toLong())
                     .emit()
 
-                findTargetForTap(window.decorView, motionEvent.x, motionEvent.y)?.let { view ->
+                findTargetForTap(window.decorView, safeEvent.x, safeEvent.y)?.let { view ->
                     createEvent(VIEW_CLICK_EVENT_NAME, gesture)
                         .setAllAttributes(createViewAttributes(view))
                         .emit()
                 }
+                safeEvent.recycle()
             }
             return false
         }
@@ -79,18 +86,66 @@ internal class ViewClickEventGenerator(
         override fun onLongPress(e: MotionEvent) {
             windowRef?.get()?.let { window ->
 
-                val gesture = Gesture.LongPress(e)
+                val safeEvent = MotionEvent.obtain(e)
+                val gesture = Gesture.LongPress(safeEvent)
                 createEvent(APP_SCREEN_LONG_PRESS_EVENT_NAME, gesture)
-                    .setAttribute(APP_SCREEN_COORDINATE_Y, e.y.toLong())
-                    .setAttribute(APP_SCREEN_COORDINATE_X, e.x.toLong())
+                    .setAttribute(APP_SCREEN_COORDINATE_Y, safeEvent.y.toLong())
+                    .setAttribute(APP_SCREEN_COORDINATE_X, safeEvent.x.toLong())
                     .emit()
 
-                findTargetForTap(window.decorView, e.x, e.y)?.let { view ->
+                findTargetForTap(window.decorView, safeEvent.x, safeEvent.y)?.let { view ->
                     createEvent(VIEW_LONG_PRESS_EVENT_NAME, gesture)
                         .setAllAttributes(createViewAttributes(view))
                         .emit()
                 }
+                safeEvent.recycle()
             }
+        }
+
+        override fun onScroll(
+            e1: MotionEvent?, e2: MotionEvent,
+            distanceX: Float, distanceY: Float
+        ): Boolean {
+            windowRef?.get()?.let { window ->
+
+                val safeEvent = MotionEvent.obtain(e2)
+                val gesture = Gesture.Scroll(safeEvent, distanceX.toDouble(), distanceY.toDouble())
+                createEvent(APP_SCREEN_SCROLL_EVENT_NAME, gesture)
+                    .setAttribute(APP_SCREEN_COORDINATE_Y, safeEvent.y.toLong())
+                    .setAttribute(APP_SCREEN_COORDINATE_X, safeEvent.x.toLong())
+                    .emit()
+
+                findTargetForTap(window.decorView, safeEvent.x, safeEvent.y)?.let { view ->
+                    createEvent(VIEW_SCROLL_EVENT_NAME, gesture)
+                        .setAllAttributes(createViewAttributes(view))
+                        .emit()
+                }
+                safeEvent.recycle()
+            }
+            return false
+        }
+
+        override fun onFling(
+            e1: MotionEvent?, e2: MotionEvent,
+            velocityX: Float, velocityY: Float
+        ): Boolean {
+            windowRef?.get()?.let { window ->
+
+                val safeEvent = MotionEvent.obtain(e2)
+                val gesture = Gesture.Fling(safeEvent, velocityX.toDouble(), velocityY.toDouble())
+                createEvent(APP_SCREEN_FLING_EVENT_NAME, gesture)
+                    .setAttribute(APP_SCREEN_COORDINATE_Y, safeEvent.y.toLong())
+                    .setAttribute(APP_SCREEN_COORDINATE_X, safeEvent.x.toLong())
+                    .emit()
+
+                findTargetForTap(window.decorView, safeEvent.x, safeEvent.y)?.let { view ->
+                    createEvent(VIEW_FLING_EVENT_NAME, gesture)
+                        .setAllAttributes(createViewAttributes(view))
+                        .emit()
+                }
+                safeEvent.recycle()
+            }
+            return false
         }
     }
 

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/internal/ViewUtils.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/internal/ViewUtils.kt
@@ -19,6 +19,24 @@ internal const val HARDWARE_POINTER_BUTTON = "hw.pointer.button"
 
 internal const val HARDWARE_POINTER_CLICKS = "hw.pointer.clicks"
 
+internal const val APP_SCREEN_SCROLL_EVENT_NAME = "app.screen.scroll"
+
+internal const val VIEW_SCROLL_EVENT_NAME = "app.widget.scroll"
+
+internal const val APP_SCREEN_FLING_EVENT_NAME = "app.screen.fling"
+
+internal const val VIEW_FLING_EVENT_NAME = "app.widget.fling"
+
+internal const val HARDWARE_POINTER_VELOCITY_X = "hw.pointer.velocity.x"
+
+internal const val HARDWARE_POINTER_VELOCITY_Y = "hw.pointer.velocity.y"
+
+
+internal const val HARDWARE_POINTER_DISTANCE_X = "hw.pointer.distance.x"
+
+
+internal const val HARDWARE_POINTER_DISTANCE_Y = "hw.pointer.distance.y"
+
 internal fun buttonStateToString(buttonStateInt: Int): String? {
     return when(buttonStateInt) {
         MotionEvent.BUTTON_PRIMARY, MotionEvent.BUTTON_STYLUS_PRIMARY -> "primary"
@@ -76,6 +94,22 @@ internal sealed class Gesture(val m: MotionEvent) {
     class Click(val motionEvent: MotionEvent, clicks: Int): Gesture(motionEvent) {
         init {
             attributes = attributes.toBuilder().put(HARDWARE_POINTER_CLICKS, clicks.toLong()).build()
+        }
+    }
+    class Fling(val motionEvent: MotionEvent, val velocityX: Double, val velocityY: Double): Gesture(motionEvent) {
+        init {
+            attributes = attributes.toBuilder()
+                .put(HARDWARE_POINTER_VELOCITY_X, velocityX)
+                .put(HARDWARE_POINTER_VELOCITY_Y, velocityY)
+                .build()
+        }
+    }
+    class Scroll(val motionEvent: MotionEvent, val distanceX: Double, val distanceY: Double): Gesture(motionEvent) {
+        init {
+            attributes = attributes.toBuilder()
+                .put(HARDWARE_POINTER_DISTANCE_X, distanceX)
+                .put(HARDWARE_POINTER_DISTANCE_Y, distanceY)
+                .build()
         }
     }
 }

--- a/instrumentation/view-click/src/test/kotlin/TestUtils.kt
+++ b/instrumentation/view-click/src/test/kotlin/TestUtils.kt
@@ -199,6 +199,55 @@ fun getLongPressSequence(x: Float, y: Float, toolType: Int = MotionEvent.TOOL_TY
     )
 }
 
+fun getScrollSequence(x: Float, y: Float, angleDegrees: Double, distance: Int,
+                      toolType: Int = MotionEvent.TOOL_TYPE_FINGER, buttonState: Int = 0,
+                      timeMillis: Long = 100L, letGo: Boolean = false)
+    : Array<MotionEvent> {
+    require(toolType in allowedToolTypes) {
+        "Invalid tool type"
+    }
+
+    if(buttonState != 0) {
+        require(toolType == MotionEvent.TOOL_TYPE_MOUSE || toolType == MotionEvent.TOOL_TYPE_STYLUS) {
+            "Invalid tool type for button state"
+        }
+        require(buttonState in allowedButtonStates) { "Invalid button state" }
+    }
+
+    val initialTime = SystemClock.uptimeMillis()
+
+    val pointerProperties = MotionEvent.PointerProperties()
+    pointerProperties.id = 0
+    pointerProperties.toolType = toolType
+
+    val startPointerCoords = PointerCoordsBuilder.newBuilder().setCoords(x, y).build()
+    val (endX, endY) = getDestinationPoint(arrayOf(x, y), distance, angleDegrees)
+    val endPointerCoords = PointerCoordsBuilder.newBuilder().setCoords(endX, endY).build()
+
+    var array = arrayOf(
+        MotionEvent.obtain(initialTime, initialTime,
+            MotionEvent.ACTION_DOWN, 1, arrayOf(pointerProperties),
+            arrayOf(startPointerCoords), 0, buttonState, 1f, 1f,
+            0, 0, 0, 0),
+
+        MotionEvent.obtain(initialTime, initialTime + timeMillis,
+            MotionEvent.ACTION_MOVE, 1, arrayOf(pointerProperties),
+            arrayOf(endPointerCoords), 0, buttonState, 1f, 1f,
+            0, 0, 0, 0)
+    )
+    val timeToLetGoAfterMoving = 50L
+    if(letGo) {
+       array +=
+           MotionEvent.obtain(
+               initialTime, initialTime + timeMillis + timeToLetGoAfterMoving,
+               MotionEvent.ACTION_UP, 1, arrayOf(pointerProperties),
+               arrayOf(endPointerCoords), 0, buttonState, 1f, 1f,
+               0, 0, 0, 0
+           )
+    }
+    return array
+}
+
 fun fastForwardDoubleTapTimeout() {
     ShadowLooper.idleMainLooper(ViewConfiguration.getDoubleTapTimeout().toLong(), TimeUnit.MILLISECONDS)
 }
@@ -206,4 +255,13 @@ fun fastForwardDoubleTapTimeout() {
 fun fastForwardLongPressTimeout() {
     val allowanceTime = 150L
     ShadowLooper.idleMainLooper(ViewConfiguration.getLongPressTimeout().toLong() + allowanceTime, TimeUnit.MILLISECONDS)
+}
+
+
+fun getDestinationPoint(pointA: Array<Float>, distance: Int, angleDegrees: Double): Array<Float> {
+    val angleRadians = angleDegrees * Math.PI / 180
+    val (xA, yA) = pointA
+    val xDist = Math.round(distance * Math.cos(angleRadians)).toInt()
+    val yDist = Math.round(distance * Math.sin(angleRadians)).toInt()
+    return arrayOf(xA + xDist, yA + yDist)
 }

--- a/instrumentation/view-click/src/test/kotlin/TestUtilsTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/TestUtilsTest.kt
@@ -1,0 +1,42 @@
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.Test
+
+class TestUtilsTest {
+
+    @Test
+    fun testGetDestinationHorizontal() {
+        val pointA = arrayOf(20f, 20f)
+        val expectedPointB = arrayOf(40f, 20f)
+        val (pointBx, pointBy) = getDestinationPoint(pointA, 20, 0.0)
+        assertThat(pointBx).isCloseTo(expectedPointB[0], within(1f))
+        assertThat(pointBy).isCloseTo(expectedPointB[1], within(1f))
+    }
+
+    @Test
+    fun testGetDestinationVertical() {
+        val pointA = arrayOf(20f, 20f)
+        val expectedPointB = arrayOf(20f, 40f)
+        val (pointBx, pointBy) = getDestinationPoint(pointA, 20, 90.0)
+        assertThat(pointBx).isCloseTo(expectedPointB[0], within(1f))
+        assertThat(pointBy).isCloseTo(expectedPointB[1], within(1f))
+    }
+
+    @Test
+    fun testGetDestinationNonCardinalAngle() {
+        val pointA = arrayOf(20f, 20f)
+        val expectedPointB = arrayOf(34.14f, 34.14f)
+        val (pointBx, pointBy) = getDestinationPoint(pointA, 20, 45.0)
+        assertThat(pointBx).isCloseTo(expectedPointB[0], within(1f))
+        assertThat(pointBy).isCloseTo(expectedPointB[1], within(1f))
+    }
+
+    @Test
+    fun testGetDestinationNonCardinalAngleNegativeDirection() {
+        val pointA = arrayOf(20f, 20f)
+        val expectedPointB = arrayOf(5.86f, 5.86f)
+        val (pointBx, pointBy) = getDestinationPoint(pointA, 20, 225.0)
+        assertThat(pointBx).isCloseTo(expectedPointB[0], within(1f))
+        assertThat(pointBy).isCloseTo(expectedPointB[1], within(1f))
+    }
+}

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewScrollInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewScrollInstrumentationTest.kt
@@ -105,7 +105,7 @@ class ViewScrollInstrumentationTest {
         every { window.callback = any() } returns Unit
 
         val distance = 20
-        val scrollSequence = getScrollSequence(250f, 50f, 90.0, distance)
+        val scrollSequence = getScrollSequence(250f, 50f, 30.0, distance)
         val motionEvent = scrollSequence[0]
         val newPositionEvent = scrollSequence[1]
 
@@ -124,8 +124,8 @@ class ViewScrollInstrumentationTest {
 
         val events = openTelemetryRule.logRecords
         assertThat(events).hasSize(2)
-
-        val negativeDistance = -1.0 * distance
+        val horizontalDistance = -17.0 // 17.32 rounded down
+        val verticalDistance = -10.0
 
         var event = events[0]
         assertThat(event)
@@ -133,8 +133,8 @@ class ViewScrollInstrumentationTest {
             .hasAttributesSatisfyingExactly(
                 equalTo(longKey(APP_SCREEN_COORDINATE_X), newPositionEvent.x.toLong()),
                 equalTo(longKey(APP_SCREEN_COORDINATE_Y), newPositionEvent.y.toLong()),
-                equalTo(doubleKey(HARDWARE_POINTER_DISTANCE_X), 0.0),
-                equalTo(doubleKey(HARDWARE_POINTER_DISTANCE_Y), negativeDistance),
+                equalTo(doubleKey(HARDWARE_POINTER_DISTANCE_X), horizontalDistance),
+                equalTo(doubleKey(HARDWARE_POINTER_DISTANCE_Y), verticalDistance),
                 equalTo(toolTypeKey, "finger")
             )
 
@@ -147,8 +147,8 @@ class ViewScrollInstrumentationTest {
                 equalTo(stringKey(APP_WIDGET_ID), mockView.id.toString()),
                 equalTo(stringKey(APP_WIDGET_NAME), "10012"),
                 equalTo(toolTypeKey, "finger"),
-                equalTo(doubleKey(HARDWARE_POINTER_DISTANCE_X), 0.0),
-                equalTo(doubleKey(HARDWARE_POINTER_DISTANCE_Y), negativeDistance)
+                equalTo(doubleKey(HARDWARE_POINTER_DISTANCE_X), horizontalDistance),
+                equalTo(doubleKey(HARDWARE_POINTER_DISTANCE_Y), verticalDistance)
             )
     }
 
@@ -332,8 +332,6 @@ class ViewScrollInstrumentationTest {
 
         val events = openTelemetryRule.logRecords
         assertThat(events).hasSize(1)
-
-//        val negativeDistance = -1.0 * distance
 
         var event = events[0]
         assertThat(event)

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewScrollInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewScrollInstrumentationTest.kt
@@ -1,0 +1,351 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+@file:OptIn(IncubatingApi::class)
+
+package io.opentelemetry.android.instrumentation.view.click
+
+import android.app.Activity
+import android.app.Application
+import android.view.View
+import android.view.ViewConfiguration
+import android.view.ViewGroup
+import android.view.Window
+import android.view.Window.Callback
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import getScrollSequence
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_FLING_EVENT_NAME
+import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_SCROLL_EVENT_NAME
+import io.opentelemetry.android.instrumentation.view.click.internal.HARDWARE_POINTER_DISTANCE_X
+import io.opentelemetry.android.instrumentation.view.click.internal.HARDWARE_POINTER_DISTANCE_Y
+import io.opentelemetry.android.instrumentation.view.click.internal.HARDWARE_POINTER_TYPE
+import io.opentelemetry.android.instrumentation.view.click.internal.HARDWARE_POINTER_VELOCITY_X
+import io.opentelemetry.android.instrumentation.view.click.internal.HARDWARE_POINTER_VELOCITY_Y
+import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_FLING_EVENT_NAME
+import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_SCROLL_EVENT_NAME
+import io.opentelemetry.android.session.SessionProvider
+import io.opentelemetry.api.common.AttributeKey.doubleKey
+import io.opentelemetry.api.common.AttributeKey.longKey
+import io.opentelemetry.api.common.AttributeKey.stringKey
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_COORDINATE_X
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_COORDINATE_Y
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_WIDGET_ID
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_WIDGET_NAME
+import io.opentelemetry.kotlin.semconv.IncubatingApi
+import io.opentelemetry.sdk.common.Clock
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
+import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
+import mockView
+import org.junit.Before
+import org.junit.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@ExtendWith(MockKExtension::class)
+class ViewScrollInstrumentationTest {
+
+    private lateinit var openTelemetryRule: OpenTelemetryRule
+
+    @MockK
+    lateinit var window: Window
+
+    @MockK
+    lateinit var callback: Callback
+
+    @MockK
+    lateinit var activity: Activity
+
+    @MockK
+    lateinit var application: Application
+
+
+    private val toolTypeKey = stringKey(HARDWARE_POINTER_TYPE)
+
+    @Before
+    fun setUp() {
+        openTelemetryRule = OpenTelemetryRule.create()
+        MockKAnnotations.init(this, relaxUnitFun = true)
+    }
+
+    @Test
+    fun capture_view_scroll() {
+        val openTelemetryRum = mockk<OpenTelemetryRum> {
+            every { openTelemetry } returns openTelemetryRule.openTelemetry
+            every { sessionProvider } returns mockk<SessionProvider>()
+            every { clock } returns Clock.getDefault()
+        }
+
+        val callbackCapturingSlot = slot<ViewClickActivityCallback>()
+        every { window.callback } returns callback
+        every { callback.dispatchTouchEvent(any()) } returns false
+
+        every { activity.window } returns window
+        every { application.registerActivityLifecycleCallbacks(any()) } returns Unit
+
+        ViewClickInstrumentation().install(application, openTelemetryRum)
+
+        verify {
+            application.registerActivityLifecycleCallbacks(capture(callbackCapturingSlot))
+        }
+
+        val viewClickActivityCallback = callbackCapturingSlot.captured
+        val wrapperCapturingSlot = slot<WindowCallbackWrapper>()
+        every { window.callback = any() } returns Unit
+
+        val distance = 20
+        val scrollSequence = getScrollSequence(250f, 50f, 90.0, distance)
+        val motionEvent = scrollSequence[0]
+        val newPositionEvent = scrollSequence[1]
+
+        val mockView = mockView<View>(10012, motionEvent)
+        every { window.decorView } returns mockView
+
+        viewClickActivityCallback.onActivityResumed(activity)
+
+        verify {
+            window.callback = capture(wrapperCapturingSlot)
+        }
+
+        wrapperCapturingSlot.captured.dispatchTouchEvent(scrollSequence[0])
+        wrapperCapturingSlot.captured.dispatchTouchEvent(scrollSequence[1])
+
+
+        val events = openTelemetryRule.logRecords
+        assertThat(events).hasSize(2)
+
+        val negativeDistance = -1.0 * distance
+
+        var event = events[0]
+        assertThat(event)
+            .hasEventName(APP_SCREEN_SCROLL_EVENT_NAME)
+            .hasAttributesSatisfyingExactly(
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), newPositionEvent.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), newPositionEvent.y.toLong()),
+                equalTo(doubleKey(HARDWARE_POINTER_DISTANCE_X), 0.0),
+                equalTo(doubleKey(HARDWARE_POINTER_DISTANCE_Y), negativeDistance),
+                equalTo(toolTypeKey, "finger")
+            )
+
+        event = events[1]
+        assertThat(event)
+            .hasEventName(VIEW_SCROLL_EVENT_NAME)
+            .hasAttributesSatisfyingExactly(
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
+                equalTo(stringKey(APP_WIDGET_ID), mockView.id.toString()),
+                equalTo(stringKey(APP_WIDGET_NAME), "10012"),
+                equalTo(toolTypeKey, "finger"),
+                equalTo(doubleKey(HARDWARE_POINTER_DISTANCE_X), 0.0),
+                equalTo(doubleKey(HARDWARE_POINTER_DISTANCE_Y), negativeDistance)
+            )
+    }
+
+    @Test
+    fun capture_view_no_scroll_when_less_than_slop() {
+        val openTelemetryRum = mockk<OpenTelemetryRum> {
+            every { openTelemetry } returns openTelemetryRule.openTelemetry
+            every { sessionProvider } returns mockk<SessionProvider>()
+            every { clock } returns Clock.getDefault()
+        }
+
+        val callbackCapturingSlot = slot<ViewClickActivityCallback>()
+        every { window.callback } returns callback
+        every { callback.dispatchTouchEvent(any()) } returns false
+
+        every { activity.window } returns window
+        every { application.registerActivityLifecycleCallbacks(any()) } returns Unit
+
+        ViewClickInstrumentation().install(application, openTelemetryRum)
+
+        verify {
+            application.registerActivityLifecycleCallbacks(capture(callbackCapturingSlot))
+        }
+
+        val viewClickActivityCallback = callbackCapturingSlot.captured
+        val wrapperCapturingSlot = slot<WindowCallbackWrapper>()
+        every { window.callback = any() } returns Unit
+
+        val touchSlop = ViewConfiguration.getTouchSlop()
+        val distanceLessThanTouchSlop = (touchSlop * 0.6).toInt()
+        val scrollSequence = getScrollSequence(250f, 50f, 90.0, distanceLessThanTouchSlop)
+        val motionEvent = scrollSequence[0]
+        val newPositionEvent = scrollSequence[1]
+
+        val mockView = mockView<View>(10012, motionEvent)
+        every { window.decorView } returns mockView
+
+        viewClickActivityCallback.onActivityResumed(activity)
+
+        verify {
+            window.callback = capture(wrapperCapturingSlot)
+        }
+
+        wrapperCapturingSlot.captured.dispatchTouchEvent(
+            scrollSequence[0],
+        )
+        wrapperCapturingSlot.captured.dispatchTouchEvent(
+            scrollSequence[1],
+        )
+
+
+        val events = openTelemetryRule.logRecords
+        assertThat(events).hasSize(0)
+    }
+
+    @Test
+    fun capture_view_fling() {
+        val openTelemetryRum = mockk<OpenTelemetryRum> {
+            every { openTelemetry } returns openTelemetryRule.openTelemetry
+            every { sessionProvider } returns mockk<SessionProvider>()
+            every { clock } returns Clock.getDefault()
+        }
+
+        val callbackCapturingSlot = slot<ViewClickActivityCallback>()
+        every { window.callback } returns callback
+        every { callback.dispatchTouchEvent(any()) } returns false
+
+        every { activity.window } returns window
+        every { application.registerActivityLifecycleCallbacks(any()) } returns Unit
+
+        ViewClickInstrumentation().install(application, openTelemetryRum)
+
+        verify {
+            application.registerActivityLifecycleCallbacks(capture(callbackCapturingSlot))
+        }
+
+        val viewClickActivityCallback = callbackCapturingSlot.captured
+        val wrapperCapturingSlot = slot<WindowCallbackWrapper>()
+        every { window.callback = any() } returns Unit
+
+
+        val distance = 20
+        val time = 100L
+        val scrollSequence = getScrollSequence(250f, 50f, 90.0, distance, timeMillis = time, letGo = true)
+        val motionEvent = scrollSequence[0]
+        val newPositionEvent = scrollSequence[1]
+
+        val mockView = mockView<View>(10012, motionEvent)
+        every { window.decorView } returns mockView
+
+        viewClickActivityCallback.onActivityResumed(activity)
+
+        verify {
+            window.callback = capture(wrapperCapturingSlot)
+        }
+
+        wrapperCapturingSlot.captured.dispatchTouchEvent(scrollSequence[0])
+        wrapperCapturingSlot.captured.dispatchTouchEvent(scrollSequence[1])
+        wrapperCapturingSlot.captured.dispatchTouchEvent(scrollSequence[2])
+
+
+        val events = openTelemetryRule.logRecords
+        assertThat(events).hasSize(4)
+
+        val verticalVelocity = distance / (time.toDouble() / 1000)
+
+
+        var event = events[2]
+
+        assertThat(event)
+            .hasEventName(APP_SCREEN_FLING_EVENT_NAME)
+            .hasAttributesSatisfyingExactly(
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), newPositionEvent.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), newPositionEvent.y.toLong()),
+                equalTo(doubleKey(HARDWARE_POINTER_VELOCITY_X), 0.0),
+                equalTo(doubleKey(HARDWARE_POINTER_VELOCITY_Y), verticalVelocity),
+                equalTo(toolTypeKey, "finger")
+            )
+
+        event = events[3]
+        assertThat(event)
+            .hasEventName(VIEW_FLING_EVENT_NAME)
+            .hasAttributesSatisfyingExactly(
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
+                equalTo(stringKey(APP_WIDGET_ID), mockView.id.toString()),
+                equalTo(stringKey(APP_WIDGET_NAME), "10012"),
+                equalTo(doubleKey(HARDWARE_POINTER_VELOCITY_X), 0.0),
+                equalTo(doubleKey(HARDWARE_POINTER_VELOCITY_Y), verticalVelocity),
+                equalTo(toolTypeKey, "finger")
+            )
+    }
+
+    @Test
+    fun capture_view_scroll_in_view_group() {
+        val openTelemetryRum = mockk<OpenTelemetryRum> {
+            every { openTelemetry } returns openTelemetryRule.openTelemetry
+            every { sessionProvider } returns mockk<SessionProvider>()
+            every { clock } returns Clock.getDefault()
+        }
+
+        val callbackCapturingSlot = slot<ViewClickActivityCallback>()
+        every { window.callback } returns callback
+        every { callback.dispatchTouchEvent(any()) } returns false
+
+        every { activity.window } returns window
+        every { application.registerActivityLifecycleCallbacks(any()) } returns Unit
+
+        ViewClickInstrumentation().install(application, openTelemetryRum)
+
+        verify {
+            application.registerActivityLifecycleCallbacks(capture(callbackCapturingSlot))
+        }
+
+        val viewClickActivityCallback = callbackCapturingSlot.captured
+        val wrapperCapturingSlot = slot<WindowCallbackWrapper>()
+        every { window.callback = any() } returns Unit
+
+        val distance = 20
+        val scrollSequence = getScrollSequence(250f, 50f, 270.0, distance)
+        val motionEvent = scrollSequence[0]
+        val newPositionEvent = scrollSequence[1]
+
+        val mockView = mockView<View>(10012, motionEvent)
+        val mockViewGroup =
+            mockView<ViewGroup>(10013, motionEvent, clickable = false) {
+                every { it.childCount } returns 1
+                every { it.getChildAt(any()) } returns mockView
+            }
+        every { window.decorView } returns mockViewGroup
+
+        viewClickActivityCallback.onActivityResumed(activity)
+
+        verify {
+            window.callback = capture(wrapperCapturingSlot)
+        }
+
+        wrapperCapturingSlot.captured.dispatchTouchEvent(scrollSequence[0])
+        wrapperCapturingSlot.captured.dispatchTouchEvent(scrollSequence[1])
+
+
+        val events = openTelemetryRule.logRecords
+        assertThat(events).hasSize(1)
+
+//        val negativeDistance = -1.0 * distance
+
+        var event = events[0]
+        assertThat(event)
+            .hasEventName(APP_SCREEN_SCROLL_EVENT_NAME)
+            .hasAttributesSatisfyingExactly(
+                equalTo(longKey(APP_SCREEN_COORDINATE_X), newPositionEvent.x.toLong()),
+                equalTo(longKey(APP_SCREEN_COORDINATE_Y), newPositionEvent.y.toLong()),
+                equalTo(doubleKey(HARDWARE_POINTER_DISTANCE_X), 0.0),
+                equalTo(doubleKey(HARDWARE_POINTER_DISTANCE_Y), distance.toDouble()),
+                equalTo(toolTypeKey, "finger")
+            )
+
+    }
+
+}


### PR DESCRIPTION
Adds scroll and fling. Adds suggestions from https://github.com/open-telemetry/opentelemetry-android/pull/1741#discussion_r3273710893 by @marandaneto 

At this point, I think the instrumentation has gone beyond the name of "click". I'd like to ask how to address the nomenclature:
* Move the non-click code to a new "gesture" instrumentation?
* Rename the existing module instead?