### PR TITLE
redux: Extract CurrentNetworkProvider from ServicesFactory

### DIFF
--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
@@ -86,7 +86,6 @@ class OpenTelemetryRumInitializerTest {
     private fun createAndSetServiceManager(): Services {
         val services = mockk<Services>()
         every { services.appLifecycle }.returns(appLifecycle)
-        every { services.currentNetworkProvider }.returns(mockk(relaxed = true))
         every { services.visibleScreenTracker }.returns(mockk(relaxed = true))
         every { services.close() } just Runs
         Services.set(services)

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -188,13 +188,6 @@ public abstract interface class io/opentelemetry/android/instrumentation/Android
 	public abstract fun getByType (Ljava/lang/Class;)Lio/opentelemetry/android/instrumentation/AndroidInstrumentation;
 }
 
-public final class io/opentelemetry/android/internal/features/networkattrs/NetworkAttributesLogRecordAppender : io/opentelemetry/sdk/logs/LogRecordProcessor {
-	public fun <init> (Lio/opentelemetry/android/internal/services/network/CurrentNetworkProvider;)V
-	public fun <init> (Lio/opentelemetry/android/internal/services/network/CurrentNetworkProvider;Lio/opentelemetry/android/common/internal/features/networkattributes/CurrentNetworkAttributesExtractor;)V
-	public synthetic fun <init> (Lio/opentelemetry/android/internal/services/network/CurrentNetworkProvider;Lio/opentelemetry/android/common/internal/features/networkattributes/CurrentNetworkAttributesExtractor;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun onEmit (Lio/opentelemetry/context/Context;Lio/opentelemetry/sdk/logs/ReadWriteLogRecord;)V
-}
-
 public abstract interface class io/opentelemetry/android/internal/initialization/InitializationEvents {
 	public static final field Companion Lio/opentelemetry/android/internal/initialization/InitializationEvents$Companion;
 	public abstract fun anrMonitorInitialized ()V

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -61,6 +61,7 @@ dependencies {
 
     implementation(project(":agent-api"))
     implementation(project(":instrumentation:android-instrumentation"))
+    implementation(project(":instrumentation:network"))
     implementation(project(":common"))
     implementation(project(":services"))
     implementation(project(":session"))

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.kt
@@ -23,20 +23,19 @@ import io.opentelemetry.android.features.diskbuffering.scheduler.ScheduleEnablem
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.instrumentation.AndroidInstrumentationLoader
 import io.opentelemetry.android.instrumentation.AndroidInstrumentationLoaderImpl
-import io.opentelemetry.android.internal.features.networkattrs.NetworkAttributesLogRecordAppender
-import io.opentelemetry.android.internal.features.networkattrs.NetworkAttributesSpanAppender.Companion.create
+import io.opentelemetry.android.instrumentation.network.internal.NetworkAttributesLogRecordAppender
+import io.opentelemetry.android.instrumentation.network.internal.NetworkAttributesSpanAppender.Companion.create
+import io.opentelemetry.android.instrumentation.network.internal.NetworkProviderHolder
 import io.opentelemetry.android.internal.features.persistence.DiskManager
 import io.opentelemetry.android.internal.initialization.InitializationEvents
 import io.opentelemetry.android.internal.processors.GlobalAttributesLogRecordAppender
 import io.opentelemetry.android.internal.processors.ScreenAttributesLogRecordProcessor
 import io.opentelemetry.android.internal.processors.SessionIdLogRecordAppender
 import io.opentelemetry.android.internal.services.Services
-import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
 import io.opentelemetry.android.internal.services.periodic.PeriodicTaskScheduler
 import io.opentelemetry.android.internal.services.periodic.PeriodicTaskSchedulerImpl
 import io.opentelemetry.android.internal.services.storage.CacheStorage
 import io.opentelemetry.android.internal.services.storage.CacheStorageImpl
-import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTracker
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator
@@ -335,11 +334,7 @@ class OpenTelemetryRumBuilder internal constructor(
         val periodicTaskScheduler: Lazy<PeriodicTaskScheduler> =
             lazy { periodicTaskSchedulerOverride ?: PeriodicTaskSchedulerImpl() }
         val initializationEvents = InitializationEvents.get()
-        applyConfiguration(
-            initializationEvents,
-            lazy { services.currentNetworkProvider },
-            lazy { services.visibleScreenTracker },
-        )
+        applyConfiguration(services, initializationEvents)
 
         val bufferDelegatingSpanExporter = BufferDelegatingSpanExporter()
         val bufferDelegatingLogExporter = BufferDelegatingLogExporter()
@@ -378,6 +373,7 @@ class OpenTelemetryRumBuilder internal constructor(
                 .setShutdownHook {
                     exportScheduleEnablement?.disable()
                     services.close()
+                    NetworkProviderHolder.close()
                     if (cacheStorage.isInitialized()) {
                         cacheStorage.value.close()
                     }
@@ -494,9 +490,8 @@ class OpenTelemetryRumBuilder internal constructor(
 
     /** Leverage the configuration to wire up various instrumentation components.  */
     private fun applyConfiguration(
+        services: Services,
         initializationEvents: InitializationEvents,
-        currentNetworkProvider: Lazy<CurrentNetworkProvider>,
-        visibleScreenTracker: Lazy<VisibleScreenTracker>,
     ) {
         if (config.shouldGenerateSdkInitializationEvents()) {
             initializationEvents.recordConfiguration(config)
@@ -514,7 +509,7 @@ class OpenTelemetryRumBuilder internal constructor(
 
         // Network specific attributes
         if (config.shouldIncludeNetworkAttributes()) {
-            val networkProvider = currentNetworkProvider.value
+            val networkProvider = NetworkProviderHolder.get(context)
             // Add span processor that appends network attributes.
             addTracerProviderCustomizer { tracerProviderBuilder: SdkTracerProviderBuilder, _: Context ->
                 val networkAttributesSpanAppender = create(networkProvider)
@@ -535,7 +530,7 @@ class OpenTelemetryRumBuilder internal constructor(
                 BiFunction { builder: SdkTracerProviderBuilder, _: Context ->
                     builder.addSpanProcessor(
                         ScreenAttributesSpanProcessor(
-                            visibleScreenTracker.value,
+                            services.visibleScreenTracker
                         ),
                     )
                 },
@@ -545,7 +540,7 @@ class OpenTelemetryRumBuilder internal constructor(
                 BiFunction { builder: SdkLoggerProviderBuilder, _: Context ->
                     builder.addLogRecordProcessor(
                         ScreenAttributesLogRecordProcessor(
-                            visibleScreenTracker.value,
+                            services.visibleScreenTracker
                         ),
                     )
                 },

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.kt
@@ -25,6 +25,8 @@ import io.opentelemetry.android.features.diskbuffering.SignalFromDiskExporter.Co
 import io.opentelemetry.android.features.diskbuffering.scheduler.ScheduleEnablement
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.instrumentation.AndroidInstrumentationLoaderImpl
+import io.opentelemetry.android.instrumentation.network.internal.CurrentNetworkProvider
+import io.opentelemetry.android.instrumentation.network.internal.NetworkProviderHolder
 import io.opentelemetry.android.internal.initialization.InitializationEvents
 import io.opentelemetry.android.internal.services.Services
 import io.opentelemetry.android.internal.services.Services.Companion.set
@@ -113,6 +115,7 @@ class OpenTelemetryRumBuilderTest {
         every { application.mainLooper } returns looper
         every { application.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
         InitializationEvents.set(initializationEvents)
+        NetworkProviderHolder.set(mockk<CurrentNetworkProvider>(relaxed = true))
     }
 
     @After
@@ -122,6 +125,7 @@ class OpenTelemetryRumBuilderTest {
         resetForTesting()
         InitializationEvents.resetForTest()
         set(null)
+        NetworkProviderHolder.set(null)
     }
 
     @Test
@@ -632,7 +636,11 @@ class OpenTelemetryRumBuilderTest {
 
     private fun makeBuilder(): OpenTelemetryRumBuilder = RumBuilder.builder(application, buildConfig())
 
-    private fun buildConfig(): OtelRumConfig = OtelRumConfig().disableNetworkAttributes().disableSdkInitializationEvents()
+    private fun buildConfig(): OtelRumConfig =
+        OtelRumConfig()
+            .disableNetworkAttributes()
+            .disableSdkInitializationEvents()
+            .suppressInstrumentation("network")
 
     companion object {
         const val CUR_SCREEN_NAME: String = "Celebratory Token"

--- a/core/src/test/java/io/opentelemetry/android/instrumentation/AndroidInstrumentationLoaderImplTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/instrumentation/AndroidInstrumentationLoaderImplTest.kt
@@ -34,7 +34,6 @@ class AndroidInstrumentationLoaderImplTest {
     fun `Find implementations available in the classpath when querying all instrumentations`() {
         val instrumentations = loader.getAll()
 
-        assertThat(instrumentations).hasSize(1)
-        assertThat(instrumentations.first()).isInstanceOf(TestAndroidInstrumentation::class.java)
+        assertThat(instrumentations).anyMatch { it is TestAndroidInstrumentation }
     }
 }

--- a/instrumentation/network/api/network.api
+++ b/instrumentation/network/api/network.api
@@ -13,3 +13,59 @@ public final class io/opentelemetry/android/instrumentation/network/NetworkChang
 	public fun uninstall (Landroid/content/Context;Lio/opentelemetry/android/OpenTelemetryRum;)V
 }
 
+public abstract interface class io/opentelemetry/android/instrumentation/network/internal/CurrentNetworkProvider : java/io/Closeable {
+	public static final field Companion Lio/opentelemetry/android/instrumentation/network/internal/CurrentNetworkProvider$Companion;
+	public static final field NO_NETWORK Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;
+	public static final field UNKNOWN_NETWORK Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;
+	public abstract fun addNetworkChangeListener (Lio/opentelemetry/android/instrumentation/network/internal/NetworkChangeListener;)V
+	public fun close ()V
+	public abstract fun getCurrentNetwork ()Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;
+	public abstract fun refreshNetworkStatus ()Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;
+	public abstract fun removeNetworkChangeListener (Lio/opentelemetry/android/instrumentation/network/internal/NetworkChangeListener;)V
+}
+
+public final class io/opentelemetry/android/instrumentation/network/internal/CurrentNetworkProvider$Companion {
+}
+
+public final class io/opentelemetry/android/instrumentation/network/internal/NetworkAttributesLogRecordAppender : io/opentelemetry/sdk/logs/LogRecordProcessor {
+	public fun <init> (Lio/opentelemetry/android/instrumentation/network/internal/CurrentNetworkProvider;)V
+	public fun <init> (Lio/opentelemetry/android/instrumentation/network/internal/CurrentNetworkProvider;Lio/opentelemetry/android/common/internal/features/networkattributes/CurrentNetworkAttributesExtractor;)V
+	public synthetic fun <init> (Lio/opentelemetry/android/instrumentation/network/internal/CurrentNetworkProvider;Lio/opentelemetry/android/common/internal/features/networkattributes/CurrentNetworkAttributesExtractor;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun onEmit (Lio/opentelemetry/context/Context;Lio/opentelemetry/sdk/logs/ReadWriteLogRecord;)V
+}
+
+public final class io/opentelemetry/android/instrumentation/network/internal/NetworkAttributesSpanAppender : io/opentelemetry/sdk/trace/SpanProcessor {
+	public static final field Companion Lio/opentelemetry/android/instrumentation/network/internal/NetworkAttributesSpanAppender$Companion;
+	public fun <init> (Lio/opentelemetry/android/instrumentation/network/internal/CurrentNetworkProvider;)V
+	public static final fun create (Lio/opentelemetry/android/instrumentation/network/internal/CurrentNetworkProvider;)Lio/opentelemetry/sdk/trace/SpanProcessor;
+	public fun isEndRequired ()Z
+	public fun isStartRequired ()Z
+	public fun onEnd (Lio/opentelemetry/sdk/trace/ReadableSpan;)V
+	public fun onStart (Lio/opentelemetry/context/Context;Lio/opentelemetry/sdk/trace/ReadWriteSpan;)V
+}
+
+public final class io/opentelemetry/android/instrumentation/network/internal/NetworkAttributesSpanAppender$Companion {
+	public final fun create (Lio/opentelemetry/android/instrumentation/network/internal/CurrentNetworkProvider;)Lio/opentelemetry/sdk/trace/SpanProcessor;
+}
+
+public abstract interface class io/opentelemetry/android/instrumentation/network/internal/NetworkChangeListener {
+	public abstract fun onNetworkChange (Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;)V
+}
+
+public final class io/opentelemetry/android/instrumentation/network/internal/NetworkProviderHolder {
+	public static final field INSTANCE Lio/opentelemetry/android/instrumentation/network/internal/NetworkProviderHolder;
+	public static final fun close ()V
+	public static final fun get (Landroid/content/Context;)Lio/opentelemetry/android/instrumentation/network/internal/CurrentNetworkProvider;
+	public static final fun set (Lio/opentelemetry/android/instrumentation/network/internal/CurrentNetworkProvider;)V
+}
+
+public abstract interface class io/opentelemetry/android/instrumentation/network/internal/detector/NetworkDetector {
+	public static final field Companion Lio/opentelemetry/android/instrumentation/network/internal/detector/NetworkDetector$Companion;
+	public static fun create (Landroid/content/Context;)Lio/opentelemetry/android/instrumentation/network/internal/detector/NetworkDetector;
+	public abstract fun detectCurrentNetwork ()Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;
+}
+
+public final class io/opentelemetry/android/instrumentation/network/internal/detector/NetworkDetector$Companion {
+	public final fun create (Landroid/content/Context;)Lio/opentelemetry/android/instrumentation/network/internal/detector/NetworkDetector;
+}
+

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkApplicationListener.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkApplicationListener.kt
@@ -6,9 +6,9 @@
 package io.opentelemetry.android.instrumentation.network
 
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
+import io.opentelemetry.android.instrumentation.network.internal.CurrentNetworkProvider
+import io.opentelemetry.android.instrumentation.network.internal.NetworkChangeListener
 import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateListener
-import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
-import io.opentelemetry.android.internal.services.network.NetworkChangeListener
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Logger

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentation.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentation.kt
@@ -10,6 +10,7 @@ import com.google.auto.service.AutoService
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
+import io.opentelemetry.android.instrumentation.network.internal.NetworkProviderHolder
 import io.opentelemetry.android.internal.services.Services.Companion.get
 import io.opentelemetry.api.common.AttributesBuilder
 
@@ -34,19 +35,17 @@ class NetworkChangeInstrumentation : AndroidInstrumentation {
 
     override fun install(context: Context, openTelemetryRum: OpenTelemetryRum) {
         additionalAttributeExtractors.add(NetworkChangeAttributesExtractor())
-        val services = get(context)
-        val listener = NetworkApplicationListener(services.currentNetworkProvider)
+        val listener = NetworkApplicationListener(NetworkProviderHolder.get(context))
         val logger = openTelemetryRum.openTelemetry.logsBridge["io.opentelemetry.network"]
         listener.startMonitoring(logger, additionalAttributeExtractors)
-        services.appLifecycle.registerListener(listener)
+        get(context).appLifecycle.registerListener(listener)
         networkApplicationListener = listener
     }
 
     override fun uninstall(context: Context, openTelemetryRum: OpenTelemetryRum) {
         networkApplicationListener?.let { listener ->
             listener.stopMonitoring()
-            val services = get(context)
-            services.appLifecycle.unregisterListener(listener)
+            get(context).appLifecycle.unregisterListener(listener)
         }
         networkApplicationListener = null
     }

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/CarrierFinder.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/CarrierFinder.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.android.internal.services.network
+package io.opentelemetry.android.instrumentation.network.internal
 
 import android.content.Context
 import android.os.Build

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/CurrentNetworkProvider.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/CurrentNetworkProvider.kt
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.android.internal.services.network
+package io.opentelemetry.android.instrumentation.network.internal
 
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
 import io.opentelemetry.android.common.internal.features.networkattributes.data.NetworkState
-import io.opentelemetry.android.internal.services.Service
+import java.io.Closeable
 
 // note: based on ideas from stack overflow:
 // https://stackoverflow.com/questions/32547006/connectivitymanager-getnetworkinfoint-deprecated
@@ -19,7 +19,7 @@ import io.opentelemetry.android.internal.services.Service
  * This class is internal and not for public use. Its APIs are unstable and can change at any
  * time.
  */
-interface CurrentNetworkProvider : Service {
+interface CurrentNetworkProvider : Closeable {
     /** Returns up-to-date current network information.  */
     fun refreshNetworkStatus(): CurrentNetwork
 
@@ -28,6 +28,8 @@ interface CurrentNetworkProvider : Service {
     fun addNetworkChangeListener(listener: NetworkChangeListener)
 
     fun removeNetworkChangeListener(listener: NetworkChangeListener)
+
+    override fun close() {}
 
     companion object {
         @JvmField

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/CurrentNetworkProviderImpl.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/CurrentNetworkProviderImpl.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.android.internal.services.network
+package io.opentelemetry.android.instrumentation.network.internal
 
 import android.net.ConnectivityManager
 import android.net.ConnectivityManager.NetworkCallback
@@ -15,7 +15,7 @@ import android.util.Log
 import androidx.annotation.RequiresApi
 import io.opentelemetry.android.common.RumConstants
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
-import io.opentelemetry.android.internal.services.network.detector.NetworkDetector
+import io.opentelemetry.android.instrumentation.network.internal.detector.NetworkDetector
 import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicReference
 

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/NetworkAttributesLogRecordAppender.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/NetworkAttributesLogRecordAppender.kt
@@ -3,10 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.android.internal.features.networkattrs
+package io.opentelemetry.android.instrumentation.network.internal
 
 import io.opentelemetry.android.common.internal.features.networkattributes.CurrentNetworkAttributesExtractor
-import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
 import io.opentelemetry.context.Context
 import io.opentelemetry.sdk.logs.LogRecordProcessor
 import io.opentelemetry.sdk.logs.ReadWriteLogRecord

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/NetworkAttributesSpanAppender.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/NetworkAttributesSpanAppender.kt
@@ -3,11 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.android.internal.features.networkattrs
+package io.opentelemetry.android.instrumentation.network.internal
 
 import io.opentelemetry.android.common.internal.features.networkattributes.CurrentNetworkAttributesExtractor
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
-import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
 import io.opentelemetry.context.Context
 import io.opentelemetry.sdk.trace.ReadWriteSpan
 import io.opentelemetry.sdk.trace.ReadableSpan
@@ -17,7 +16,7 @@ import io.opentelemetry.sdk.trace.SpanProcessor
  * A [SpanProcessor] implementation that appends a set of [attributes][Attributes]
  * describing the [current network][CurrentNetwork] to every span that is exported.
  */
-internal class NetworkAttributesSpanAppender(
+class NetworkAttributesSpanAppender(
     private val currentNetworkProvider: CurrentNetworkProvider,
 ) : SpanProcessor {
     private val networkAttributesExtractor = CurrentNetworkAttributesExtractor()

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/NetworkChangeListener.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/NetworkChangeListener.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.android.internal.services.network
+package io.opentelemetry.android.instrumentation.network.internal
 
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
 

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/NetworkProviderHolder.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/NetworkProviderHolder.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.network.internal
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.net.ConnectivityManager
+import androidx.annotation.VisibleForTesting
+import io.opentelemetry.android.instrumentation.network.internal.detector.NetworkDetector
+
+/**
+ * Process-wide lazy holder for the [CurrentNetworkProvider].
+ *
+ * This class is internal and not for public use. Its APIs are unstable and can change at any time.
+ */
+object NetworkProviderHolder {
+
+    @SuppressLint("StaticFieldLeak") // only application context
+    @Volatile
+    private var instance: CurrentNetworkProvider? = null
+
+    @JvmStatic
+    fun get(context: Context): CurrentNetworkProvider =
+        instance ?: synchronized(this) {
+            instance ?: createProvider(context).also { instance = it }
+        }
+
+    @JvmStatic
+    fun close() {
+        synchronized(this) {
+            instance?.close()
+            instance = null
+        }
+    }
+
+    @JvmStatic
+    @VisibleForTesting
+    fun set(provider: CurrentNetworkProvider?) {
+        synchronized(this) {
+            instance = provider
+        }
+    }
+
+    private fun createProvider(context: Context): CurrentNetworkProvider =
+        CurrentNetworkProviderImpl(
+            NetworkDetector.create(context),
+            context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager,
+        )
+}

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/NetworkUtils.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/NetworkUtils.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.android.internal.services.network
+package io.opentelemetry.android.instrumentation.network.internal
 
 import android.Manifest
 import android.content.Context

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/detector/NetworkDetector.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/detector/NetworkDetector.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.android.internal.services.network.detector
+package io.opentelemetry.android.instrumentation.network.internal.detector
 
 import android.content.Context
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/detector/NetworkDetectorImpl.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/internal/detector/NetworkDetectorImpl.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.android.internal.services.network.detector
+package io.opentelemetry.android.instrumentation.network.internal.detector
 
 import android.content.Context
 import android.net.ConnectivityManager
@@ -16,11 +16,11 @@ import io.opentelemetry.android.common.RumConstants
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
 import io.opentelemetry.android.common.internal.features.networkattributes.data.NetworkState
 import io.opentelemetry.android.common.internal.features.networkattributes.data.NetworkState.TRANSPORT_CELLULAR
-import io.opentelemetry.android.internal.services.network.CarrierFinder
-import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
-import io.opentelemetry.android.internal.services.network.getNetworkTypeName
-import io.opentelemetry.android.internal.services.network.hasPhoneStatePermission
-import io.opentelemetry.android.internal.services.network.hasTelephonyFeature
+import io.opentelemetry.android.instrumentation.network.internal.CarrierFinder
+import io.opentelemetry.android.instrumentation.network.internal.CurrentNetworkProvider
+import io.opentelemetry.android.instrumentation.network.internal.getNetworkTypeName
+import io.opentelemetry.android.instrumentation.network.internal.hasPhoneStatePermission
+import io.opentelemetry.android.instrumentation.network.internal.hasTelephonyFeature
 
 /**
  * Implementation of NetworkDetector interface.

--- a/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentationTest.kt
+++ b/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentationTest.kt
@@ -21,11 +21,12 @@ import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.common.internal.features.networkattributes.data.Carrier
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
 import io.opentelemetry.android.common.internal.features.networkattributes.data.NetworkState
+import io.opentelemetry.android.instrumentation.network.internal.CurrentNetworkProvider
+import io.opentelemetry.android.instrumentation.network.internal.NetworkChangeListener
+import io.opentelemetry.android.instrumentation.network.internal.NetworkProviderHolder
 import io.opentelemetry.android.internal.services.Services
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle
 import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateListener
-import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
-import io.opentelemetry.android.internal.services.network.NetworkChangeListener
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.kotlin.semconv.IncubatingApi
@@ -39,6 +40,7 @@ import io.opentelemetry.kotlin.semconv.NetworkAttributes.NETWORK_CARRIER_MNC
 import io.opentelemetry.kotlin.semconv.NetworkAttributes.NETWORK_CARRIER_NAME
 import io.opentelemetry.kotlin.semconv.NetworkAttributes.NETWORK_CONNECTION_SUBTYPE
 import io.opentelemetry.kotlin.semconv.NetworkAttributes.NETWORK_CONNECTION_TYPE
+import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -61,6 +63,12 @@ class NetworkChangeInstrumentationTest {
     fun setUp() {
         otelTesting = OpenTelemetryRule.create()
         MockKAnnotations.init(this, relaxUnitFun = true)
+    }
+
+    @After
+    fun tearDown() {
+        NetworkProviderHolder.set(null)
+        Services.set(null)
     }
 
     @Test
@@ -224,9 +232,9 @@ class NetworkChangeInstrumentationTest {
     private fun createTestDependencies(): Pair<Application, OpenTelemetryRum> {
         val app = mockk<Application>()
         val services = mockk<Services>()
-        every { services.currentNetworkProvider } returns currentNetworkProvider
         every { services.appLifecycle } returns appLifecycle
         Services.set(services)
+        NetworkProviderHolder.set(currentNetworkProvider)
         val openTelemetryRum = mockk<OpenTelemetryRum>()
         every { openTelemetryRum.openTelemetry } returns otelTesting.openTelemetry
         every { openTelemetryRum.sessionProvider } returns mockk<SessionProvider>()

--- a/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/internal/CarrierFinderTest.kt
+++ b/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/internal/CarrierFinderTest.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.android.internal.services.network
+package io.opentelemetry.android.instrumentation.network.internal
 
 import android.Manifest.permission.READ_BASIC_PHONE_STATE
 import android.Manifest.permission.READ_PHONE_STATE
@@ -206,6 +206,7 @@ class CarrierFinderTest {
     }
 
     @Test
+    @Config(sdk = [Build.VERSION_CODES.M])
     fun testShortSimOperator() {
         setupTelephonyCapability(true)
 
@@ -221,6 +222,7 @@ class CarrierFinderTest {
     }
 
     @Test
+    @Config(sdk = [Build.VERSION_CODES.M])
     fun testInvalidSimOperator() {
         setupTelephonyCapability(true)
 
@@ -236,6 +238,7 @@ class CarrierFinderTest {
     }
 
     @Test
+    @Config(sdk = [Build.VERSION_CODES.M])
     fun testInvalidIsoCountryCode() {
         setupTelephonyCapability(true)
 

--- a/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/internal/CurrentNetworkProviderTest.kt
+++ b/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/internal/CurrentNetworkProviderTest.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.android.internal.services.network
+package io.opentelemetry.android.instrumentation.network.internal
 
 import android.net.ConnectivityManager
 import android.net.ConnectivityManager.NetworkCallback
@@ -19,8 +19,8 @@ import io.mockk.slot
 import io.mockk.verify
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
 import io.opentelemetry.android.common.internal.features.networkattributes.data.NetworkState
-import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider.Companion.UNKNOWN_NETWORK
-import io.opentelemetry.android.internal.services.network.detector.NetworkDetector
+import io.opentelemetry.android.instrumentation.network.internal.CurrentNetworkProvider.Companion.UNKNOWN_NETWORK
+import io.opentelemetry.android.instrumentation.network.internal.detector.NetworkDetector
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/internal/NetworkAttributesSpanAppenderTest.kt
+++ b/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/internal/NetworkAttributesSpanAppenderTest.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.android.internal.features.networkattrs
+package io.opentelemetry.android.instrumentation.network.internal
 
 import io.mockk.MockKAnnotations
 import io.mockk.every
@@ -12,9 +12,8 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.verify
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
 import io.opentelemetry.android.common.internal.features.networkattributes.data.NetworkState
-import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
-import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.context.Context
 import io.opentelemetry.kotlin.semconv.IncubatingApi
 import io.opentelemetry.kotlin.semconv.NetworkAttributes.NETWORK_CONNECTION_SUBTYPE

--- a/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/internal/NetworkUtilsTest.kt
+++ b/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/internal/NetworkUtilsTest.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.android.internal.services.network
+package io.opentelemetry.android.instrumentation.network.internal
 
 import android.Manifest.permission.READ_BASIC_PHONE_STATE
 import android.Manifest.permission.READ_PHONE_STATE

--- a/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/internal/detector/NetworkDetectorTest.kt
+++ b/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/internal/detector/NetworkDetectorTest.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.android.internal.services.network.detector
+package io.opentelemetry.android.instrumentation.network.internal.detector
 
 import android.Manifest
 import android.content.Context

--- a/services/api/services.api
+++ b/services/api/services.api
@@ -7,7 +7,6 @@ public final class io/opentelemetry/android/internal/services/Services : io/open
 	public fun close ()V
 	public static final fun get (Landroid/content/Context;)Lio/opentelemetry/android/internal/services/Services;
 	public fun getAppLifecycle ()Lio/opentelemetry/android/internal/services/applifecycle/AppLifecycle;
-	public fun getCurrentNetworkProvider ()Lio/opentelemetry/android/internal/services/network/CurrentNetworkProvider;
 	public fun getVisibleScreenTracker ()Lio/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTracker;
 	public static final fun set (Lio/opentelemetry/android/internal/services/Services;)V
 }
@@ -19,7 +18,6 @@ public final class io/opentelemetry/android/internal/services/Services$Companion
 
 public abstract interface class io/opentelemetry/android/internal/services/ServicesFactory : java/io/Closeable {
 	public abstract fun getAppLifecycle ()Lio/opentelemetry/android/internal/services/applifecycle/AppLifecycle;
-	public abstract fun getCurrentNetworkProvider ()Lio/opentelemetry/android/internal/services/network/CurrentNetworkProvider;
 	public abstract fun getVisibleScreenTracker ()Lio/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTracker;
 }
 
@@ -31,33 +29,6 @@ public abstract interface class io/opentelemetry/android/internal/services/appli
 public abstract interface class io/opentelemetry/android/internal/services/applifecycle/ApplicationStateListener {
 	public abstract fun onApplicationBackgrounded ()V
 	public abstract fun onApplicationForegrounded ()V
-}
-
-public abstract interface class io/opentelemetry/android/internal/services/network/CurrentNetworkProvider : io/opentelemetry/android/internal/services/Service {
-	public static final field Companion Lio/opentelemetry/android/internal/services/network/CurrentNetworkProvider$Companion;
-	public static final field NO_NETWORK Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;
-	public static final field UNKNOWN_NETWORK Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;
-	public abstract fun addNetworkChangeListener (Lio/opentelemetry/android/internal/services/network/NetworkChangeListener;)V
-	public abstract fun getCurrentNetwork ()Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;
-	public abstract fun refreshNetworkStatus ()Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;
-	public abstract fun removeNetworkChangeListener (Lio/opentelemetry/android/internal/services/network/NetworkChangeListener;)V
-}
-
-public final class io/opentelemetry/android/internal/services/network/CurrentNetworkProvider$Companion {
-}
-
-public abstract interface class io/opentelemetry/android/internal/services/network/NetworkChangeListener {
-	public abstract fun onNetworkChange (Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;)V
-}
-
-public abstract interface class io/opentelemetry/android/internal/services/network/detector/NetworkDetector {
-	public static final field Companion Lio/opentelemetry/android/internal/services/network/detector/NetworkDetector$Companion;
-	public static fun create (Landroid/content/Context;)Lio/opentelemetry/android/internal/services/network/detector/NetworkDetector;
-	public abstract fun detectCurrentNetwork ()Lio/opentelemetry/android/common/internal/features/networkattributes/data/CurrentNetwork;
-}
-
-public final class io/opentelemetry/android/internal/services/network/detector/NetworkDetector$Companion {
-	public final fun create (Landroid/content/Context;)Lio/opentelemetry/android/internal/services/network/detector/NetworkDetector;
 }
 
 public abstract interface class io/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTracker : io/opentelemetry/android/internal/services/Service {

--- a/services/src/main/java/io/opentelemetry/android/internal/services/Services.kt
+++ b/services/src/main/java/io/opentelemetry/android/internal/services/Services.kt
@@ -7,16 +7,11 @@ package io.opentelemetry.android.internal.services
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.content.Context.CONNECTIVITY_SERVICE
-import android.net.ConnectivityManager
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.ProcessLifecycleOwner
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycleImpl
 import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateWatcher
-import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
-import io.opentelemetry.android.internal.services.network.CurrentNetworkProviderImpl
-import io.opentelemetry.android.internal.services.network.detector.NetworkDetector
 import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTracker
 import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTrackerImpl
 
@@ -26,12 +21,6 @@ import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTra
 class Services internal constructor(
     private val context: Context,
 ) : ServicesFactory {
-    override val currentNetworkProvider: CurrentNetworkProvider by lazy {
-        CurrentNetworkProviderImpl(
-            NetworkDetector.Companion.create(context),
-            context.getSystemService(CONNECTIVITY_SERVICE) as ConnectivityManager,
-        )
-    }
 
     override val appLifecycle: AppLifecycle by lazy {
         AppLifecycleImpl(
@@ -45,7 +34,6 @@ class Services internal constructor(
     }
 
     override fun close() {
-        currentNetworkProvider.close()
         appLifecycle.close()
         visibleScreenTracker.close()
     }

--- a/services/src/main/java/io/opentelemetry/android/internal/services/ServicesFactory.kt
+++ b/services/src/main/java/io/opentelemetry/android/internal/services/ServicesFactory.kt
@@ -6,12 +6,10 @@
 package io.opentelemetry.android.internal.services
 
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle
-import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
 import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTracker
 import java.io.Closeable
 
 interface ServicesFactory : Closeable {
-    val currentNetworkProvider: CurrentNetworkProvider
     val appLifecycle: AppLifecycle
     val visibleScreenTracker: VisibleScreenTracker
 }

--- a/services/src/test/java/io/opentelemetry/android/internal/services/ServicesTest.kt
+++ b/services/src/test/java/io/opentelemetry/android/internal/services/ServicesTest.kt
@@ -20,7 +20,6 @@ class ServicesTest {
         val services = Services(ctx)
         assertNotNull(services)
         assertNotNull(services.appLifecycle)
-        assertNotNull(services.currentNetworkProvider)
         assertNotNull(services.visibleScreenTracker)
 
         // assert no exceptions thrown


### PR DESCRIPTION
This is a recreation of #1768 since @fractalwrench is away.

That PR has conflicts due to a few broad PRs coming in under it, so I forked his branch and rebased.

>Extracts CurrentNetworkProvider from ServicesFactory. This follows on from https://github.com/open-telemetry/opentelemetry-android/pull/1767 by attempting to extract one of the services that instrumentation depends on via static calls and isn't easy to inject due to SPI. I've therefore created NetworkProviderHolder which does that job, and injected NetworkProvider as a parameter where possible.