### PR TITLE
Bumping upstream versions

### DIFF
--- a/core/consumer-rules.pro
+++ b/core/consumer-rules.pro
@@ -10,3 +10,4 @@
 -dontwarn io.grpc.stub.AbstractFutureStub
 -dontwarn io.grpc.stub.AbstractStub$StubFactory
 -dontwarn io.grpc.stub.AbstractStub
+-dontwarn io.opentelemetry.sdk.autoconfigure.**

--- a/demo-app/gradle/libs.versions.toml
+++ b/demo-app/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 byteBuddy = "1.18.10"
 okhttp = "5.4.0"
-opentelemetry = "1.62.0"
-opentelemetry-alpha = "1.62.0-alpha"
+opentelemetry = "1.63.0"
+opentelemetry-alpha = "1.63.0-alpha"
 junit = "6.1.0"
 spotless = "8.7.0"
 kotlin = "2.3.21"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-opentelemetry-instrumentation-alpha = "2.28.1-alpha"
+opentelemetry-instrumentation-alpha = "2.29.0-alpha"
 #opentelemetry-instrumentation = "2.9.0" // alpha bom includes non-alpha bom
 opentelemetry-contrib = "1.57.0-alpha"
 opentelemetry-semconv-kotlin = "0.4.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 opentelemetry-instrumentation-alpha = "2.29.0-alpha"
 #opentelemetry-instrumentation = "2.9.0" // alpha bom includes non-alpha bom
-opentelemetry-contrib = "1.57.0-alpha"
+opentelemetry-contrib = "1.58.0-alpha"
 opentelemetry-semconv-kotlin = "0.4.0"
 junit = "6.1.0"
 byteBuddy = "1.18.10"


### PR DESCRIPTION
Supersedes https://github.com/open-telemetry/opentelemetry-android/pull/1831, https://github.com/open-telemetry/opentelemetry-android/pull/1830, and https://github.com/open-telemetry/opentelemetry-android/pull/1793