### PR TITLE
Federated semantic conventions phase 1

### DIFF
--- a/semconv/README.md
+++ b/semconv/README.md
@@ -1,0 +1,13 @@
+# Federated Android Semantic Conventions
+
+This directory contains Android-specific semantic convention definitions that are not currently
+defined by the upstream `open-telemetry/semantic-conventions` repository.
+
+These conventions are modeled as a federated semantic convention registry. The registry manifest
+declares the upstream OpenTelemetry semantic conventions as a dependency so Android-specific
+events can reference upstream attributes without redefining them.
+
+The model intentionally excludes names that are already covered by upstream semantic conventions,
+such as `app.crash`, `app.jank`, `app.screen.click`, and `app.widget.click`.
+
+Code generation and production code usage will be added in later phases.

--- a/semconv/model/android/events.yaml
+++ b/semconv/model/android/events.yaml
@@ -1,0 +1,142 @@
+groups:
+  - id: event.app.screen.longpress
+    type: event
+    name: app.screen.longpress
+    stability: development
+    brief: >
+      This event represents a long press on the screen of an application.
+    attributes:
+      - ref: app.screen.coordinate.x
+        requirement_level: required
+      - ref: app.screen.coordinate.y
+        requirement_level: required
+      - ref: app.screen.id
+        requirement_level: recommended
+      - ref: app.screen.name
+        requirement_level: opt_in
+      - ref: hw.pointer.button
+        requirement_level: opt_in
+      - ref: hw.pointer.type
+        requirement_level: recommended
+  - id: event.app.widget.longpress
+    type: event
+    name: app.widget.longpress
+    stability: development
+    brief: >
+      This event represents a long press on an application widget.
+    attributes:
+      - ref: app.widget.id
+        requirement_level: required
+      - ref: app.widget.name
+        requirement_level: opt_in
+      - ref: app.screen.coordinate.x
+        requirement_level: opt_in
+      - ref: app.screen.coordinate.y
+        requirement_level: opt_in
+      - ref: app.screen.id
+        requirement_level: recommended
+      - ref: app.screen.name
+        requirement_level: opt_in
+      - ref: hw.pointer.button
+        requirement_level: opt_in
+      - ref: hw.pointer.type
+        requirement_level: recommended
+  - id: event.device.anr
+    type: event
+    name: device.anr
+    stability: development
+    brief: >
+      This event indicates that an Android application did not respond on the main thread.
+  - id: event.device.screen_orientation
+    type: event
+    name: device.screen_orientation
+    stability: development
+    brief: >
+      This event indicates that the Android screen orientation changed.
+    attributes:
+      - ref: screen.orientation
+        requirement_level: required
+  - id: event.network.change
+    type: event
+    name: network.change
+    stability: development
+    brief: >
+      This event indicates that Android network connectivity changed.
+    attributes:
+      - ref: network.status
+        requirement_level: recommended
+  - id: event.rum.sdk.init.started
+    type: event
+    name: rum.sdk.init.started
+    stability: development
+    brief: >
+      This event indicates that Android RUM SDK initialization started.
+  - id: event.rum.sdk.init.net.provider
+    type: event
+    name: rum.sdk.init.net.provider
+    stability: development
+    brief: >
+      This event indicates that the current network provider initialized during Android RUM SDK
+      startup.
+  - id: event.rum.sdk.init.net.monitor
+    type: event
+    name: rum.sdk.init.net.monitor
+    stability: development
+    brief: >
+      This event indicates that the network monitor initialized during Android RUM SDK startup.
+  - id: event.rum.sdk.init.anr_monitor
+    type: event
+    name: rum.sdk.init.anr_monitor
+    stability: development
+    brief: >
+      This event indicates that the ANR monitor initialized during Android RUM SDK startup.
+  - id: event.rum.sdk.init.jank_monitor
+    type: event
+    name: rum.sdk.init.jank_monitor
+    stability: development
+    brief: >
+      This event indicates that the jank monitor initialized during Android RUM SDK startup.
+  - id: event.rum.sdk.init.crash.reporter
+    type: event
+    name: rum.sdk.init.crash.reporter
+    stability: development
+    brief: >
+      This event indicates that crash reporting initialized during Android RUM SDK startup.
+  - id: event.rum.sdk.init.span.exporter
+    type: event
+    name: rum.sdk.init.span.exporter
+    stability: development
+    brief: >
+      This event indicates that the span exporter initialized during Android RUM SDK startup.
+    attributes:
+      - ref: span.exporter
+        requirement_level: required
+  - id: event.websocket.close
+    type: event
+    name: websocket.close
+    stability: development
+    brief: >
+      This event indicates that a WebSocket closed.
+  - id: event.websocket.error
+    type: event
+    name: websocket.error
+    stability: development
+    brief: >
+      This event indicates that a WebSocket failed.
+  - id: event.websocket.message
+    type: event
+    name: websocket.message
+    stability: development
+    brief: >
+      This event indicates that a WebSocket message was received.
+    attributes:
+      - ref: websocket.message.size
+        requirement_level: recommended
+      - ref: websocket.message.type
+        requirement_level: recommended
+  - id: event.websocket.open
+    type: event
+    name: websocket.open
+    stability: development
+    brief: >
+      This event indicates that a WebSocket opened.

