### PR TITLE
Allow each signal API to be thoroughly disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ private fun initOTel(context: Context): OpenTelemetryRum? =
                 globalAttributes {
                     Attributes.of(stringKey("demo-version"), "test")
                 }
-                disableMetrics(true)
+                disableMetrics()
             }
         )
     }.onFailure {

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ private fun initOTel(context: Context): OpenTelemetryRum? =
                 globalAttributes {
                     Attributes.of(stringKey("demo-version"), "test")
                 }
+                disableMetrics(true)
             }
         )
     }.onFailure {

--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -59,9 +59,9 @@ public final class io/opentelemetry/android/agent/dsl/HttpExportConfiguration {
 }
 
 public final class io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration {
-	public final fun disableLogging (Z)V
-	public final fun disableMetrics (Z)V
-	public final fun disableTracing (Z)V
+	public final fun disableLogging ()V
+	public final fun disableMetrics ()V
+	public final fun disableTracing ()V
 	public final fun diskBuffering (Lkotlin/jvm/functions/Function1;)V
 	public final fun getClock ()Lio/opentelemetry/sdk/common/Clock;
 	public final fun globalAttributes (Lkotlin/jvm/functions/Function0;)V

--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -59,6 +59,9 @@ public final class io/opentelemetry/android/agent/dsl/HttpExportConfiguration {
 }
 
 public final class io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration {
+	public final fun disableLogging (Z)V
+	public final fun disableMetrics (Z)V
+	public final fun disableTracing (Z)V
 	public final fun diskBuffering (Lkotlin/jvm/functions/Function1;)V
 	public final fun getClock ()Lio/opentelemetry/sdk/common/Clock;
 	public final fun globalAttributes (Lkotlin/jvm/functions/Function0;)V

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
@@ -55,26 +55,36 @@ object OpenTelemetryRumInitializer {
             }
 
         val rumConfig = OtelRumConfig()
-        val builder = RumBuilder.builder(ctx, rumConfig)
-        val cfg = OpenTelemetryConfiguration(rumConfig, instrumentationLoader = builder.instrumentationLoader)
-        configuration(cfg)
+        return RumBuilder.builder(ctx, rumConfig).apply {
+            val cfg = OpenTelemetryConfiguration(
+                rumConfig = rumConfig,
+                instrumentationLoader = instrumentationLoader
+            ).also(configuration)
 
-        val spansEndpoint = cfg.exportConfig.spansEndpoint()
-        val logsEndpoints = cfg.exportConfig.logsEndpoint()
-        val metricsEndpoint = cfg.exportConfig.metricsEndpoint()
+            setSessionProvider(createSessionProvider(Services.get(ctx).appLifecycle, cfg))
+            setResource(
+                AndroidResource.createDefault(ctx).toBuilder().apply {
+                    cfg.resourceAction(this)
+                }.build()
+            )
+            setClock(cfg.clock)
 
-        val resourceBuilder = AndroidResource.createDefault(ctx).toBuilder()
-        cfg.resourceAction(resourceBuilder)
-        val resource = resourceBuilder.build()
-
-        return builder
-            .setSessionProvider(createSessionProvider(Services.get(ctx).appLifecycle, cfg))
-            .setResource(resource)
-            .setClock(cfg.clock)
-            .addSpanExporterCustomizer { createSpanExporter(spansEndpoint) }
-            .addLogRecordExporterCustomizer { createLogExporter(logsEndpoints) }
-            .addMetricExporterCustomizer { createMetricExporter(metricsEndpoint) }
-            .build()
+            if (rumConfig.tracingEnabled) {
+                addSpanExporterCustomizer {
+                    createSpanExporter(cfg.exportConfig.spansEndpoint())
+                }
+            }
+            if (rumConfig.loggingEnabled) {
+                addLogRecordExporterCustomizer {
+                    createLogExporter(cfg.exportConfig.logsEndpoint())
+                }
+            }
+            if (rumConfig.metricsEnabled) {
+                addMetricExporterCustomizer {
+                    createMetricExporter(cfg.exportConfig.metricsEndpoint())
+                }
+            }
+        }.build()
     }
 
     private fun createSpanExporter(endpoint: HttpEndpointConnectivity): SpanExporter =

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
@@ -36,22 +36,22 @@ class OpenTelemetryConfiguration internal constructor(
     /**
      * Disable tracing in the SDK by providing no-op implementations that don't incur overhead even if instrumentation creates spans
      */
-    fun disableTracing(disable: Boolean) {
-        rumConfig.setTracingEnabled(!disable)
+    fun disableTracing() {
+        rumConfig.setTracingDisabled(false)
     }
 
     /**
-     * Disable logging in the SDK by providing no-op implementations that don't incur overhead even if instrumentation emits logs
+     * Disable logging and events in the SDK by providing no-op implementations that don't incur overhead even if instrumentation emits logs
      */
-    fun disableLogging(disable: Boolean) {
-        rumConfig.setLoggingEnabled(!disable)
+    fun disableLogging() {
+        rumConfig.setLoggingDisabled(false)
     }
 
     /**
      * Disable metrics in the SDK by providing no-op implementations that don't incur overhead even if instrumentation records metrics
      */
-    fun disableMetrics(disable: Boolean) {
-        rumConfig.setMetricsEnabled(!disable)
+    fun disableMetrics() {
+        rumConfig.setMetricsEnabled(false)
     }
 
     /**

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
@@ -37,21 +37,21 @@ class OpenTelemetryConfiguration internal constructor(
      * Disable tracing in the SDK by providing no-op implementations that don't incur overhead even if instrumentation creates spans
      */
     fun disableTracing() {
-        rumConfig.setTracingDisabled(true)
+        rumConfig.setTracingDisabled()
     }
 
     /**
      * Disable logging and events in the SDK by providing no-op implementations that don't incur overhead even if instrumentation emits logs
      */
     fun disableLogging() {
-        rumConfig.setLoggingDisabled(true)
+        rumConfig.setLoggingDisabled()
     }
 
     /**
      * Disable metrics in the SDK by providing no-op implementations that don't incur overhead even if instrumentation records metrics
      */
     fun disableMetrics() {
-        rumConfig.setMetricsDisabled(true)
+        rumConfig.setMetricsDisabled()
     }
 
     /**

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
@@ -37,21 +37,21 @@ class OpenTelemetryConfiguration internal constructor(
      * Disable tracing in the SDK by providing no-op implementations that don't incur overhead even if instrumentation creates spans
      */
     fun disableTracing() {
-        rumConfig.setTracingDisabled(false)
+        rumConfig.setTracingDisabled(true)
     }
 
     /**
      * Disable logging and events in the SDK by providing no-op implementations that don't incur overhead even if instrumentation emits logs
      */
     fun disableLogging() {
-        rumConfig.setLoggingDisabled(false)
+        rumConfig.setLoggingDisabled(true)
     }
 
     /**
      * Disable metrics in the SDK by providing no-op implementations that don't incur overhead even if instrumentation records metrics
      */
     fun disableMetrics() {
-        rumConfig.setMetricsDisabled(false)
+        rumConfig.setMetricsDisabled(true)
     }
 
     /**

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
@@ -51,7 +51,7 @@ class OpenTelemetryConfiguration internal constructor(
      * Disable metrics in the SDK by providing no-op implementations that don't incur overhead even if instrumentation records metrics
      */
     fun disableMetrics() {
-        rumConfig.setMetricsEnabled(false)
+        rumConfig.setMetricsDisabled(false)
     }
 
     /**

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
@@ -34,6 +34,27 @@ class OpenTelemetryConfiguration internal constructor(
     internal var resourceAction: ResourceBuilder.() -> Unit = {}
 
     /**
+     * Disable tracing in the SDK by providing no-op implementations that don't incur overhead even if instrumentation creates spans
+     */
+    fun disableTracing(disable: Boolean) {
+        rumConfig.setTracingEnabled(!disable)
+    }
+
+    /**
+     * Disable logging in the SDK by providing no-op implementations that don't incur overhead even if instrumentation emits logs
+     */
+    fun disableLogging(disable: Boolean) {
+        rumConfig.setLoggingEnabled(!disable)
+    }
+
+    /**
+     * Disable metrics in the SDK by providing no-op implementations that don't incur overhead even if instrumentation records metrics
+     */
+    fun disableMetrics(disable: Boolean) {
+        rumConfig.setMetricsEnabled(!disable)
+    }
+
+    /**
      * Configures how OpenTelemetry should export telemetry over HTTP.
      */
     fun httpExport(action: HttpExportConfiguration.() -> Unit) {

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/SignalEnablementTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/SignalEnablementTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl
+
+import io.opentelemetry.android.agent.FakeClock
+import io.opentelemetry.android.agent.FakeInstrumentationLoader
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class SignalEnablementTest {
+    private lateinit var otelConfig: OpenTelemetryConfiguration
+
+    @Before
+    fun setUp() {
+        otelConfig =
+            OpenTelemetryConfiguration(
+                instrumentationLoader = FakeInstrumentationLoader(),
+                clock = FakeClock(),
+            )
+    }
+
+    @Test
+    fun testDefaults() {
+        assertTrue(otelConfig.rumConfig.tracingEnabled)
+        assertTrue(otelConfig.rumConfig.loggingEnabled)
+        assertTrue(otelConfig.rumConfig.metricsEnabled)
+    }
+
+    @Test
+    fun testToggleTracingEnablement() {
+        otelConfig.disableTracing(true)
+        assertFalse(otelConfig.rumConfig.tracingEnabled)
+
+        otelConfig.disableTracing(false)
+        assertTrue(otelConfig.rumConfig.tracingEnabled)
+    }
+
+    @Test
+    fun testToggleLoggingEnablement() {
+        otelConfig.disableLogging(true)
+        assertFalse(otelConfig.rumConfig.loggingEnabled)
+
+        otelConfig.disableLogging(false)
+        assertTrue(otelConfig.rumConfig.loggingEnabled)
+    }
+
+    @Test
+    fun testToggleMetricsEnablement() {
+        otelConfig.disableMetrics(true)
+        assertFalse(otelConfig.rumConfig.metricsEnabled)
+
+        otelConfig.disableMetrics(false)
+        assertTrue(otelConfig.rumConfig.metricsEnabled)
+    }
+}

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/SignalEnablementTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/SignalEnablementTest.kt
@@ -32,29 +32,24 @@ class SignalEnablementTest {
     }
 
     @Test
-    fun testToggleTracingEnablement() {
-        otelConfig.disableTracing(true)
+    fun testDisableTracing() {
+        assertTrue(otelConfig.rumConfig.tracingEnabled)
+        otelConfig.disableTracing()
         assertFalse(otelConfig.rumConfig.tracingEnabled)
 
-        otelConfig.disableTracing(false)
-        assertTrue(otelConfig.rumConfig.tracingEnabled)
     }
 
     @Test
-    fun testToggleLoggingEnablement() {
-        otelConfig.disableLogging(true)
-        assertFalse(otelConfig.rumConfig.loggingEnabled)
-
-        otelConfig.disableLogging(false)
+    fun testDisableLogging() {
         assertTrue(otelConfig.rumConfig.loggingEnabled)
+        otelConfig.disableLogging()
+        assertFalse(otelConfig.rumConfig.loggingEnabled)
     }
 
     @Test
-    fun testToggleMetricsEnablement() {
-        otelConfig.disableMetrics(true)
-        assertFalse(otelConfig.rumConfig.metricsEnabled)
-
-        otelConfig.disableMetrics(false)
+    fun testDisableMetrics() {
         assertTrue(otelConfig.rumConfig.metricsEnabled)
+        otelConfig.disableMetrics()
+        assertFalse(otelConfig.rumConfig.metricsEnabled)
     }
 }

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/FakeOpenTelemetryServer.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/FakeOpenTelemetryServer.kt
@@ -76,6 +76,10 @@ internal class FakeOpenTelemetryServer {
     fun awaitLogRequest(predicate: (ExportLogsServiceRequest) -> Boolean): ExportLogsServiceRequest =
         awaitRequestMatchingPredicate(logRequests, predicate)
 
+    fun traceRequestCount(): Int = traceRequests.size
+
+    fun logRequestCount(): Int = logRequests.size
+
     private fun readRequestBodyAsStream(request: RecordedRequest): InputStream {
         val bytes =
             checkNotNull(request.body?.toByteArray()) {

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/OpenTelemetryRumSmokeTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/OpenTelemetryRumSmokeTest.kt
@@ -15,7 +15,6 @@ import io.opentelemetry.android.agent.dsl.OpenTelemetryConfiguration
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
-import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -76,8 +75,7 @@ class OpenTelemetryRumSmokeTest {
                     baseUrl = server.url
                 }
                 diskBufferingConfig.enabled(false)
-                disableTracing(true)
-                disableLogging(false)
+                disableTracing()
             },
             action = {
                 recordSpan()
@@ -86,7 +84,7 @@ class OpenTelemetryRumSmokeTest {
         )
 
         server.awaitLogRequest { findLog(it) }
-        assertEquals(0, server.traceRequestCount())
+        assertThat(server.traceRequestCount()).isZero
     }
 
     @Test
@@ -97,8 +95,7 @@ class OpenTelemetryRumSmokeTest {
                     baseUrl = server.url
                 }
                 diskBufferingConfig.enabled(false)
-                disableTracing(false)
-                disableLogging(true)
+                disableLogging()
             },
             action = {
                 recordLog()
@@ -107,7 +104,7 @@ class OpenTelemetryRumSmokeTest {
         )
 
         server.awaitTraceRequest { findSpan(it) }
-        assertEquals(0, server.logRequestCount())
+        assertThat(server.logRequestCount()).isZero
     }
 
     private fun OpenTelemetryRum.recordLog() {

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/OpenTelemetryRumSmokeTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/OpenTelemetryRumSmokeTest.kt
@@ -15,12 +15,18 @@ import io.opentelemetry.android.agent.dsl.OpenTelemetryConfiguration
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class OpenTelemetryRumSmokeTest {
+    private val tracerScopeName = "tracer"
+    private val spanName = "span-span"
+    private val logScopeName = "logger"
+    private val logMessage = "Hello world"
+
     private lateinit var server: FakeOpenTelemetryServer
 
     @Before
@@ -30,8 +36,6 @@ class OpenTelemetryRumSmokeTest {
 
     @Test
     fun testLogExported() {
-        val logMessage = "Hello world"
-        val logScopeName = "logger"
         performOpenTelemetryRumAction(
             config = {
                 httpExport {
@@ -40,37 +44,15 @@ class OpenTelemetryRumSmokeTest {
                 diskBufferingConfig.enabled(false)
             },
             action = {
-                val logger = openTelemetry.logsBridge.get(logScopeName)
-                logger.logRecordBuilder().setBody(logMessage).emit()
+                recordLog()
             },
         )
 
-        val logRequest =
-            server.awaitLogRequest(findLogBodyWithinScope(logScopeName, logMessage))
-
-        assertLogRequestReceived(logRequest)
+        assertLogRequestReceived(server.awaitLogRequest { findLog(it) })
     }
-
-    private fun findLogBodyWithinScope(
-        logScopeName: String,
-        logMessage: String,
-    ): (ExportLogsServiceRequest) -> Boolean =
-        {
-            it
-                .getResourceLogs(0)
-                .scopeLogsList
-                .find { scopeLogs ->
-                    scopeLogs.scope.name == logScopeName
-                }?.logRecordsList
-                .orEmpty()
-                .map { logRecord ->
-                    logRecord.body.stringValue
-                }.contains(logMessage)
-        }
 
     @Test
     fun testTraceExported() {
-        val spanName = "span"
         performOpenTelemetryRumAction(
             config = {
                 httpExport {
@@ -79,21 +61,81 @@ class OpenTelemetryRumSmokeTest {
                 diskBufferingConfig.enabled(false)
             },
             action = {
-                val tracer = openTelemetry.tracerProvider.get("tracer")
-                tracer.spanBuilder(spanName).startSpan().end()
+                recordSpan()
             },
         )
 
-        val traceRequest =
-            server.awaitTraceRequest {
-                it
-                    .getResourceSpans(0)
-                    .getScopeSpans(0)
-                    .getSpans(0)
-                    .name == spanName
-            }
-        assertTraceRequestReceived(traceRequest)
+        assertTraceRequestReceived(server.awaitTraceRequest { findSpan(it) })
     }
+
+    @Test
+    fun testSpansNotExportedWhenDisabled() {
+        performOpenTelemetryRumAction(
+            config = {
+                httpExport {
+                    baseUrl = server.url
+                }
+                diskBufferingConfig.enabled(false)
+                disableTracing(true)
+                disableLogging(false)
+            },
+            action = {
+                recordSpan()
+                recordLog()
+            },
+        )
+
+        server.awaitLogRequest { findLog(it) }
+        assertEquals(0, server.traceRequestCount())
+    }
+
+    @Test
+    fun testLogsNotExportedWhenDisabled() {
+        performOpenTelemetryRumAction(
+            config = {
+                httpExport {
+                    baseUrl = server.url
+                }
+                diskBufferingConfig.enabled(false)
+                disableTracing(false)
+                disableLogging(true)
+            },
+            action = {
+                recordLog()
+                recordSpan()
+            },
+        )
+
+        server.awaitTraceRequest { findSpan(it) }
+        assertEquals(0, server.logRequestCount())
+    }
+
+    private fun OpenTelemetryRum.recordLog() {
+        openTelemetry.logsBridge.get(logScopeName).logRecordBuilder().setBody(logMessage).emit()
+    }
+
+    private fun OpenTelemetryRum.recordSpan() {
+        openTelemetry.tracerProvider.get(tracerScopeName).spanBuilder(spanName).startSpan().end()
+    }
+
+    private fun findLog(request: ExportLogsServiceRequest) =
+        request
+            .getResourceLogs(0)
+            .scopeLogsList
+            .find { scopeLogs ->
+                scopeLogs.scope.name == logScopeName
+            }?.logRecordsList
+            .orEmpty()
+            .map { logRecord ->
+                logRecord.body.stringValue
+            }.contains(logMessage)
+
+    private fun findSpan(request: ExportTraceServiceRequest): Boolean =
+        request
+            .getResourceSpans(0)
+            .getScopeSpans(0)
+            .getSpans(0)
+            .name == spanName
 
     private fun assertLogRequestReceived(request: ExportLogsServiceRequest) {
         assertThat(
@@ -101,10 +143,10 @@ class OpenTelemetryRumSmokeTest {
                 .getResourceLogs(0)
                 .scopeLogsList
                 .first { x ->
-                    x.scope.name.equals("logger")
+                    x.scope.name.equals(logScopeName)
                 }.getLogRecords(0)
                 .body.stringValue,
-        ).isEqualTo("Hello world")
+        ).isEqualTo(logMessage)
     }
 
     private fun assertTraceRequestReceived(request: ExportTraceServiceRequest) {
@@ -113,10 +155,10 @@ class OpenTelemetryRumSmokeTest {
                 .getResourceSpans(0)
                 .scopeSpansList
                 .first { x ->
-                    x.scope.name.equals("tracer")
+                    x.scope.name.equals(tracerScopeName)
                 }.getSpans(0)
                 .name,
-        ).isEqualTo("span")
+        ).isEqualTo(spanName)
     }
 
     private fun performOpenTelemetryRumAction(

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -62,11 +62,17 @@ public final class io/opentelemetry/android/config/OtelRumConfig {
 	public final fun disableSdkInitializationEvents ()Lio/opentelemetry/android/config/OtelRumConfig;
 	public final fun getDiskBufferingConfig ()Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
 	public final fun getGlobalAttributesSupplier ()Ljava/util/function/Supplier;
+	public final fun getLoggingEnabled ()Z
+	public final fun getMetricsEnabled ()Z
+	public final fun getTracingEnabled ()Z
 	public final fun hasGlobalAttributes ()Z
 	public final fun isSuppressed (Ljava/lang/String;)Z
 	public final fun setDiskBufferingConfig (Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;)Lio/opentelemetry/android/config/OtelRumConfig;
 	public final fun setGlobalAttributes (Lio/opentelemetry/api/common/Attributes;)Lio/opentelemetry/android/config/OtelRumConfig;
 	public final fun setGlobalAttributes (Ljava/util/function/Supplier;)Lio/opentelemetry/android/config/OtelRumConfig;
+	public final fun setLoggingEnabled (Z)Lio/opentelemetry/android/config/OtelRumConfig;
+	public final fun setMetricsEnabled (Z)Lio/opentelemetry/android/config/OtelRumConfig;
+	public final fun setTracingEnabled (Z)Lio/opentelemetry/android/config/OtelRumConfig;
 	public final fun shouldDiscoverInstrumentations ()Z
 	public final fun shouldGenerateSdkInitializationEvents ()Z
 	public final fun shouldIncludeNetworkAttributes ()Z

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -70,9 +70,9 @@ public final class io/opentelemetry/android/config/OtelRumConfig {
 	public final fun setDiskBufferingConfig (Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;)Lio/opentelemetry/android/config/OtelRumConfig;
 	public final fun setGlobalAttributes (Lio/opentelemetry/api/common/Attributes;)Lio/opentelemetry/android/config/OtelRumConfig;
 	public final fun setGlobalAttributes (Ljava/util/function/Supplier;)Lio/opentelemetry/android/config/OtelRumConfig;
-	public final fun setLoggingEnabled (Z)Lio/opentelemetry/android/config/OtelRumConfig;
-	public final fun setMetricsEnabled (Z)Lio/opentelemetry/android/config/OtelRumConfig;
-	public final fun setTracingEnabled (Z)Lio/opentelemetry/android/config/OtelRumConfig;
+	public final fun setLoggingDisabled (Z)Lio/opentelemetry/android/config/OtelRumConfig;
+	public final fun setMetricsDisabled (Z)Lio/opentelemetry/android/config/OtelRumConfig;
+	public final fun setTracingDisabled (Z)Lio/opentelemetry/android/config/OtelRumConfig;
 	public final fun shouldDiscoverInstrumentations ()Z
 	public final fun shouldGenerateSdkInitializationEvents ()Z
 	public final fun shouldIncludeNetworkAttributes ()Z

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -70,9 +70,9 @@ public final class io/opentelemetry/android/config/OtelRumConfig {
 	public final fun setDiskBufferingConfig (Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;)Lio/opentelemetry/android/config/OtelRumConfig;
 	public final fun setGlobalAttributes (Lio/opentelemetry/api/common/Attributes;)Lio/opentelemetry/android/config/OtelRumConfig;
 	public final fun setGlobalAttributes (Ljava/util/function/Supplier;)Lio/opentelemetry/android/config/OtelRumConfig;
-	public final fun setLoggingDisabled (Z)Lio/opentelemetry/android/config/OtelRumConfig;
-	public final fun setMetricsDisabled (Z)Lio/opentelemetry/android/config/OtelRumConfig;
-	public final fun setTracingDisabled (Z)Lio/opentelemetry/android/config/OtelRumConfig;
+	public final fun setLoggingDisabled ()Lio/opentelemetry/android/config/OtelRumConfig;
+	public final fun setMetricsDisabled ()Lio/opentelemetry/android/config/OtelRumConfig;
+	public final fun setTracingDisabled ()Lio/opentelemetry/android/config/OtelRumConfig;
 	public final fun shouldDiscoverInstrumentations ()Z
 	public final fun shouldGenerateSdkInitializationEvents ()Z
 	public final fun shouldIncludeNetworkAttributes ()Z

--- a/core/src/main/java/io/opentelemetry/android/DisableableOpenTelemetry.kt
+++ b/core/src/main/java/io/opentelemetry/android/DisableableOpenTelemetry.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android
+
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.logs.LoggerProvider
+import io.opentelemetry.api.metrics.MeterProvider
+import io.opentelemetry.api.trace.TracerProvider
+import io.opentelemetry.context.propagation.ContextPropagators
+
+/**
+ * A wrapper around [delegate] that provides no-op implementations for the providers of each API that are disabled.
+ */
+internal class DisableableOpenTelemetry(
+    private val delegate: OpenTelemetry,
+    private val tracingEnabled: Boolean,
+    private val loggingEnabled: Boolean,
+    private val metricsEnabled: Boolean,
+) : OpenTelemetry {
+    override fun getTracerProvider(): TracerProvider =
+        if (tracingEnabled) {
+            delegate.tracerProvider
+        } else {
+            TracerProvider.noop()
+        }
+
+    override fun getLogsBridge(): LoggerProvider =
+        if (loggingEnabled) {
+            delegate.logsBridge
+        } else {
+            LoggerProvider.noop()
+        }
+
+    override fun getMeterProvider(): MeterProvider =
+        if (metricsEnabled) {
+            delegate.meterProvider
+        } else {
+            MeterProvider.noop()
+        }
+
+    override fun getPropagators(): ContextPropagators = delegate.propagators
+}

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.kt
@@ -345,31 +345,41 @@ class OpenTelemetryRumBuilder internal constructor(
         val bufferDelegatingLogExporter = BufferDelegatingLogExporter()
         val bufferDelegatingMetricExporter = BufferDelegatingMetricExporter()
 
-        val sdk =
-            OpenTelemetrySdk
-                .builder()
-                .setTracerProvider(
+        val sdk = OpenTelemetrySdk.builder().apply {
+            if (config.tracingEnabled) {
+                setTracerProvider(
                     buildTracerProvider(
                         sessionProvider,
                         context,
                         bufferDelegatingSpanExporter,
                         clock,
-                    ),
-                ).setLoggerProvider(
+                    )
+                )
+            }
+
+            if (config.loggingEnabled) {
+                setLoggerProvider(
                     buildLoggerProvider(
                         sessionProvider,
                         context,
                         bufferDelegatingLogExporter,
                         clock,
-                    ),
-                ).setMeterProvider(
+                    )
+                )
+            }
+
+            if (config.metricsEnabled) {
+                setMeterProvider(
                     buildMeterProvider(
                         context,
                         bufferDelegatingMetricExporter,
                         clock,
-                    ),
-                ).setPropagators(buildFinalPropagators())
-                .build()
+                    )
+                )
+            }
+
+            setPropagators(buildFinalPropagators())
+        }.build()
 
         otelReadyListeners.forEach { it(sdk) }
 
@@ -411,15 +421,17 @@ class OpenTelemetryRumBuilder internal constructor(
         bufferDelegatingMetricExporter: BufferDelegatingMetricExporter,
     ) {
         val diskBufferingConfig = config.getDiskBufferingConfig()
-        var spanExporter = buildSpanExporter()
-        var logsExporter = buildLogsExporter()
-        var metricExporter = buildMetricExporter()
+        var spanExporter: SpanExporter? = null
+        var logsExporter: LogRecordExporter? = null
+        var metricExporter: MetricExporter? = null
         var signalFromDiskExporter: SignalFromDiskExporter? = null
 
         if (diskBufferingConfig.enabled) {
+            spanExporter = buildSpanExporter()
+            logsExporter = buildLogsExporter()
+            metricExporter = buildMetricExporter()
             try {
                 val diskManager = DiskManager(cacheStorage.value, diskBufferingConfig)
-
                 val signalsRoot = diskManager.signalsBufferDir
                 val spansDir = File(signalsRoot, "spans")
                 val metricsDir = File(signalsRoot, "metrics")
@@ -428,30 +440,47 @@ class OpenTelemetryRumBuilder internal constructor(
                 val spanStorage = FileSpanStorage.create(spansDir, fileConfig)
                 val logStorage = FileLogRecordStorage.create(logsDir, fileConfig)
                 val metricStorage = FileMetricStorage.create(metricsDir, fileConfig)
-
-                val originalSpanExporter = spanExporter
-                spanExporter = SpanToDiskExporter.builder(spanStorage).build()
-                val originalLogsExporter = logsExporter
-                logsExporter = LogRecordToDiskExporter.builder(logStorage).build()
-                val originalMetricExporter = metricExporter
-                metricExporter = MetricToDiskExporter.builder(metricStorage).build()
                 signalFromDiskExporter =
                     SignalFromDiskExporter(
-                        spanStorage,
-                        originalSpanExporter,
-                        logStorage,
-                        originalLogsExporter,
-                        metricStorage,
-                        originalMetricExporter,
+                        spanStorage = spanStorage,
+                        spanExporter = spanExporter,
+                        logStorage = logStorage,
+                        logExporter = logsExporter,
+                        metricStorage = metricStorage,
+                        metricExporter = metricExporter,
                     )
+
+                logsExporter = LogRecordToDiskExporter.builder(logStorage).build()
+                spanExporter = SpanToDiskExporter.builder(spanStorage).build()
+                metricExporter = MetricToDiskExporter.builder(metricStorage).build()
             } catch (e: IOException) {
                 Log.e(RumConstants.OTEL_RUM_LOG_TAG, "Could not initialize disk exporters.", e)
             }
+        } else {
+            if (config.tracingEnabled) {
+                spanExporter = buildSpanExporter()
+            }
+            if (config.loggingEnabled) {
+                logsExporter = buildLogsExporter()
+            }
+            if (config.metricsEnabled) {
+                metricExporter = buildMetricExporter()
+            }
         }
-        initializationEvents.spanExporterInitialized(spanExporter)
-        bufferedDelegatingLogExporter.setDelegate(logsExporter)
-        bufferDelegatingSpanExporter.setDelegate(spanExporter)
-        bufferDelegatingMetricExporter.setDelegate(metricExporter)
+
+        if (spanExporter != null) {
+            initializationEvents.spanExporterInitialized(spanExporter)
+            bufferDelegatingSpanExporter.setDelegate(spanExporter)
+        }
+
+        if (logsExporter != null) {
+            bufferedDelegatingLogExporter.setDelegate(logsExporter)
+        }
+
+        if (metricExporter != null) {
+            bufferDelegatingMetricExporter.setDelegate(metricExporter)
+        }
+
         scheduleDiskTelemetryReader(periodicTaskScheduler, signalFromDiskExporter)
     }
 

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumImpl.kt
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumImpl.kt
@@ -9,21 +9,18 @@ import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Logger
-import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.common.Clock
 
 internal class OpenTelemetryRumImpl(
-    private val openTelemetrySdk: OpenTelemetrySdk,
+    override val openTelemetry: OpenTelemetry,
     override val sessionProvider: SessionProvider,
     override val clock: Clock,
 ) : OpenTelemetryRum {
     var onShutdown: Runnable = Runnable {}
     private val logger: Logger =
-        openTelemetrySdk.logsBridge
+        openTelemetry.logsBridge
             .loggerBuilder("io.opentelemetry.rum.events")
             .build()
-
-    override val openTelemetry: OpenTelemetry = openTelemetrySdk
 
     override fun emitEvent(
         eventName: String,

--- a/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
@@ -50,7 +50,7 @@ class SdkPreconfiguredRumBuilder internal constructor(
      * Creates a new instance of [io.opentelemetry.android.OpenTelemetryRum] with the settings of this [ ].
      *
      * This method uses a preconfigured OpenTelemetry SDK and install built-in system
-     * instrumentations in the passed Android [Context].
+     * instrumentations in the passed-in Android [Context].
      *
      * @return A new [io.opentelemetry.android.OpenTelemetryRum] instance.
      */
@@ -59,14 +59,23 @@ class SdkPreconfiguredRumBuilder internal constructor(
             Log.w(
                 RumConstants.OTEL_RUM_LOG_TAG,
                 "Cannot retrieve applicationContext. This indicates the OpenTelemetry SDK was " +
-                    "initialized outside of the Application subclass too early using an " +
-                    "inappropriate context. Functionality that relies on lifecycle callbacks will " +
-                    "not work until you resolve this problem.",
+                        "initialized outside of the Application subclass too early using an " +
+                        "inappropriate context. Functionality that relies on lifecycle callbacks will " +
+                        "not work until you resolve this problem.",
             )
         }
 
         val enabledInstrumentations = getEnabledInstrumentations()
-        val openTelemetryRum = OpenTelemetryRumImpl(sdk, sessionProvider, clock)
+        val openTelemetryRum = OpenTelemetryRumImpl(
+            openTelemetry = DisableableOpenTelemetry(
+                delegate = sdk,
+                tracingEnabled = config.tracingEnabled,
+                loggingEnabled = config.loggingEnabled,
+                metricsEnabled = config.metricsEnabled,
+            ),
+            sessionProvider = sessionProvider,
+            clock = clock
+        )
         openTelemetryRum.onShutdown = Runnable {
             for (instrumentation in enabledInstrumentations) {
                 instrumentation.uninstall(context, openTelemetryRum)

--- a/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.kt
+++ b/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.kt
@@ -144,8 +144,8 @@ class OtelRumConfig {
      * Enables or disables the tracing API for the SDK. When disabled, the SDK will provide no-op implementations to instrumentation
      * that use this API.
      */
-    fun setTracingDisabled(disabled: Boolean): OtelRumConfig {
-        tracingEnabled = !disabled
+    fun setTracingDisabled(): OtelRumConfig {
+        tracingEnabled = false
         return this
     }
 
@@ -153,8 +153,8 @@ class OtelRumConfig {
      * Enables or disables the logging API for the SDK. When disabled, the SDK will provide no-op implementations to instrumentation
      * that use this API.
      */
-    fun setLoggingDisabled(disabled: Boolean): OtelRumConfig {
-        loggingEnabled = !disabled
+    fun setLoggingDisabled(): OtelRumConfig {
+        loggingEnabled = false
         return this
     }
 
@@ -162,8 +162,8 @@ class OtelRumConfig {
      * Enables or disables the metrics API for the SDK. When disabled, the SDK will provide no-op implementations to instrumentation
      * that use this API.
      */
-    fun setMetricsDisabled(disabled: Boolean): OtelRumConfig {
-        metricsEnabled = !disabled
+    fun setMetricsDisabled(): OtelRumConfig {
+        metricsEnabled = false
         return this
     }
 

--- a/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.kt
+++ b/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.kt
@@ -25,6 +25,27 @@ class OtelRumConfig {
     private var diskBufferingConfigImpl: DiskBufferingConfig = create()
 
     /**
+     * Whether the tracing API is enabled. Toggle with using [setTracingEnabled]
+     */
+    @Volatile
+    var tracingEnabled = true
+        private set
+
+    /**
+     * Whether the logging API is enabled. Toggle with using [setLoggingEnabled]
+     */
+    @Volatile
+    var loggingEnabled = true
+        private set
+
+    /**
+     * Whether the metrics API is enabled. Toggle with using [setMetricsEnabled]
+     */
+    @Volatile
+    var metricsEnabled = true
+        private set
+
+    /**
      * Configures the set of global attributes to emit with every span and event. Any existing
      * configured attributes will be dropped. Default = none.
      */
@@ -121,6 +142,33 @@ class OtelRumConfig {
 
     /** Returns false when the given instrumentation has been suppressed. True otherwise.  */
     fun isSuppressed(instrumentationName: String): Boolean = suppressedInstrumentations.contains(instrumentationName)
+
+    /**
+     * Enables or disables the tracing API for the SDK. When disabled, the SDK will provide no-op implementations to instrumentation
+     * that use this API.
+     */
+    fun setTracingEnabled(enabled: Boolean): OtelRumConfig {
+        tracingEnabled = enabled
+        return this
+    }
+
+    /**
+     * Enables or disables the logging API for the SDK. When disabled, the SDK will provide no-op implementations to instrumentation
+     * that use this API.
+     */
+    fun setLoggingEnabled(enabled: Boolean): OtelRumConfig {
+        loggingEnabled = enabled
+        return this
+    }
+
+    /**
+     * Enables or disables the metrics API for the SDK. When disabled, the SDK will provide no-op implementations to instrumentation
+     * that use this API.
+     */
+    fun setMetricsEnabled(enabled: Boolean): OtelRumConfig {
+        metricsEnabled = enabled
+        return this
+    }
 
     fun getDiskBufferingConfig(): DiskBufferingConfig = diskBufferingConfigImpl
 

--- a/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.kt
+++ b/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.kt
@@ -13,7 +13,7 @@ import java.util.function.Supplier
 /**
  * Configuration object for OpenTelemetry Android. The configuration items in this class will be
  * used in the OpenTelemetryRumBuilder to wire up and enable/disable various mobile instrumentation
- * components.
+ * components. Property reads are not threadsafe.
  */
 class OtelRumConfig {
     private var globalAttributesSupplierImpl: Supplier<Attributes>? = null
@@ -27,21 +27,18 @@ class OtelRumConfig {
     /**
      * Whether the tracing API is enabled. Toggle with using [setTracingEnabled]
      */
-    @Volatile
     var tracingEnabled = true
         private set
 
     /**
      * Whether the logging API is enabled. Toggle with using [setLoggingEnabled]
      */
-    @Volatile
     var loggingEnabled = true
         private set
 
     /**
      * Whether the metrics API is enabled. Toggle with using [setMetricsEnabled]
      */
-    @Volatile
     var metricsEnabled = true
         private set
 

--- a/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.kt
+++ b/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.kt
@@ -25,13 +25,13 @@ class OtelRumConfig {
     private var diskBufferingConfigImpl: DiskBufferingConfig = create()
 
     /**
-     * Whether the tracing API is enabled. Toggle with using [setTracingEnabled]
+     * Whether the tracing API is enabled. Toggle with using [setTracingDisabled]
      */
     var tracingEnabled = true
         private set
 
     /**
-     * Whether the logging API is enabled. Toggle with using [setLoggingEnabled]
+     * Whether the logging API is enabled. Toggle with using [setLoggingDisabled]
      */
     var loggingEnabled = true
         private set
@@ -144,8 +144,8 @@ class OtelRumConfig {
      * Enables or disables the tracing API for the SDK. When disabled, the SDK will provide no-op implementations to instrumentation
      * that use this API.
      */
-    fun setTracingEnabled(enabled: Boolean): OtelRumConfig {
-        tracingEnabled = enabled
+    fun setTracingDisabled(disabled: Boolean): OtelRumConfig {
+        tracingEnabled = !disabled
         return this
     }
 
@@ -153,8 +153,8 @@ class OtelRumConfig {
      * Enables or disables the logging API for the SDK. When disabled, the SDK will provide no-op implementations to instrumentation
      * that use this API.
      */
-    fun setLoggingEnabled(enabled: Boolean): OtelRumConfig {
-        loggingEnabled = enabled
+    fun setLoggingDisabled(disabled: Boolean): OtelRumConfig {
+        loggingEnabled = !disabled
         return this
     }
 
@@ -162,8 +162,8 @@ class OtelRumConfig {
      * Enables or disables the metrics API for the SDK. When disabled, the SDK will provide no-op implementations to instrumentation
      * that use this API.
      */
-    fun setMetricsEnabled(enabled: Boolean): OtelRumConfig {
-        metricsEnabled = enabled
+    fun setMetricsEnabled(disabled: Boolean): OtelRumConfig {
+        metricsEnabled = !disabled
         return this
     }
 

--- a/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.kt
+++ b/core/src/main/java/io/opentelemetry/android/config/OtelRumConfig.kt
@@ -37,7 +37,7 @@ class OtelRumConfig {
         private set
 
     /**
-     * Whether the metrics API is enabled. Toggle with using [setMetricsEnabled]
+     * Whether the metrics API is enabled. Toggle with using [setMetricsDisabled]
      */
     var metricsEnabled = true
         private set
@@ -162,7 +162,7 @@ class OtelRumConfig {
      * Enables or disables the metrics API for the SDK. When disabled, the SDK will provide no-op implementations to instrumentation
      * that use this API.
      */
-    fun setMetricsEnabled(disabled: Boolean): OtelRumConfig {
+    fun setMetricsDisabled(disabled: Boolean): OtelRumConfig {
         metricsEnabled = !disabled
         return this
     }

--- a/core/src/test/java/io/opentelemetry/android/DisableableOpenTelemetryTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/DisableableOpenTelemetryTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android
+
+import io.opentelemetry.api.logs.LoggerProvider
+import io.opentelemetry.api.metrics.MeterProvider
+import io.opentelemetry.api.trace.TracerProvider
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DisableableOpenTelemetryTest {
+    private val delegate: OpenTelemetrySdk = OpenTelemetrySdk.builder().build()
+
+    @Test
+    fun `delegates every provider when all signals enabled`() {
+        val result =
+            DisableableOpenTelemetry(
+                delegate = delegate,
+                tracingEnabled = true,
+                loggingEnabled = true,
+                metricsEnabled = true,
+            )
+
+        assertThat(result.tracerProvider).isSameAs(delegate.tracerProvider)
+        assertThat(result.logsBridge).isSameAs(delegate.logsBridge)
+        assertThat(result.meterProvider).isSameAs(delegate.meterProvider)
+        assertThat(result.propagators).isSameAs(delegate.propagators)
+    }
+
+    @Test
+    fun `provide no-ops for any disabled api`() {
+        val result =
+            DisableableOpenTelemetry(
+                delegate = delegate,
+                tracingEnabled = false,
+                loggingEnabled = false,
+                metricsEnabled = false,
+            )
+
+        assertThat(result.tracerProvider).isSameAs(TracerProvider.noop())
+        assertThat(result.logsBridge).isSameAs(LoggerProvider.noop())
+        assertThat(result.meterProvider).isSameAs(MeterProvider.noop())
+        assertThat(result.propagators).isSameAs(delegate.propagators)
+    }
+}

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.kt
@@ -41,7 +41,6 @@ import io.opentelemetry.context.propagation.TextMapGetter
 import io.opentelemetry.context.propagation.TextMapPropagator
 import io.opentelemetry.contrib.disk.buffering.exporters.SpanToDiskExporter
 import io.opentelemetry.kotlin.semconv.IncubatingApi
-import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.common.CompletableResultCode
 import io.opentelemetry.sdk.logs.SdkLoggerProviderBuilder
 import io.opentelemetry.sdk.logs.data.LogRecordData
@@ -223,8 +222,7 @@ class OpenTelemetryRumBuilderTest {
                         .registerMetricReader(metricReader)
                 }.build()
 
-        val sdk = openTelemetryRum.openTelemetry as OpenTelemetrySdk
-        val meter = sdk.sdkMeterProvider.meterBuilder("myMeter").build()
+        val meter = openTelemetryRum.openTelemetry.meterProvider.meterBuilder("myMeter").build()
         val counterAttrs = Attributes.of(AttributeKey.longKey("adams"), 42L)
         val counter = meter.counterBuilder("myCounter").build()
         counter.add(40, counterAttrs)
@@ -264,8 +262,7 @@ class OpenTelemetryRumBuilderTest {
                 }.addMetricExporterCustomizer(Function { _: MetricExporter -> exporter })
                 .build()
 
-        val sdk = openTelemetryRum.openTelemetry as OpenTelemetrySdk
-        val meter = sdk.sdkMeterProvider.meterBuilder("FOOMETER").build()
+        val meter = openTelemetryRum.openTelemetry.meterProvider.meterBuilder("FOOMETER").build()
         val counter = meter.counterBuilder("FOOCOUNTER").build()
         counter.add(22)
         periodicReader.forceFlush()

--- a/core/src/test/java/io/opentelemetry/android/config/OtelRumConfigTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/config/OtelRumConfigTest.kt
@@ -82,10 +82,10 @@ class OtelRumConfigTest {
     @Test
     fun `signal enablement can be toggled`() {
         val config = OtelRumConfig()
-        assertThat(config.setTracingEnabled(false).tracingEnabled).isFalse()
-        assertThat(config.setTracingEnabled(true).tracingEnabled).isTrue()
-        assertThat(config.setLoggingEnabled(false).loggingEnabled).isFalse()
-        assertThat(config.setLoggingEnabled(true).loggingEnabled).isTrue()
+        assertThat(config.setTracingDisabled(false).tracingEnabled).isFalse()
+        assertThat(config.setTracingDisabled(true).tracingEnabled).isTrue()
+        assertThat(config.setLoggingDisabled(false).loggingEnabled).isFalse()
+        assertThat(config.setLoggingDisabled(true).loggingEnabled).isTrue()
         assertThat(config.setMetricsEnabled(false).metricsEnabled).isFalse()
         assertThat(config.setMetricsEnabled(true).metricsEnabled).isTrue()
     }

--- a/core/src/test/java/io/opentelemetry/android/config/OtelRumConfigTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/config/OtelRumConfigTest.kt
@@ -86,7 +86,7 @@ class OtelRumConfigTest {
         assertThat(config.setTracingDisabled(true).tracingEnabled).isTrue()
         assertThat(config.setLoggingDisabled(false).loggingEnabled).isFalse()
         assertThat(config.setLoggingDisabled(true).loggingEnabled).isTrue()
-        assertThat(config.setMetricsEnabled(false).metricsEnabled).isFalse()
-        assertThat(config.setMetricsEnabled(true).metricsEnabled).isTrue()
+        assertThat(config.setMetricsDisabled(false).metricsEnabled).isFalse()
+        assertThat(config.setMetricsDisabled(true).metricsEnabled).isTrue()
     }
 }

--- a/core/src/test/java/io/opentelemetry/android/config/OtelRumConfigTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/config/OtelRumConfigTest.kt
@@ -70,4 +70,23 @@ class OtelRumConfigTest {
             config.getGlobalAttributesSupplier().get().get(stringKey("foo")),
         ).isEqualTo("bar")
     }
+
+    @Test
+    fun `signals are enabled by default`() {
+        val config = OtelRumConfig()
+        assertThat(config.tracingEnabled).isTrue()
+        assertThat(config.loggingEnabled).isTrue()
+        assertThat(config.metricsEnabled).isTrue()
+    }
+
+    @Test
+    fun `signal enablement can be toggled`() {
+        val config = OtelRumConfig()
+        assertThat(config.setTracingEnabled(false).tracingEnabled).isFalse()
+        assertThat(config.setTracingEnabled(true).tracingEnabled).isTrue()
+        assertThat(config.setLoggingEnabled(false).loggingEnabled).isFalse()
+        assertThat(config.setLoggingEnabled(true).loggingEnabled).isTrue()
+        assertThat(config.setMetricsEnabled(false).metricsEnabled).isFalse()
+        assertThat(config.setMetricsEnabled(true).metricsEnabled).isTrue()
+    }
 }

--- a/core/src/test/java/io/opentelemetry/android/config/OtelRumConfigTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/config/OtelRumConfigTest.kt
@@ -80,13 +80,10 @@ class OtelRumConfigTest {
     }
 
     @Test
-    fun `signal enablement can be toggled`() {
+    fun `signals can be disabled`() {
         val config = OtelRumConfig()
-        assertThat(config.setTracingDisabled(false).tracingEnabled).isFalse()
-        assertThat(config.setTracingDisabled(true).tracingEnabled).isTrue()
-        assertThat(config.setLoggingDisabled(false).loggingEnabled).isFalse()
-        assertThat(config.setLoggingDisabled(true).loggingEnabled).isTrue()
-        assertThat(config.setMetricsDisabled(false).metricsEnabled).isFalse()
-        assertThat(config.setMetricsDisabled(true).metricsEnabled).isTrue()
+        assertThat(config.setTracingDisabled().tracingEnabled).isFalse()
+        assertThat(config.setLoggingDisabled().loggingEnabled).isFalse()
+        assertThat(config.setMetricsDisabled().metricsEnabled).isFalse()
     }
 }


### PR DESCRIPTION
Add the ability to disable each signal API via the config DSL that provides a no-op provider instead of just not configuring any processors. This eliminates the overhead of instrumentation that are still configured but whose telemetry doesn't ever get recorded and sent.