### PR TITLE
Use jank semconv constants

### DIFF
--- a/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/EventJankReporter.kt
+++ b/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/EventJankReporter.kt
@@ -7,7 +7,6 @@ package io.opentelemetry.android.instrumentation.slowrendering
 
 import android.util.Log
 import io.opentelemetry.android.common.RumConstants
-import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.kotlin.semconv.AppAttributes.APP_JANK_FRAME_COUNT

--- a/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/EventJankReporter.kt
+++ b/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/EventJankReporter.kt
@@ -10,17 +10,17 @@ import io.opentelemetry.android.common.RumConstants
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Logger
-
-// TODO: Replace with semconv constants
-internal val FRAME_COUNT: AttributeKey<Long> = AttributeKey.longKey("app.jank.frame_count")
-internal val PERIOD: AttributeKey<Double> = AttributeKey.doubleKey("app.jank.period")
-internal val THRESHOLD: AttributeKey<Double> = AttributeKey.doubleKey("app.jank.threshold")
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_JANK_FRAME_COUNT
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_JANK_PERIOD
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_JANK_THRESHOLD
+import io.opentelemetry.kotlin.semconv.IncubatingApi
 
 internal class EventJankReporter(
     private val eventLogger: Logger,
     private val threshold: Double,
     private val debugVerbose: Boolean = false,
 ) : JankReporter {
+    @OptIn(IncubatingApi::class)
     override fun reportSlow(
         durationToCountHistogram: Map<Int, Int>,
         periodSeconds: Double,
@@ -46,9 +46,9 @@ internal class EventJankReporter(
             val attributes =
                 Attributes
                     .builder()
-                    .put(FRAME_COUNT, frameCount)
-                    .put(PERIOD, periodSeconds)
-                    .put(THRESHOLD, threshold)
+                    .put(APP_JANK_FRAME_COUNT, frameCount)
+                    .put(APP_JANK_PERIOD, periodSeconds)
+                    .put(APP_JANK_THRESHOLD, threshold)
                     .build()
             eventBuilder
                 .setEventName("app.jank")

--- a/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/EventJankReporterTest.kt
+++ b/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/EventJankReporterTest.kt
@@ -8,6 +8,12 @@ package io.opentelemetry.android.instrumentation.slowrendering
 import android.util.Log
 import io.mockk.every
 import io.mockk.mockkStatic
+import io.opentelemetry.api.common.AttributeKey.doubleKey
+import io.opentelemetry.api.common.AttributeKey.longKey
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_JANK_FRAME_COUNT
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_JANK_PERIOD
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_JANK_THRESHOLD
+import io.opentelemetry.kotlin.semconv.IncubatingApi
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
@@ -17,6 +23,7 @@ class EventJankReporterTest {
     @Rule
     var otelTesting: OpenTelemetryRule = OpenTelemetryRule.create()
 
+    @OptIn(IncubatingApi::class)
     @Test
     fun `event is generated`() {
         val eventLogger = otelTesting.openTelemetry.logsBridge.get("JANK!")
@@ -33,8 +40,8 @@ class EventJankReporterTest {
         assertThat(otelTesting.logRecords.size).isEqualTo(1)
         val log = otelTesting.logRecords.get(0)
         assertThat(log.eventName).isEqualTo("app.jank")
-        assertThat(log.attributes.get(FRAME_COUNT)).isEqualTo(1)
-        assertThat(log.attributes.get(PERIOD)).isEqualTo(10.5)
-        assertThat(log.attributes.get(THRESHOLD)).isEqualTo(0.6)
+        assertThat(log.attributes.get(longKey(APP_JANK_FRAME_COUNT))).isEqualTo(1)
+        assertThat(log.attributes.get(doubleKey(APP_JANK_PERIOD))).isEqualTo(10.5)
+        assertThat(log.attributes.get(doubleKey(APP_JANK_THRESHOLD))).isEqualTo(0.6)
     }
 }

--- a/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderListenerTest.kt
+++ b/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderListenerTest.kt
@@ -20,7 +20,13 @@ import io.mockk.junit4.MockKRule
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import io.opentelemetry.api.common.AttributeKey.doubleKey
+import io.opentelemetry.api.common.AttributeKey.longKey
 import io.opentelemetry.api.logs.Logger
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_JANK_FRAME_COUNT
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_JANK_PERIOD
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_JANK_THRESHOLD
+import io.opentelemetry.kotlin.semconv.IncubatingApi
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
 import kotlinx.coroutines.Runnable
 import org.assertj.core.api.Assertions.assertThat
@@ -234,19 +240,20 @@ class SlowRenderListenerTest {
             .combine(EventJankReporter(eventLogger, FROZEN_THRESHOLD_MS / 1000.0))
     }
 
+    @OptIn(IncubatingApi::class)
     private fun assertLogContent(periodSeconds: Double) {
         assertThat(otelTesting.logRecords).hasSize(2)
 
         val slowLog = otelTesting.logRecords[0]
         assertThat(slowLog.eventName).isEqualTo("app.jank")
-        assertThat(slowLog.attributes.get(FRAME_COUNT)).isEqualTo(4)
-        assertThat(slowLog.attributes.get(PERIOD)).isEqualTo(periodSeconds)
-        assertThat(slowLog.attributes.get(THRESHOLD)).isEqualTo(0.016)
+        assertThat(slowLog.attributes.get(longKey(APP_JANK_FRAME_COUNT))).isEqualTo(4)
+        assertThat(slowLog.attributes.get(doubleKey(APP_JANK_PERIOD))).isEqualTo(periodSeconds)
+        assertThat(slowLog.attributes.get(doubleKey(APP_JANK_THRESHOLD))).isEqualTo(0.016)
 
         val frozenLog = otelTesting.logRecords[1]
         assertThat(frozenLog.eventName).isEqualTo("app.jank")
-        assertThat(frozenLog.attributes.get(FRAME_COUNT)).isEqualTo(1)
-        assertThat(frozenLog.attributes.get(PERIOD)).isEqualTo(periodSeconds)
-        assertThat(frozenLog.attributes.get(THRESHOLD)).isEqualTo(0.7)
+        assertThat(frozenLog.attributes.get(longKey(APP_JANK_FRAME_COUNT))).isEqualTo(1)
+        assertThat(frozenLog.attributes.get(doubleKey(APP_JANK_PERIOD))).isEqualTo(periodSeconds)
+        assertThat(frozenLog.attributes.get(doubleKey(APP_JANK_THRESHOLD))).isEqualTo(0.7)
     }
 }


### PR DESCRIPTION
Allows us to remove our hard-coded constants in favor of semconv.