--- a/semconv/model/android/registry.yaml
+++ b/semconv/model/android/registry.yaml
@@ -1,0 +1,110 @@
+groups:
+  - id: registry.android.semconv
+    type: attribute_group
+    brief: >
+      Android SDK attributes that are not currently defined by upstream OpenTelemetry semantic
+      conventions.
+    stability: development
+    attributes:
+      - id: activity.name
+        type: string
+        stability: development
+        brief: >
+          The Android activity class name for which telemetry is relevant.
+        examples: ["MainActivity", "LoginScreen"]
+      - id: android.log.tag
+        type: string
+        stability: development
+        brief: >
+          The Android log tag supplied to android.util.Log.
+        examples: ["MainActivity", "OkHttp"]
+      - id: battery.percent
+        type: double
+        stability: development
+        brief: >
+          The current battery charge as a percentage of total capacity.
+        examples: [42.0, 99.5]
+      - id: fragment.name
+        type: string
+        stability: development
+        brief: >
+          The Android fragment class name for which telemetry is relevant.
+        examples: ["ProductDetailFragment"]
+      - id: heap.free
+        type: int
+        stability: development
+        brief: >
+          The amount of free heap memory, in bytes.
+        examples: [1048576]
+      - id: hw.pointer.button
+        type: string
+        stability: development
+        brief: >
+          The hardware pointer button associated with a pointer gesture.
+        examples: ["primary", "secondary", "tertiary", "back", "forward"]
+      - id: hw.pointer.clicks
+        type: int
+        stability: development
+        brief: >
+          The click count associated with a pointer gesture.
+        examples: [1, 2]
+      - id: hw.pointer.type
+        type: string
+        stability: development
+        brief: >
+          The hardware pointer type associated with a pointer gesture.
+        examples: ["finger", "mouse", "stylus", "eraser", "unknown"]
+      - id: last.screen.name
+        type: string
+        stability: development
+        brief: >
+          The previously visible screen name.
+        examples: ["MainActivity"]
+      - id: network.status
+        type: string
+        stability: development
+        brief: >
+          The Android network status after a network change.
+        examples: ["TRANSPORT_WIFI", "TRANSPORT_CELLULAR", "NO_NETWORK_AVAILABLE"]
+      - id: screen.name
+        type: string
+        stability: development
+        brief: >
+          The current application screen name used by the Android SDK.
+        examples: ["user.login", "Cart"]
+      - id: screen.orientation
+        type: string
+        stability: development
+        brief: >
+          The Android screen orientation.
+        examples: ["portrait", "landscape", "undefined"]
+      - id: span.exporter
+        type: string
+        stability: development
+        brief: >
+          A string representation of the span exporter configured during SDK initialization.
+        examples: ["OtlpHttpSpanExporter"]
+      - id: start.type
+        type: string
+        stability: development
+        brief: >
+          The application start type.
+        examples: ["cold", "warm", "hot"]
+      - id: storage.free
+        type: int
+        stability: development
+        brief: >
+          The amount of free application file storage, in bytes.
+        examples: [1048576]
+      - id: websocket.message.size
+        type: int
+        stability: development
+        brief: >
+          The size of a WebSocket message payload.
+        examples: [128]
+      - id: websocket.message.type
+        type: string
+        stability: development
+        brief: >
+          The WebSocket message payload type.
+        examples: ["text", "bytes"]

--- a/semconv/model/manifest.yaml
+++ b/semconv/model/manifest.yaml
@@ -1,0 +1,6 @@
+name: opentelemetry-android
+description: Local semantic conventions for opentelemetry-android.
+schema_url: https://opentelemetry.io/schemas/opentelemetry-android/0.1.0
+dependencies:
+  - name: otel
+    registry_path: https://github.com/open-telemetry/semantic-conventions@v1.41.1[model]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,6 +20,7 @@ include(":animal-sniffer-signature")
 include(":common")
 include(":services")
 include(":session")
+include(":semconv")
 include(":opentelemetry-android-bom")
 includeFromDir("instrumentation")
 
@@ -39,4 +40,3 @@ fun includeFromDir(
         }
     }
 }
- 


### PR DESCRIPTION
Part of #1814. AI assisted.

This establishes a new module to hold our android-specific semconv. This PR pulls in all of the semantic conventions that I could find and creates attribute and event entries for these. 

There is not yet any weaver or code generation. As described in #1814, this will come in the following phase(s).