### PR TITLE
Introduce InstrumentationConfigurator

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
@@ -12,6 +12,7 @@ import io.opentelemetry.android.common.RumConstants
 import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.instrumentation.AndroidInstrumentationLoader
+import io.opentelemetry.android.instrumentation.InstrumentationConfigurators
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.common.Clock
@@ -87,8 +88,10 @@ class SdkPreconfiguredRumBuilder internal constructor(
                 onShutdown.run()
             }
 
+        val configurator = InstrumentationConfigurators.create()
         // Install instrumentations
         for (instrumentation in enabledInstrumentations) {
+            configurator.configure(instrumentation)
             instrumentation.install(context, openTelemetryRum)
         }
 

--- a/core/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurators.kt
+++ b/core/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurators.kt
@@ -2,7 +2,7 @@ package io.opentelemetry.android.instrumentation
 
 import java.util.ServiceLoader
 
-private typealias Konfigurator = InstrumentationConfigurator<AndroidInstrumentation>
+private typealias Konfigurator = InstrumentationConfigurator<*>
 
 internal class InstrumentationConfigurators
     private constructor(private val configurators: Map<String, List<Konfigurator>>) {
@@ -13,22 +13,23 @@ internal class InstrumentationConfigurators
         }
 
         // Exists for testing
-        @Suppress("UNCHECKED_CAST")
-        fun create(loader: Loader<Konfigurator>): InstrumentationConfigurators {
+        fun create(loader: Loader): InstrumentationConfigurators {
             val configurators = loader.load(Konfigurator::class.java)
                 .groupBy { it.instrumentationName }
             return InstrumentationConfigurators(configurators)
         }
     }
 
-    fun configure(instrumentation: AndroidInstrumentation){
-        configurators[instrumentation.name]?.forEach { it.configure(instrumentation) }
+    @Suppress("UNCHECKED_CAST")
+    fun configure(instrumentation: AndroidInstrumentation) {
+        configurators[instrumentation.name]
+            ?.forEach { (it as InstrumentationConfigurator<AndroidInstrumentation>).configure(instrumentation) }
     }
 }
 
 /**
  * Exists for testing
  */
