### PR TITLE
Make the disk buffering export period configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Disk buffering now lets you configure how often buffered signals are read from disk and
   exported, via `DiskBufferingConfig.exportPeriodMillis` (defaults to 10 seconds).
-  ([#1823](https://github.com/open-telemetry/opentelemetry-android/issues/1823))
+  ([#1834](https://github.com/open-telemetry/opentelemetry-android/pull/1834))
 
 ## Version 1.5.0 (2026-06-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Add opt-in power save mode instrumentation that listens for device power-save (battery saver)
   mode changes and emits a `device.power_save_mode.change` event per change.
   ([#1811](https://github.com/open-telemetry/opentelemetry-android/pull/1811))
+- Disk buffering now lets you configure how often buffered signals are read from disk and
+  exported, via `DiskBufferingConfig.exportPeriodMillis` (defaults to 10 seconds).
+  ([#1823](https://github.com/open-telemetry/opentelemetry-android/issues/1823))
 
 ## Version 1.4.0 (2026-05-19)
 

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -112,7 +112,8 @@ public final class io/opentelemetry/android/features/diskbuffering/DiskBuffering
 	public fun <init> (ZIJJJI)V
 	public fun <init> (ZIJJJIZ)V
 	public fun <init> (ZIJJJIZLjava/io/File;)V
-	public synthetic fun <init> (ZIJJJIZLjava/io/File;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZIJJJIZLjava/io/File;J)V
+	public synthetic fun <init> (ZIJJJIZLjava/io/File;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()I
 	public final fun component3 ()J
@@ -121,8 +122,9 @@ public final class io/opentelemetry/android/features/diskbuffering/DiskBuffering
 	public final fun component6 ()I
 	public final fun component7 ()Z
 	public final fun component8 ()Ljava/io/File;
-	public final fun copy (ZIJJJIZLjava/io/File;)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
-	public static synthetic fun copy$default (Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;ZIJJJIZLjava/io/File;ILjava/lang/Object;)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public final fun component9 ()J
+	public final fun copy (ZIJJJIZLjava/io/File;J)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public static synthetic fun copy$default (Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;ZIJJJIZLjava/io/File;JILjava/lang/Object;)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
 	public static final fun create ()Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
 	public static final fun create (Z)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
 	public static final fun create (ZI)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
@@ -132,9 +134,11 @@ public final class io/opentelemetry/android/features/diskbuffering/DiskBuffering
 	public static final fun create (ZIJJJI)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
 	public static final fun create (ZIJJJIZ)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
 	public static final fun create (ZIJJJIZLjava/io/File;)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public static final fun create (ZIJJJIZLjava/io/File;J)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDebugEnabled ()Z
 	public final fun getEnabled ()Z
+	public final fun getExportPeriodMillis ()J
 	public final fun getMaxCacheFileSize ()I
 	public final fun getMaxCacheSize ()I
 	public final fun getMaxFileAgeForReadMillis ()J
@@ -155,10 +159,12 @@ public final class io/opentelemetry/android/features/diskbuffering/DiskBuffering
 	public final fun create (ZIJJJI)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
 	public final fun create (ZIJJJIZ)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
 	public final fun create (ZIJJJIZLjava/io/File;)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
-	public static synthetic fun create$default (Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig$Companion;ZIJJJIZLjava/io/File;ILjava/lang/Object;)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public final fun create (ZIJJJIZLjava/io/File;J)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
+	public static synthetic fun create$default (Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig$Companion;ZIJJJIZLjava/io/File;JILjava/lang/Object;)Lio/opentelemetry/android/features/diskbuffering/DiskBufferingConfig;
 }
 
 public final class io/opentelemetry/android/features/diskbuffering/DiskBufferingConfigKt {
+	public static final field DEFAULT_EXPORT_PERIOD_MS J
 	public static final field DEFAULT_MAX_CACHE_SIZE I
 	public static final field DEFAULT_MAX_FILE_AGE_FOR_READ_MS J
 	public static final field DEFAULT_MAX_FILE_AGE_FOR_WRITE_MS J

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -164,7 +164,7 @@ public final class io/opentelemetry/android/features/diskbuffering/DiskBuffering
 }
 
 public final class io/opentelemetry/android/features/diskbuffering/DiskBufferingConfigKt {
-	public static final field DEFAULT_EXPORT_PERIOD_MS J
+	public static final field DEFAULT_EXPORT_PERIOD_S J
 	public static final field DEFAULT_MAX_CACHE_SIZE I
 	public static final field DEFAULT_MAX_FILE_AGE_FOR_READ_MS J
 	public static final field DEFAULT_MAX_FILE_AGE_FOR_WRITE_MS J

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.kt
@@ -75,6 +75,7 @@ import java.io.IOException
 import java.util.function.BiFunction
 import java.util.function.Consumer
 import java.util.function.Function
+import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * A builder of [OpenTelemetryRum]. It enabled configuring the OpenTelemetry SDK and disabling
@@ -499,7 +500,11 @@ class OpenTelemetryRumBuilder internal constructor(
     ) {
         val handler =
             exportScheduleEnablement ?: signalExporter?.let {
-                DiskBufferingEnablement(it, periodicTaskScheduler.value)
+                DiskBufferingEnablement(
+                    it,
+                    periodicTaskScheduler.value,
+                    config.getDiskBufferingConfig().exportPeriodMillis.milliseconds,
+                )
             }
 
         exportScheduleEnablement = handler

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfig.kt
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfig.kt
@@ -15,6 +15,7 @@ const val MAX_CACHE_FILE_SIZE: Int = 1024 * 1024
 const val DEFAULT_MAX_FILE_AGE_FOR_WRITE_MS = 30L
 const val DEFAULT_MIN_FILE_AGE_FOR_READ_MS = 33L
 const val DEFAULT_MAX_FILE_AGE_FOR_READ_MS = 18L
+const val DEFAULT_EXPORT_PERIOD_MS = 10L
 
 data class DiskBufferingConfig
     @JvmOverloads
@@ -31,6 +32,10 @@ data class DiskBufferingConfig
          * `null`, a default directory inside the application's cache directory will be used.
          */
         val signalsBufferDir: File? = null,
+        /**
+         * How often the exporter wakes up to read buffered signals from disk and send them.
+         */
+        val exportPeriodMillis: Long = TimeUnit.SECONDS.toMillis(DEFAULT_EXPORT_PERIOD_MS),
     ) {
         companion object {
             /**
@@ -49,12 +54,19 @@ data class DiskBufferingConfig
                 maxCacheFileSize: Int = MAX_CACHE_FILE_SIZE,
                 debugEnabled: Boolean = false,
                 signalsBufferDir: File? = null,
+                exportPeriodMillis: Long = TimeUnit.SECONDS.toMillis(10),
             ): DiskBufferingConfig {
                 var minRead = minFileAgeForReadMillis
                 if (minFileAgeForReadMillis <= maxFileAgeForWriteMillis) {
                     minRead = maxFileAgeForWriteMillis + 5
                     Log.w(OTEL_RUM_LOG_TAG, "minFileAgeForReadMillis must be greater than maxFileAgeForWriteMillis")
                     Log.w(OTEL_RUM_LOG_TAG, "overriding minFileAgeForReadMillis from $minFileAgeForReadMillis to $minRead")
+                }
+                var exportPeriod = exportPeriodMillis
+                if (exportPeriod <= 0) {
+                    exportPeriod = TimeUnit.SECONDS.toMillis(10)
+                    Log.w(OTEL_RUM_LOG_TAG, "exportPeriodMillis must be greater than 0")
+                    Log.w(OTEL_RUM_LOG_TAG, "overriding exportPeriodMillis from $exportPeriodMillis to $exportPeriod")
                 }
                 return DiskBufferingConfig(
                     enabled = enabled,
@@ -65,6 +77,7 @@ data class DiskBufferingConfig
                     maxCacheFileSize = maxCacheFileSize,
                     debugEnabled = debugEnabled,
                     signalsBufferDir = signalsBufferDir,
+                    exportPeriodMillis = exportPeriod,
                 )
             }
         }

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfig.kt
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfig.kt
@@ -54,7 +54,7 @@ data class DiskBufferingConfig
                 maxCacheFileSize: Int = MAX_CACHE_FILE_SIZE,
                 debugEnabled: Boolean = false,
                 signalsBufferDir: File? = null,
-                exportPeriodMillis: Long = TimeUnit.SECONDS.toMillis(10),
+                exportPeriodMillis: Long = TimeUnit.SECONDS.toMillis(DEFAULT_EXPORT_PERIOD_MS),
             ): DiskBufferingConfig {
                 var minRead = minFileAgeForReadMillis
                 if (minFileAgeForReadMillis <= maxFileAgeForWriteMillis) {
@@ -64,7 +64,7 @@ data class DiskBufferingConfig
                 }
                 var exportPeriod = exportPeriodMillis
                 if (exportPeriod <= 0) {
-                    exportPeriod = TimeUnit.SECONDS.toMillis(10)
+                    exportPeriod = TimeUnit.SECONDS.toMillis(DEFAULT_EXPORT_PERIOD_MS)
                     Log.w(OTEL_RUM_LOG_TAG, "exportPeriodMillis must be greater than 0")
                     Log.w(OTEL_RUM_LOG_TAG, "overriding exportPeriodMillis from $exportPeriodMillis to $exportPeriod")
                 }

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfig.kt
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfig.kt
@@ -15,7 +15,7 @@ const val MAX_CACHE_FILE_SIZE: Int = 1024 * 1024
 const val DEFAULT_MAX_FILE_AGE_FOR_WRITE_MS = 30L
 const val DEFAULT_MIN_FILE_AGE_FOR_READ_MS = 33L
 const val DEFAULT_MAX_FILE_AGE_FOR_READ_MS = 18L
-const val DEFAULT_EXPORT_PERIOD_MS = 10L
+const val DEFAULT_EXPORT_PERIOD_S = 10L
 
 data class DiskBufferingConfig
     @JvmOverloads
@@ -35,7 +35,7 @@ data class DiskBufferingConfig
         /**
          * How often the exporter wakes up to read buffered signals from disk and send them.
          */
-        val exportPeriodMillis: Long = TimeUnit.SECONDS.toMillis(DEFAULT_EXPORT_PERIOD_MS),
+        val exportPeriodMillis: Long = TimeUnit.SECONDS.toMillis(DEFAULT_EXPORT_PERIOD_S),
     ) {
         companion object {
             /**
@@ -54,7 +54,7 @@ data class DiskBufferingConfig
                 maxCacheFileSize: Int = MAX_CACHE_FILE_SIZE,
                 debugEnabled: Boolean = false,
                 signalsBufferDir: File? = null,
-                exportPeriodMillis: Long = TimeUnit.SECONDS.toMillis(DEFAULT_EXPORT_PERIOD_MS),
+                exportPeriodMillis: Long = TimeUnit.SECONDS.toMillis(DEFAULT_EXPORT_PERIOD_S),
             ): DiskBufferingConfig {
                 var minRead = minFileAgeForReadMillis
                 if (minFileAgeForReadMillis <= maxFileAgeForWriteMillis) {
@@ -64,7 +64,7 @@ data class DiskBufferingConfig
                 }
                 var exportPeriod = exportPeriodMillis
                 if (exportPeriod <= 0) {
-                    exportPeriod = TimeUnit.SECONDS.toMillis(DEFAULT_EXPORT_PERIOD_MS)
+                    exportPeriod = TimeUnit.SECONDS.toMillis(DEFAULT_EXPORT_PERIOD_S)
                     Log.w(OTEL_RUM_LOG_TAG, "exportPeriodMillis must be greater than 0")
                     Log.w(OTEL_RUM_LOG_TAG, "overriding exportPeriodMillis from $exportPeriodMillis to $exportPeriod")
                 }

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DiskBufferingEnablement.kt
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DiskBufferingEnablement.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.android.features.diskbuffering.scheduler
 
+import io.opentelemetry.android.features.diskbuffering.DEFAULT_EXPORT_PERIOD_S
 import io.opentelemetry.android.features.diskbuffering.SignalFromDiskExporter
 import io.opentelemetry.android.internal.services.periodic.PeriodicTaskScheduler
 import java.util.concurrent.atomic.AtomicReference
@@ -14,7 +15,7 @@ import kotlin.time.Duration.Companion.seconds
 internal class DiskBufferingEnablement(
     private val signalFromDiskExporter: SignalFromDiskExporter,
     private val taskScheduler: PeriodicTaskScheduler,
-    private val exportPeriod: Duration = 10.seconds,
+    private val exportPeriod: Duration = DEFAULT_EXPORT_PERIOD_S.seconds,
 ) : ScheduleEnablement {
     private val periodicExporter = AtomicReference<PeriodicExporter?>(null)
 

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DiskBufferingEnablement.kt
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/scheduler/DiskBufferingEnablement.kt
@@ -8,15 +8,18 @@ package io.opentelemetry.android.features.diskbuffering.scheduler
 import io.opentelemetry.android.features.diskbuffering.SignalFromDiskExporter
 import io.opentelemetry.android.internal.services.periodic.PeriodicTaskScheduler
 import java.util.concurrent.atomic.AtomicReference
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 internal class DiskBufferingEnablement(
     private val signalFromDiskExporter: SignalFromDiskExporter,
     private val taskScheduler: PeriodicTaskScheduler,
+    private val exportPeriod: Duration = 10.seconds,
 ) : ScheduleEnablement {
     private val periodicExporter = AtomicReference<PeriodicExporter?>(null)
 
     override fun enable() {
-        val exporter = PeriodicExporter(signalFromDiskExporter)
+        val exporter = PeriodicExporter(signalFromDiskExporter, exportPeriod)
         if (periodicExporter.compareAndSet(null, exporter)) {
             taskScheduler.start(exporter)
         }

--- a/core/src/test/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfigTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfigTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.features.diskbuffering
+
+import java.util.concurrent.TimeUnit
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class DiskBufferingConfigTest {
+    @Test
+    fun `defaults to a ten second export period`() {
+        assertThat(DiskBufferingConfig.create().exportPeriodMillis)
+            .isEqualTo(TimeUnit.SECONDS.toMillis(10))
+    }
+
+    @Test
+    fun `keeps a custom export period`() {
+        val config = DiskBufferingConfig.create(exportPeriodMillis = TimeUnit.MINUTES.toMillis(15))
+
+        assertThat(config.exportPeriodMillis).isEqualTo(TimeUnit.MINUTES.toMillis(15))
+    }
+
+    @Test
+    fun `falls back to the default when the export period is not positive`() {
+        val config = DiskBufferingConfig.create(exportPeriodMillis = 0)
+
+        assertThat(config.exportPeriodMillis).isEqualTo(TimeUnit.SECONDS.toMillis(10))
+    }
+}

--- a/core/src/test/java/io/opentelemetry/android/features/diskbuffering/scheduler/DiskBufferingEnablementTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/features/diskbuffering/scheduler/DiskBufferingEnablementTest.kt
@@ -14,6 +14,7 @@ import io.mockk.verify
 import io.opentelemetry.android.features.diskbuffering.SignalFromDiskExporter
 import io.opentelemetry.android.internal.services.periodic.PeriodicRunnable
 import io.opentelemetry.android.internal.services.periodic.PeriodicTaskScheduler
+import kotlin.time.Duration.Companion.minutes
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -67,5 +68,16 @@ class DiskBufferingEnablementTest {
         assertThat(captured[0].shouldStop()).isTrue()
         assertThat(captured[1].shouldStop()).isFalse()
         assertThat(captured[1]).isNotSameAs(captured[0])
+    }
+
+    @Test
+    fun `Pass the configured export period to the exporter`() {
+        val captor = slot<PeriodicRunnable>()
+        val enablement = DiskBufferingEnablement(mockk<SignalFromDiskExporter>(), taskScheduler, 1.minutes)
+
+        enablement.enable()
+
+        verify { taskScheduler.start(capture(captor)) }
+        assertThat((captor.captured as PeriodicExporter).period()).isEqualTo(1.minutes)
     }
 }


### PR DESCRIPTION
## Summary

The disk-buffering `PeriodicExporter` polled the disk for buffered signals on a fixed
10-second interval that could not be changed. Apps that deliberately buffer for longer (for
example by raising `maxFileAgeForWriteMillis` to reduce backend traffic) still paid for a
10-second poll, checking the disk far more often than data could become ready.

This adds a dedicated, configurable export period.

## Changes

- `DiskBufferingConfig` gains `exportPeriodMillis` (default 10 seconds), alongside the existing
  disk-buffering fields. The field is appended last so the positional `create()` overloads stay
  source- and binary-compatible.
- `create()` falls back to the default when given a non-positive value, mirroring how the
  existing min/max fields are fixed up.
- The value is threaded through `DiskBufferingEnablement` into the `PeriodicExporter`. Default
  behavior is unchanged.

## Notes for reviewers

- This is the `:core` half discussed in #1823. The friendlier high-level DSL
  (`exportingPeriod` / `discardAfter`) is tracked separately in #1821 and is intentionally not
  included here to keep this change focused.
- The new option deliberately does not reuse `minFileAgeForReadMillis`, in line with the
  guidance on the issue and the direction of open-telemetry/opentelemetry-java-contrib#2897.
- Public API change in `:core`; `core.api` is updated accordingly. `:android-agent` is unchanged.

## Testing

- `DiskBufferingConfigTest`: default, custom value, and non-positive fallback.
- `DiskBufferingEnablementTest`: the configured period reaches `PeriodicExporter.period()`.

Resolves #1823
