### PR TITLE
Update to Android SDK 37 for compilation

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -73,6 +73,7 @@ dependencies {
     implementation(libs.opentelemetry.diskBuffering)
     implementation(libs.opentelemetry.processors)
     implementation(libs.kotlinx.coroutines)
+    testImplementation(project(":test-common"))
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.awaitility)
     testImplementation(libs.robolectric)

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,6 +23,6 @@ android.useAndroidX=true
 
 android.minSdk=23
 android.minCompileSdk=34
-android.compileSdk=36
+android.compileSdk=37
 version=1.5.0
 group=io.opentelemetry.android

--- a/test-common/build.gradle.kts
+++ b/test-common/build.gradle.kts
@@ -20,4 +20,6 @@ dependencies {
     api(libs.assertj.core)
     implementation(libs.androidx.core)
     implementation(libs.androidx.junit)
+    // Needed to compile OtelGlobalConfigProvider; consumers already provide Robolectric at test runtime.
+    compileOnly(libs.robolectric)
 }

--- a/test-common/src/main/kotlin/io/opentelemetry/android/test/common/OtelGlobalConfigProvider.kt
+++ b/test-common/src/main/kotlin/io/opentelemetry/android/test/common/OtelGlobalConfigProvider.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.test.common
+
+import org.robolectric.annotation.Config
+import org.robolectric.pluginapi.config.GlobalConfigProvider
+
+class OtelGlobalConfigProvider : GlobalConfigProvider {
+    override fun get(): Config = Config.Builder().setSdk(Config.NEWEST_SDK).build()
+}

--- a/test-common/src/main/resources/META-INF/services/org.robolectric.pluginapi.config.GlobalConfigProvider
+++ b/test-common/src/main/resources/META-INF/services/org.robolectric.pluginapi.config.GlobalConfigProvider
@@ -1,0 +1,1 @@
+io.opentelemetry.android.test.common.OtelGlobalConfigProvider


### PR DESCRIPTION
Use Android SDK 37 so we can support apps that target Android 17