-internal fun interface Loader<S: Konfigurator> {
-    fun load(service: Class<S>): Iterable<S>
+internal fun interface Loader {
+    fun load(service: Class<Konfigurator>): Iterable<Konfigurator>
 }

--- a/core/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurators.kt
+++ b/core/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurators.kt
@@ -1,0 +1,23 @@
+package io.opentelemetry.android.instrumentation
+
+import java.util.ServiceLoader
+
+internal class InstrumentationConfigurators
+    private constructor(
+        private val configurators: Map<String, List<InstrumentationConfigurator<AndroidInstrumentation>>>,
+    ) {
+
+    companion object {
+        @Suppress("UNCHECKED_CAST")
+        fun create(): InstrumentationConfigurators {
+            val configurators = ServiceLoader
+                .load(InstrumentationConfigurator::class.java)
+                .groupBy { it.instrumentationName }
+            return InstrumentationConfigurators(configurators as Map<String, List<InstrumentationConfigurator<AndroidInstrumentation>>>)
+        }
+    }
+
+    fun configure(instrumentation: AndroidInstrumentation){
+        configurators[instrumentation.name]?.forEach { it.configure(instrumentation) }
+    }
+}

--- a/core/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurators.kt
+++ b/core/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurators.kt
@@ -2,22 +2,33 @@ package io.opentelemetry.android.instrumentation
 
 import java.util.ServiceLoader
 
+private typealias Konfigurator = InstrumentationConfigurator<AndroidInstrumentation>
+
 internal class InstrumentationConfigurators
-    private constructor(
-        private val configurators: Map<String, List<InstrumentationConfigurator<AndroidInstrumentation>>>,
-    ) {
+    private constructor(private val configurators: Map<String, List<Konfigurator>>) {
 
     companion object {
-        @Suppress("UNCHECKED_CAST")
         fun create(): InstrumentationConfigurators {
-            val configurators = ServiceLoader
-                .load(InstrumentationConfigurator::class.java)
+            return create { s -> ServiceLoader.load(s) }
+        }
+
+        // Exists for testing
+        @Suppress("UNCHECKED_CAST")
+        fun create(loader: Loader<Konfigurator>): InstrumentationConfigurators {
+            val configurators = loader.load(Konfigurator::class.java)
                 .groupBy { it.instrumentationName }
-            return InstrumentationConfigurators(configurators as Map<String, List<InstrumentationConfigurator<AndroidInstrumentation>>>)
+            return InstrumentationConfigurators(configurators)
         }
     }
 
     fun configure(instrumentation: AndroidInstrumentation){
         configurators[instrumentation.name]?.forEach { it.configure(instrumentation) }
     }
+}
+
+/**
+ * Exists for testing
+ */
+internal fun interface Loader<S: Konfigurator> {
+    fun load(service: Class<S>): Iterable<S>
 }

--- a/core/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurators.kt
+++ b/core/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurators.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.android.instrumentation
 
 import io.opentelemetry.android.common.RumConstants.OTEL_RUM_LOG_TAG
@@ -6,31 +11,32 @@ import java.util.ServiceLoader
 private typealias Konfigurator = InstrumentationConfigurator<*>
 
 internal class InstrumentationConfigurators
-    private constructor(private val configurators: Map<Class<out AndroidInstrumentation>, List<Konfigurator>>) {
+    private constructor(
+        private val configurators: Map<Class<out AndroidInstrumentation>, List<Konfigurator>>,
+    ) {
+        companion object {
+            fun create(): InstrumentationConfigurators = create { ServiceLoader.load(Konfigurator::class.java) }
 
-    companion object {
-        fun create(): InstrumentationConfigurators {
-            return create { ServiceLoader.load(Konfigurator::class.java) }
-        }
-        // Exists for testing
-        inline fun create(loader: () -> Iterable<Konfigurator>): InstrumentationConfigurators {
-            val configurators = loader().groupBy { it.instrumentationType }
-            return InstrumentationConfigurators(configurators)
-        }
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    fun configure(instrumentation: AndroidInstrumentation) {
-        configurators[instrumentation.javaClass]
-            ?.forEach {
-                try {
-                    (it as InstrumentationConfigurator<AndroidInstrumentation>).configure(instrumentation)
-                } catch (e: ClassCastException) {
-                    android.util.Log.w(OTEL_RUM_LOG_TAG,
-                        "InstrumentationConfigurator '${it.javaClass.name}' could not be applied to instrumentation '${instrumentation.javaClass.name}' (name='${instrumentation.name}').",
-                        e,
-                    )
-                }
+            // Exists for testing
+            inline fun create(loader: () -> Iterable<Konfigurator>): InstrumentationConfigurators {
+                val configurators = loader().groupBy { it.instrumentationType }
+                return InstrumentationConfigurators(configurators)
             }
+        }
+
+        @Suppress("UNCHECKED_CAST")
+        fun configure(instrumentation: AndroidInstrumentation) {
+            configurators[instrumentation.javaClass]
+                ?.forEach {
+                    try {
+                        (it as InstrumentationConfigurator<AndroidInstrumentation>).configure(instrumentation)
+                    } catch (e: ClassCastException) {
+                        android.util.Log.w(
+                            OTEL_RUM_LOG_TAG,
+                            "InstrumentationConfigurator '${it.javaClass.name}' could not be applied to instrumentation '${instrumentation.javaClass.name}' (name='${instrumentation.name}').",
+                            e,
+                        )
+                    }
+                }
+        }
     }
-}

--- a/core/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurators.kt
+++ b/core/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurators.kt
@@ -1,11 +1,12 @@
 package io.opentelemetry.android.instrumentation
 
+import io.opentelemetry.android.common.RumConstants.OTEL_RUM_LOG_TAG
 import java.util.ServiceLoader
 
 private typealias Konfigurator = InstrumentationConfigurator<*>
 
 internal class InstrumentationConfigurators
-    private constructor(private val configurators: Map<String, List<Konfigurator>>) {
+    private constructor(private val configurators: Map<Class<out AndroidInstrumentation>, List<Konfigurator>>) {
 
     companion object {
         fun create(): InstrumentationConfigurators {
@@ -13,14 +14,23 @@ internal class InstrumentationConfigurators
         }
         // Exists for testing
         inline fun create(loader: () -> Iterable<Konfigurator>): InstrumentationConfigurators {
-            val configurators = loader().groupBy { it.instrumentationName }
+            val configurators = loader().groupBy { it.instrumentationType }
             return InstrumentationConfigurators(configurators)
         }
     }
 
     @Suppress("UNCHECKED_CAST")
     fun configure(instrumentation: AndroidInstrumentation) {
-        configurators[instrumentation.name]
-            ?.forEach { (it as InstrumentationConfigurator<AndroidInstrumentation>).configure(instrumentation) }
+        configurators[instrumentation.javaClass]
+            ?.forEach {
+                try {
+                    (it as InstrumentationConfigurator<AndroidInstrumentation>).configure(instrumentation)
+                } catch (e: ClassCastException) {
+                    android.util.Log.w(OTEL_RUM_LOG_TAG,
+                        "InstrumentationConfigurator '${it.javaClass.name}' could not be applied to instrumentation '${instrumentation.javaClass.name}' (name='${instrumentation.name}').",
+                        e,
+                    )
+                }
+            }
     }
 }

--- a/core/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurators.kt
+++ b/core/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurators.kt
@@ -9,13 +9,11 @@ internal class InstrumentationConfigurators
 
     companion object {
         fun create(): InstrumentationConfigurators {
-            return create { s -> ServiceLoader.load(s) }
+            return create { ServiceLoader.load(Konfigurator::class.java) }
         }
-
         // Exists for testing
-        fun create(loader: Loader): InstrumentationConfigurators {
-            val configurators = loader.load(Konfigurator::class.java)
-                .groupBy { it.instrumentationName }
+        inline fun create(loader: () -> Iterable<Konfigurator>): InstrumentationConfigurators {
+            val configurators = loader().groupBy { it.instrumentationName }
             return InstrumentationConfigurators(configurators)
         }
     }
@@ -25,11 +23,4 @@ internal class InstrumentationConfigurators
         configurators[instrumentation.name]
             ?.forEach { (it as InstrumentationConfigurator<AndroidInstrumentation>).configure(instrumentation) }
     }
-}
-
-/**
- * Exists for testing
- */
-internal fun interface Loader {
-    fun load(service: Class<Konfigurator>): Iterable<Konfigurator>
 }

--- a/core/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurators.kt
+++ b/core/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurators.kt
@@ -33,7 +33,9 @@ internal class InstrumentationConfigurators
                     } catch (e: ClassCastException) {
                         android.util.Log.w(
                             OTEL_RUM_LOG_TAG,
-                            "InstrumentationConfigurator '${it.javaClass.name}' could not be applied to instrumentation '${instrumentation.javaClass.name}' (name='${instrumentation.name}').",
+                            "InstrumentationConfigurator '${it.javaClass.name}' could not be applied " +
+                                "to instrumentation '${instrumentation.javaClass.name}' " +
+                                "(name='${instrumentation.name}').",
                             e,
                         )
                     }

--- a/core/src/test/java/io/opentelemetry/android/instrumentation/InstrumentationConfiguratorsTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/instrumentation/InstrumentationConfiguratorsTest.kt
@@ -1,0 +1,11 @@
+package io.opentelemetry.android.instrumentation
+
+import org.junit.Test
+
+class InstrumentationConfiguratorsTest {
+
+    @Test
+    fun testCreate(){
+        InstrumentationConfigurators.create()
+    }
+}

--- a/core/src/test/java/io/opentelemetry/android/instrumentation/InstrumentationConfiguratorsTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/instrumentation/InstrumentationConfiguratorsTest.kt
@@ -30,9 +30,9 @@ class InstrumentationConfiguratorsTest {
         val inst3 = TestInstrumentation1()
         inst3.name = "not going to find this but that's ok"
 
-        val instrumentations: Iterable<InstrumentationConfigurator<AndroidInstrumentation>> = listOf<InstrumentationConfigurator<out AndroidInstrumentation>>(config1, config2)
+        val instrumentations = listOf<InstrumentationConfigurator<*>>(config1, config2)
 
-        val loader: (Class<InstrumentationConfigurator<AndroidInstrumentation>>) -> Iterable<InstrumentationConfigurator<AndroidInstrumentation>> =
+        val loader: (Class<InstrumentationConfigurator<*>>) -> Iterable<InstrumentationConfigurator<*>> =
             { _ -> instrumentations }
 
         val configurators = InstrumentationConfigurators.create(loader)

--- a/core/src/test/java/io/opentelemetry/android/instrumentation/InstrumentationConfiguratorsTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/instrumentation/InstrumentationConfiguratorsTest.kt
@@ -1,11 +1,69 @@
 package io.opentelemetry.android.instrumentation
 
+import android.content.Context
+import io.opentelemetry.android.OpenTelemetryRum
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class InstrumentationConfiguratorsTest {
 
     @Test
-    fun testCreate(){
-        InstrumentationConfigurators.create()
+    fun testCreateAndConfigure(){
+        val config1 = object: InstrumentationConfigurator<TestInstrumentation1> {
+            override val instrumentationName: String = "inst1"
+
+            override fun configure(instrumentation: TestInstrumentation1) {
+                instrumentation.configured = true
+            }
+
+        }
+        val config2 = object: InstrumentationConfigurator<TestInstrumentation2> {
+            override val instrumentationName: String = "inst2"
+
+            override fun configure(instrumentation: TestInstrumentation2) {
+                instrumentation.configured = true
+            }
+
+        }
+        val inst1 = TestInstrumentation1()
+        val inst2 = TestInstrumentation2()
+        val inst3 = TestInstrumentation1()
+        inst3.name = "not going to find this but that's ok"
+
+        val instrumentations: Iterable<InstrumentationConfigurator<AndroidInstrumentation>> = listOf<InstrumentationConfigurator<out AndroidInstrumentation>>(config1, config2)
+
+        val loader: (Class<InstrumentationConfigurator<AndroidInstrumentation>>) -> Iterable<InstrumentationConfigurator<AndroidInstrumentation>> =
+            { _ -> instrumentations }
+
+        val configurators = InstrumentationConfigurators.create(loader)
+        configurators.configure(inst1)
+        configurators.configure(inst2)
+        configurators.configure(inst3)
+
+        assertThat(inst1.configured).isTrue
+        assertThat(inst2.configured).isTrue
+
+    }
+}
+
+class TestInstrumentation1: AndroidInstrumentation {
+    override var name: String = "inst1"
+    var configured = false
+
+    override fun install(
+        context: Context,
+        openTelemetryRum: OpenTelemetryRum
+    ) {
+    }
+}
+
+class TestInstrumentation2: AndroidInstrumentation {
+    override var name: String = "inst2"
+    var configured = false
+
+    override fun install(
+        context: Context,
+        openTelemetryRum: OpenTelemetryRum
+    ) {
     }
 }

--- a/core/src/test/java/io/opentelemetry/android/instrumentation/InstrumentationConfiguratorsTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/instrumentation/InstrumentationConfiguratorsTest.kt
@@ -32,8 +32,7 @@ class InstrumentationConfiguratorsTest {
 
         val instrumentations = listOf<InstrumentationConfigurator<*>>(config1, config2)
 
-        val loader: (Class<InstrumentationConfigurator<*>>) -> Iterable<InstrumentationConfigurator<*>> =
-            { _ -> instrumentations }
+        val loader: () -> Iterable<InstrumentationConfigurator<*>> = { instrumentations }
 
         val configurators = InstrumentationConfigurators.create(loader)
         configurators.configure(inst1)

--- a/core/src/test/java/io/opentelemetry/android/instrumentation/InstrumentationConfiguratorsTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/instrumentation/InstrumentationConfiguratorsTest.kt
@@ -10,7 +10,7 @@ class InstrumentationConfiguratorsTest {
     @Test
     fun testCreateAndConfigure(){
         val config1 = object: InstrumentationConfigurator<TestInstrumentation1> {
-            override val instrumentationName: String = "inst1"
+            override val instrumentationType = TestInstrumentation1::class.java
 
             override fun configure(instrumentation: TestInstrumentation1) {
                 instrumentation.configured = true
@@ -18,7 +18,7 @@ class InstrumentationConfiguratorsTest {
 
         }
         val config2 = object: InstrumentationConfigurator<TestInstrumentation2> {
-            override val instrumentationName: String = "inst2"
+            override val instrumentationType = TestInstrumentation2::class.java
 
             override fun configure(instrumentation: TestInstrumentation2) {
                 instrumentation.configured = true

--- a/core/src/test/java/io/opentelemetry/android/instrumentation/InstrumentationConfiguratorsTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/instrumentation/InstrumentationConfiguratorsTest.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.android.instrumentation
 
 import android.content.Context
@@ -6,25 +11,24 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class InstrumentationConfiguratorsTest {
-
     @Test
-    fun testCreateAndConfigure(){
-        val config1 = object: InstrumentationConfigurator<TestInstrumentation1> {
-            override val instrumentationType = TestInstrumentation1::class.java
+    fun testCreateAndConfigure() {
+        val config1 =
+            object : InstrumentationConfigurator<TestInstrumentation1> {
+                override val instrumentationType = TestInstrumentation1::class.java
 
-            override fun configure(instrumentation: TestInstrumentation1) {
-                instrumentation.configured = true
+                override fun configure(instrumentation: TestInstrumentation1) {
+                    instrumentation.configured = true
+                }
             }
+        val config2 =
+            object : InstrumentationConfigurator<TestInstrumentation2> {
+                override val instrumentationType = TestInstrumentation2::class.java
 
-        }
-        val config2 = object: InstrumentationConfigurator<TestInstrumentation2> {
-            override val instrumentationType = TestInstrumentation2::class.java
-
-            override fun configure(instrumentation: TestInstrumentation2) {
-                instrumentation.configured = true
+                override fun configure(instrumentation: TestInstrumentation2) {
+                    instrumentation.configured = true
+                }
             }
-
-        }
         val inst1 = TestInstrumentation1()
         val inst2 = TestInstrumentation2()
         val inst3 = TestInstrumentation1()
@@ -41,28 +45,27 @@ class InstrumentationConfiguratorsTest {
 
         assertThat(inst1.configured).isTrue
         assertThat(inst2.configured).isTrue
-
     }
 }
 
-class TestInstrumentation1: AndroidInstrumentation {
+class TestInstrumentation1 : AndroidInstrumentation {
     override var name: String = "inst1"
     var configured = false
 
     override fun install(
         context: Context,
-        openTelemetryRum: OpenTelemetryRum
+        openTelemetryRum: OpenTelemetryRum,
     ) {
     }
 }
 
-class TestInstrumentation2: AndroidInstrumentation {
+class TestInstrumentation2 : AndroidInstrumentation {
     override var name: String = "inst2"
     var configured = false
 
     override fun install(
         context: Context,
-        openTelemetryRum: OpenTelemetryRum
+        openTelemetryRum: OpenTelemetryRum,
     ) {
     }
 }

--- a/docs/WRITING_INSTRUMENTATION.md
+++ b/docs/WRITING_INSTRUMENTATION.md
@@ -131,6 +131,34 @@ Configuration must happen before `OpenTelemetryRum` is built. The loader discove
 instrumentation instance from the classpath, and the builder installs it during
 RUM initialization. So the configuration is read once per RUM initialization.
 
+#### Service-Loaded Configuration
+
+When you need to configure autoloaded `AndroidInstrumentation` classes before
+they are installed, you can build custom instances of 
+[`InstrumentationConfigurator`](../instrumentation/android-instrumentation/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurator.kt).
+
+These will be automatically found on the classpath at runtime and will be 
+invoked prior to installation. A configurator is matched to an instrumentation by `instrumentationName`, 
+which must equal the target instrumentation's `AndroidInstrumentation.name`. There can be multiple
+configurators for any `AndroidInstrumentation`.
+
+Configurators must be annotated with `@AutoService`:
+
+```kotlin
+@AutoService(InstrumentationConfigurator::class)
+class MyFeatureConfigurator : InstrumentationConfigurator<SomeInstrumentation> {
+    override val instrumentationName: String = "some-instrumentation"
+
+    override fun configure(instrumentation: SomeInstrumentation) {
+        instrumentation.someOption = true
+    }
+}
+```
+
+The builder discovers configurators with `ServiceLoader` and calls `configure()` after
+instrumentation discovery, but before `AndroidInstrumentation.install()`. This lets a
+configurator set properties or invoke setup methods before telemetry hooks are installed.
+
 ### Telemetry
 
 Follow OpenTelemetry semantic conventions where they exist. Keep instrumentation scope

--- a/instrumentation/android-instrumentation/api/android-instrumentation.api
+++ b/instrumentation/android-instrumentation/api/android-instrumentation.api
@@ -4,3 +4,8 @@ public abstract interface class io/opentelemetry/android/instrumentation/Android
 	public fun uninstall (Landroid/content/Context;Lio/opentelemetry/android/OpenTelemetryRum;)V
 }
 
+public abstract interface class io/opentelemetry/android/instrumentation/InstrumentationConfigurator {
+	public abstract fun configure (Lio/opentelemetry/android/instrumentation/AndroidInstrumentation;)V
+	public abstract fun getInstrumentationName ()Ljava/lang/String;
+}
+

--- a/instrumentation/android-instrumentation/api/android-instrumentation.api
+++ b/instrumentation/android-instrumentation/api/android-instrumentation.api
@@ -6,6 +6,6 @@ public abstract interface class io/opentelemetry/android/instrumentation/Android
 
 public abstract interface class io/opentelemetry/android/instrumentation/InstrumentationConfigurator {
 	public abstract fun configure (Lio/opentelemetry/android/instrumentation/AndroidInstrumentation;)V
-	public abstract fun getInstrumentationName ()Ljava/lang/String;
+	public abstract fun getInstrumentationType ()Ljava/lang/Class;
 }
 

--- a/instrumentation/android-instrumentation/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurator.kt
+++ b/instrumentation/android-instrumentation/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurator.kt
@@ -1,0 +1,20 @@
+package io.opentelemetry.android.instrumentation
+
+/**
+ * Configures a discovered [AndroidInstrumentation] before it is installed.
+ *
+ * @param T The instrumentation type this configurator can configure.
+ */
+interface InstrumentationConfigurator<in T : AndroidInstrumentation> {
+
+    /**
+     * The [AndroidInstrumentation.name] value of the instrumentation this configurator applies to.
+     * This name must exactly match the name returned by the AndroidInstrumentation.name.
+     */
+    val instrumentationName: String
+
+    /**
+     * Called to configure an [instrumentation] before [AndroidInstrumentation.install] is called.
+     */
+    fun configure(instrumentation: T)
+}

--- a/instrumentation/android-instrumentation/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurator.kt
+++ b/instrumentation/android-instrumentation/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurator.kt
@@ -5,13 +5,12 @@ package io.opentelemetry.android.instrumentation
  *
  * @param T The instrumentation type this configurator can configure.
  */
-interface InstrumentationConfigurator<in T : AndroidInstrumentation> {
+interface InstrumentationConfigurator<T : AndroidInstrumentation> {
 
     /**
-     * The [AndroidInstrumentation.name] value of the instrumentation this configurator applies to.
-     * This name must exactly match the name returned by the AndroidInstrumentation.name.
+     * The Class of the AndroidInstrumentation that this class can configure.
      */
-    val instrumentationName: String
+    val instrumentationType: Class<T>
 
     /**
      * Called to configure an [instrumentation] before [AndroidInstrumentation.install] is called.

--- a/instrumentation/android-instrumentation/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurator.kt
+++ b/instrumentation/android-instrumentation/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurator.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.android.instrumentation
 
 /**
@@ -6,7 +11,6 @@ package io.opentelemetry.android.instrumentation
  * @param T The instrumentation type this configurator can configure.
  */
 interface InstrumentationConfigurator<T : AndroidInstrumentation> {
-
     /**
      * The Class of the AndroidInstrumentation that this class can configure.
      */

--- a/instrumentation/httpurlconnection/testing/build.gradle.kts
+++ b/instrumentation/httpurlconnection/testing/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("otel.android-app-conventions")
     id("net.bytebuddy.byte-buddy-gradle-plugin")
+    id("com.google.devtools.ksp")
 }
 
 android {
@@ -12,6 +13,9 @@ dependencies {
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(project(":instrumentation:httpurlconnection:library"))
     implementation(project(":test-common"))
+    implementation(libs.opentelemetry.instrumentation.api)
+    implementation(libs.auto.service.annotations)
+    ksp(libs.auto.service.processor)
     androidTestImplementation(project(":core"))
     androidTestImplementation(libs.assertj.core)
 }

--- a/instrumentation/httpurlconnection/testing/src/androidTest/kotlin/io/opentelemetry/instrumentation/library/httpurlconnection/InstrumentationTest.kt
+++ b/instrumentation/httpurlconnection/testing/src/androidTest/kotlin/io/opentelemetry/instrumentation/library/httpurlconnection/InstrumentationTest.kt
@@ -7,6 +7,7 @@ package io.opentelemetry.instrumentation.library.httpurlconnection
 
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.test.common.OpenTelemetryRumRule
+import io.opentelemetry.api.common.AttributeKey.booleanKey
 import io.opentelemetry.instrumentation.library.httpurlconnection.HttpUrlConnectionTestUtil.executeGet
 import io.opentelemetry.instrumentation.library.httpurlconnection.HttpUrlConnectionTestUtil.post
 import org.assertj.core.api.Assertions.assertThat
@@ -100,7 +101,7 @@ class InstrumentationTest {
                     .filterIsInstance<HttpUrlInstrumentation>()
                     .firstOrNull(),
             )
-        // setting a -1ms connection inactivity timeout for testing to ensure harvester sees it as 1ms elapsed
+        // setting a -1ms connection inactivity timeout for testing to ensure harvester sees it as 1ms elapsed,
         // and we don't have to include any wait timers in the test. 0ms does not work as the time difference
         // between last connection activity and harvester time elapsed check is much lesser than 1ms due to
         // our high speed modern CPUs.
@@ -111,5 +112,13 @@ class InstrumentationTest {
 
         // span created with harvester thread
         assertThat(openTelemetryRumRule.inMemorySpanExporter.finishedSpanItems.size).isEqualTo(1)
+    }
+
+    @Test
+    fun extraAttributesCanBeExtracted() {
+        executeGet("http://httpbin.org/get")
+        val spans = openTelemetryRumRule.inMemorySpanExporter.finishedSpanItems
+        assertThat(spans[0].attributes.get(booleanKey("extractor.on.start"))).isEqualTo(true)
+        assertThat(spans[0].attributes.get(booleanKey("extractor.on.end"))).isEqualTo(true)
     }
 }

--- a/instrumentation/httpurlconnection/testing/src/main/kotlin/io/opentelemetry/instrumentation/library/httpurlconnection/AddTestExtractor.kt
+++ b/instrumentation/httpurlconnection/testing/src/main/kotlin/io/opentelemetry/instrumentation/library/httpurlconnection/AddTestExtractor.kt
@@ -1,0 +1,36 @@
+package io.opentelemetry.instrumentation.library.httpurlconnection
+
+import com.google.auto.service.AutoService
+import io.opentelemetry.android.instrumentation.InstrumentationConfigurator
+import io.opentelemetry.api.common.AttributesBuilder
+import io.opentelemetry.context.Context
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor
+import java.net.URLConnection
+
+@AutoService(InstrumentationConfigurator::class)
+class AddExtractor : InstrumentationConfigurator<HttpUrlInstrumentation> {
+    override val instrumentationName: String = "httpurlconnection"
+
+    override fun configure(instrumentation: HttpUrlInstrumentation) {
+        val extractor = object : AttributesExtractor<URLConnection, Int> {
+            override fun onStart(
+                builder: AttributesBuilder,
+                ctx: Context,
+                urlConnection: URLConnection,
+            ) {
+                builder.put("extractor.on.start", true)
+            }
+
+            override fun onEnd(
+                builder: AttributesBuilder,
+                ctx: Context,
+                urlConnection: URLConnection,
+                response: Int?,
+                err: Throwable?,
+            ) {
+                builder.put("extractor.on.end", true)
+            }
+        }
+        instrumentation.addAttributesExtractor(extractor)
+    }
+}

--- a/instrumentation/httpurlconnection/testing/src/main/kotlin/io/opentelemetry/instrumentation/library/httpurlconnection/AddTestExtractor.kt
+++ b/instrumentation/httpurlconnection/testing/src/main/kotlin/io/opentelemetry/instrumentation/library/httpurlconnection/AddTestExtractor.kt
@@ -9,7 +9,7 @@ import java.net.URLConnection
 
 @AutoService(InstrumentationConfigurator::class)
 class AddExtractor : InstrumentationConfigurator<HttpUrlInstrumentation> {
-    override val instrumentationName: String = "httpurlconnection"
+    override val instrumentationType = HttpUrlInstrumentation::class.java
 
     override fun configure(instrumentation: HttpUrlInstrumentation) {
         val extractor = object : AttributesExtractor<URLConnection, Int> {

--- a/instrumentation/httpurlconnection/testing/src/main/kotlin/io/opentelemetry/instrumentation/library/httpurlconnection/AddTestExtractor.kt
+++ b/instrumentation/httpurlconnection/testing/src/main/kotlin/io/opentelemetry/instrumentation/library/httpurlconnection/AddTestExtractor.kt
@@ -1,3 +1,8 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 package io.opentelemetry.instrumentation.library.httpurlconnection
 
 import com.google.auto.service.AutoService
@@ -8,29 +13,30 @@ import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor
 import java.net.URLConnection
 
 @AutoService(InstrumentationConfigurator::class)
-class AddExtractor : InstrumentationConfigurator<HttpUrlInstrumentation> {
+class AddTestExtractor : InstrumentationConfigurator<HttpUrlInstrumentation> {
     override val instrumentationType = HttpUrlInstrumentation::class.java
 
     override fun configure(instrumentation: HttpUrlInstrumentation) {
-        val extractor = object : AttributesExtractor<URLConnection, Int> {
-            override fun onStart(
-                builder: AttributesBuilder,
-                ctx: Context,
-                urlConnection: URLConnection,
-            ) {
-                builder.put("extractor.on.start", true)
-            }
+        val extractor: AttributesExtractor<URLConnection, Int?> =
+            object : AttributesExtractor<URLConnection, Int?> {
+                override fun onStart(
+                    builder: AttributesBuilder,
+                    ctx: Context,
+                    urlConnection: URLConnection,
+                ) {
+                    builder.put("extractor.on.start", true)
+                }
 
-            override fun onEnd(
-                builder: AttributesBuilder,
-                ctx: Context,
-                urlConnection: URLConnection,
-                response: Int?,
-                err: Throwable?,
-            ) {
-                builder.put("extractor.on.end", true)
+                override fun onEnd(
+                    builder: AttributesBuilder,
+                    ctx: Context,
+                    urlConnection: URLConnection,
+                    response: Int?,
+                    err: Throwable?,
+                ) {
+                    builder.put("extractor.on.end", true)
+                }
             }
-        }
         instrumentation.addAttributesExtractor(extractor)
     }
 }


### PR DESCRIPTION
Currently, we have a limitation in that `AutoService` instrumentations that are automatically found and loaded on the classpath cannot really be customized. The service loader just loads them and then immediately calls install. This limits users ability to tweak specific instrumentations to their needs.

So this PR adds a new interface called `InstrumentationConfigurator`. Implementations of this are found on the classpath, loaded by the service loader, and then they are invoked with the instrumentation before `install()` is called. The instances have a name field, and this name field allows the configurator to be linked/matched to the correct instrumentation.

We already have the DSL, but we cannot create type-specific DSL wrappers for 3rd party or other user-specific instrumentations. We should expect to see 1st party instrumentation libraries, and we want there to be a nice, uniform way of configuring these. 

If we like this approach, then later on we could consider adding support for `InstrumentationConfigurator` in the DSL as well.