### PR TITLE
Add power save mode instrumentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Add opt-in thermal status instrumentation that listens for device thermal-status changes
   (API 29+) and emits a `device.thermal_status.change` event per change.
   ([#1801](https://github.com/open-telemetry/opentelemetry-android/pull/1801))
+- Add opt-in power save mode instrumentation that listens for device power-save (battery saver)
+  mode changes and emits a `device.power_save_mode.change` event per change.
+  ([#1811](https://github.com/open-telemetry/opentelemetry-android/pull/1811))
 
 ## Version 1.4.0 (2026-05-19)
 

--- a/instrumentation/power-save-mode/README.md
+++ b/instrumentation/power-save-mode/README.md
@@ -1,0 +1,37 @@
+# Power Save Mode Instrumentation
+
+Status: development
+
+The OpenTelemetry power save mode instrumentation for Android detects when the device's power
+save (battery saver) mode is turned on or off.
+
+It listens for [`PowerManager.ACTION_POWER_SAVE_MODE_CHANGED`](https://developer.android.com/reference/android/os/PowerManager#ACTION_POWER_SAVE_MODE_CHANGED)
+broadcasts (no polling) and emits one event per change, reading the current state from
+[`PowerManager.isPowerSaveMode`](https://developer.android.com/reference/android/os/PowerManager#isPowerSaveMode()).
+
+This instrumentation is not currently enabled by default.
+
+## Telemetry
+
+This instrumentation produces the following telemetry, with an instrumentation scope of
+`io.opentelemetry.power_save_mode`.
+
+### Power Save Mode
+
+* Type: Event
+* Name: `device.power_save_mode.change`
+* Description: An event representing a change in the device's power save mode.
+* Attributes:
+    * `android.power_save_mode.enabled` - A boolean value that is `true` when power save mode is
+    enabled and `false` when it is disabled.
+
+## Installation
+
+This instrumentation does not come with the [android agent](../../android-agent) out of the box,
+so you need to manually install it as described below.
+
+### Adding dependencies
+
+```kotlin
+implementation("io.opentelemetry.android.instrumentation:power-save-mode:LATEST_VERSION")
+```

--- a/instrumentation/power-save-mode/api/power-save-mode.api
+++ b/instrumentation/power-save-mode/api/power-save-mode.api
@@ -1,0 +1,7 @@
+public final class io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public fun <init> ()V
+	public fun getName ()Ljava/lang/String;
+	public fun install (Landroid/content/Context;Lio/opentelemetry/android/OpenTelemetryRum;)V
+	public fun uninstall (Landroid/content/Context;Lio/opentelemetry/android/OpenTelemetryRum;)V
+}
+

--- a/instrumentation/power-save-mode/build.gradle.kts
+++ b/instrumentation/power-save-mode/build.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    id("otel.android-library-conventions")
+    id("otel.publish-conventions")
+}
+
+description = "OpenTelemetry Android Power Save Mode instrumentation"
+
+android {
+    namespace = "io.opentelemetry.android.instrumentation.powersavemode"
+
+    defaultConfig {
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
+}
+
+dependencies {
+    implementation(project(":instrumentation:android-instrumentation"))
+    implementation(project(":agent-api"))
+    testImplementation(libs.robolectric)
+}

--- a/instrumentation/power-save-mode/src/main/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeDetector.kt
+++ b/instrumentation/power-save-mode/src/main/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeDetector.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.powersavemode
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.os.PowerManager
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.logs.Logger
+
+/**
+ * Detects and logs changes to the device's power save (battery saver) mode.
+ *
+ * This detector is registered for [PowerManager.ACTION_POWER_SAVE_MODE_CHANGED]; on each broadcast
+ * it reads [PowerManager.isPowerSaveMode] and emits one event via the provided [Logger].
+ *
+ * @param powerManager The [PowerManager] used to read the current power save mode state.
+ * @param logger The [Logger] instance used to record power save mode change events.
+ */
+internal class PowerSaveModeDetector(
+    private val powerManager: PowerManager,
+    private val logger: Logger,
+) : BroadcastReceiver() {
+    internal companion object {
+        const val EVENT_NAME = "device.power_save_mode.change"
+        val POWER_SAVE_MODE_ENABLED: AttributeKey<Boolean> =
+            AttributeKey.booleanKey("android.power_save_mode.enabled")
+    }
+
+    override fun onReceive(
+        context: Context,
+        intent: Intent,
+    ) {
+        logger
+            .logRecordBuilder()
+            .setEventName(EVENT_NAME)
+            .setAttribute(POWER_SAVE_MODE_ENABLED, powerManager.isPowerSaveMode)
+            .emit()
+    }
+}

--- a/instrumentation/power-save-mode/src/main/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeInstrumentation.kt
+++ b/instrumentation/power-save-mode/src/main/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeInstrumentation.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.powersavemode
+
+import android.content.Context
+import android.content.IntentFilter
+import android.os.PowerManager
+import com.google.auto.service.AutoService
+import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.instrumentation.AndroidInstrumentation
+
+/**
+ * An Android instrumentation module that installs and manages [PowerSaveModeDetector].
+ *
+ * The power save mode APIs ([PowerManager.isPowerSaveMode] and
+ * [PowerManager.ACTION_POWER_SAVE_MODE_CHANGED]) are available since API level 21, which is below
+ * this library's minSdk, so no version gating is required.
+ */
+@AutoService(AndroidInstrumentation::class)
+class PowerSaveModeInstrumentation : AndroidInstrumentation {
+    private var detector: PowerSaveModeDetector? = null
+
+    override fun install(
+        context: Context,
+        openTelemetryRum: OpenTelemetryRum,
+    ) {
+        val applicationContext = context.applicationContext
+        val powerManager =
+            applicationContext.getSystemService(Context.POWER_SERVICE) as? PowerManager
+                ?: return
+
+        val logger =
+            openTelemetryRum.openTelemetry
+                .logsBridge
+                .loggerBuilder("io.opentelemetry.$name")
+                .build()
+
+        val detector = PowerSaveModeDetector(powerManager, logger)
+        this.detector = detector
+        applicationContext.registerReceiver(
+            detector,
+            IntentFilter(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED),
+        )
+    }
+
+    override fun uninstall(
+        context: Context,
+        openTelemetryRum: OpenTelemetryRum,
+    ) {
+        val detector = this.detector ?: return
+        context.applicationContext.unregisterReceiver(detector)
+        this.detector = null
+    }
+
+    override val name: String = "power_save_mode"
+}

--- a/instrumentation/power-save-mode/src/test/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeDetectorTest.kt
+++ b/instrumentation/power-save-mode/src/test/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeDetectorTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.powersavemode
+
+import android.content.Context
+import android.content.Intent
+import android.os.PowerManager
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+
+@RunWith(AndroidJUnit4::class)
+class PowerSaveModeDetectorTest {
+    @get:Rule
+    val openTelemetryRule: OpenTelemetryRule = OpenTelemetryRule.create()
+
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+    private val intent = Intent(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED)
+
+    private val logger =
+        openTelemetryRule.openTelemetry
+            .logsBridge
+            .loggerBuilder("io.opentelemetry.test")
+            .build()
+
+    private lateinit var detector: PowerSaveModeDetector
+
+    @Before
+    fun setup() {
+        detector = PowerSaveModeDetector(powerManager, logger)
+    }
+
+    @Test
+    fun `should emit an event with enabled true when power save mode is on`() {
+        // given
+        shadowOf(powerManager).setIsPowerSaveMode(true)
+
+        // when
+        detector.onReceive(context, intent)
+
+        // then
+        assertThat(openTelemetryRule.logRecords).hasSize(1)
+        val record = openTelemetryRule.logRecords.single()
+        assertThat(record.eventName).isEqualTo(PowerSaveModeDetector.EVENT_NAME)
+        assertThat(record.attributes.get(PowerSaveModeDetector.POWER_SAVE_MODE_ENABLED))
+            .isEqualTo(true)
+    }
+
+    @Test
+    fun `should emit an event with enabled false when power save mode is off`() {
+        // given
+        shadowOf(powerManager).setIsPowerSaveMode(false)
+
+        // when
+        detector.onReceive(context, intent)
+
+        // then
+        assertThat(openTelemetryRule.logRecords).hasSize(1)
+        val record = openTelemetryRule.logRecords.single()
+        assertThat(record.eventName).isEqualTo(PowerSaveModeDetector.EVENT_NAME)
+        assertThat(record.attributes.get(PowerSaveModeDetector.POWER_SAVE_MODE_ENABLED))
+            .isEqualTo(false)
+    }
+}

--- a/instrumentation/power-save-mode/src/test/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeInstrumentationTest.kt
+++ b/instrumentation/power-save-mode/src/test/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeInstrumentationTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.powersavemode
+
+import android.app.Application
+import android.content.Context
+import android.os.PowerManager
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import io.opentelemetry.android.OpenTelemetryRum
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PowerSaveModeInstrumentationTest {
+    private lateinit var sut: PowerSaveModeInstrumentation
+
+    private val context = mockk<Application>(relaxed = true)
+    private val openTelemetryRum = mockk<OpenTelemetryRum>(relaxed = true)
+    private val powerManager = mockk<PowerManager>(relaxed = true)
+
+    @Before
+    fun setup() {
+        sut = PowerSaveModeInstrumentation()
+        every { context.applicationContext } returns context
+        every { context.getSystemService(Context.POWER_SERVICE) } returns powerManager
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // ACTION_POWER_SAVE_MODE_CHANGED is a protected system broadcast, so the production code
+    // registers without an exported flag on purpose. Lint can't inspect the IntentFilter through
+    // the mockk matcher here, so it reports a false positive on this verification.
+    @Suppress("UnspecifiedRegisterReceiverFlag")
+    @Test
+    fun `should register a power save mode receiver on install`() {
+        // when
+        sut.install(context, openTelemetryRum)
+
+        // then
+        verify { context.registerReceiver(any<PowerSaveModeDetector>(), any()) }
+    }
+
+    @Test
+    fun `should unregister the receiver on uninstall`() {
+        // given
+        sut.install(context, openTelemetryRum)
+
+        // when
+        sut.uninstall(context, openTelemetryRum)
+
+        // then
+        verify { context.unregisterReceiver(any<PowerSaveModeDetector>()) }
+    }
+
+    @Test
+    fun `should be a safe no-op when uninstall is called before install`() {
+        // when
+        sut.uninstall(context, openTelemetryRum)
+
+        // then
+        verify(exactly = 0) { context.unregisterReceiver(any<PowerSaveModeDetector>()) }
+    }
+}

--- a/instrumentation/power-save-mode/src/test/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeInstrumentationTest.kt
+++ b/instrumentation/power-save-mode/src/test/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeInstrumentationTest.kt
@@ -5,33 +5,42 @@
 
 package io.opentelemetry.android.instrumentation.powersavemode
 
-import android.app.Application
 import android.content.Context
+import android.content.Intent
+import android.os.Looper
 import android.os.PowerManager
+import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
-import io.mockk.verify
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
 
 @RunWith(AndroidJUnit4::class)
 class PowerSaveModeInstrumentationTest {
-    private lateinit var sut: PowerSaveModeInstrumentation
+    @get:Rule
+    val openTelemetryRule: OpenTelemetryRule = OpenTelemetryRule.create()
 
-    private val context = mockk<Application>(relaxed = true)
+    private val context = ApplicationProvider.getApplicationContext<Context>()
+    private val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+    private val intent = Intent(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED)
+
+    // The RUM wrapper is only a vehicle for the OpenTelemetry instance; the assertions below run
+    // against the real in-memory telemetry produced by OpenTelemetryRule, not against the mock.
     private val openTelemetryRum = mockk<OpenTelemetryRum>(relaxed = true)
-    private val powerManager = mockk<PowerManager>(relaxed = true)
+    private val instrumentation = PowerSaveModeInstrumentation()
 
     @Before
     fun setup() {
-        sut = PowerSaveModeInstrumentation()
-        every { context.applicationContext } returns context
-        every { context.getSystemService(Context.POWER_SERVICE) } returns powerManager
+        every { openTelemetryRum.openTelemetry } returns openTelemetryRule.openTelemetry
     }
 
     @After
@@ -39,37 +48,39 @@ class PowerSaveModeInstrumentationTest {
         unmockkAll()
     }
 
-    // ACTION_POWER_SAVE_MODE_CHANGED is a protected system broadcast, so the production code
-    // registers without an exported flag on purpose. Lint can't inspect the IntentFilter through
-    // the mockk matcher here, so it reports a false positive on this verification.
-    @Suppress("UnspecifiedRegisterReceiverFlag")
     @Test
-    fun `should register a power save mode receiver on install`() {
-        // when
-        sut.install(context, openTelemetryRum)
+    fun `emits a power save mode event for broadcasts received after install`() {
+        shadowOf(powerManager).setIsPowerSaveMode(true)
+        instrumentation.install(context, openTelemetryRum)
 
-        // then
-        verify { context.registerReceiver(any<PowerSaveModeDetector>(), any()) }
+        context.sendBroadcast(intent)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertThat(openTelemetryRule.logRecords).hasSize(1)
+        val record = openTelemetryRule.logRecords.single()
+        assertThat(record.eventName).isEqualTo(PowerSaveModeDetector.EVENT_NAME)
+        assertThat(record.attributes.get(PowerSaveModeDetector.POWER_SAVE_MODE_ENABLED))
+            .isEqualTo(true)
     }
 
     @Test
-    fun `should unregister the receiver on uninstall`() {
-        // given
-        sut.install(context, openTelemetryRum)
+    fun `stops emitting events after uninstall`() {
+        instrumentation.install(context, openTelemetryRum)
+        instrumentation.uninstall(context, openTelemetryRum)
 
-        // when
-        sut.uninstall(context, openTelemetryRum)
+        context.sendBroadcast(intent)
+        shadowOf(Looper.getMainLooper()).idle()
 
-        // then
-        verify { context.unregisterReceiver(any<PowerSaveModeDetector>()) }
+        assertThat(openTelemetryRule.logRecords).isEmpty()
     }
 
     @Test
-    fun `should be a safe no-op when uninstall is called before install`() {
-        // when
-        sut.uninstall(context, openTelemetryRum)
+    fun `uninstall before install is a safe no-op`() {
+        instrumentation.uninstall(context, openTelemetryRum)
 
-        // then
-        verify(exactly = 0) { context.unregisterReceiver(any<PowerSaveModeDetector>()) }
+        context.sendBroadcast(intent)
+        shadowOf(Looper.getMainLooper()).idle()
+
+        assertThat(openTelemetryRule.logRecords).isEmpty()
     }
 }


### PR DESCRIPTION
Closes #1800.

Adds an opt-in instrumentation module that reports changes to the device's power save (battery saver) mode, following the pattern of the existing `thermal` instrumentation.

## What it does

- Registers a `BroadcastReceiver` for `PowerManager.ACTION_POWER_SAVE_MODE_CHANGED` (no polling); on each change it reads `PowerManager.isPowerSaveMode` and emits one event.
- Event `device.power_save_mode.change` with a boolean attribute `android.power_save_mode.enabled`, under instrumentation scope `io.opentelemetry.power_save_mode`.
- Opt-in: not wired into the android-agent by default, consistent with `thermal`.
- The power save mode APIs (`isPowerSaveMode` / `ACTION_POWER_SAVE_MODE_CHANGED`) are available since API 21, which is below `minSdk`, so no version gating is required.

## Notes

- Structure mirrors the `thermal` module (instrumentation + detector + unit tests + API dump + README).
- The event name and attribute are a first proposal — happy to adjust to match any preferred semantic conventions.

## Verification

`./gradlew :instrumentation:power-save-mode:build` passes locally: compile, unit tests (Robolectric), lint, API check, detekt, and assemble.