### PR TITLE
Enable Kotlin Spotless checks

### DIFF
--- a/buildSrc/src/main/kotlin/otel.spotless-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.spotless-conventions.gradle.kts
@@ -4,23 +4,13 @@ plugins {
     id("com.diffplug.spotless")
 }
 
-var kotlinConfigured = false
-
 spotless {
     java {
         googleJavaFormat().aosp()
         licenseHeaderFile(rootProject.file("gradle/spotless.license.java"), "(package|import|public)")
         target("src/**/*.java")
     }
-    plugins.withId("org.jetbrains.kotlin.jvm") {
-        configureKotlinOnce(this@spotless)
-    }
-    plugins.withId("org.jetbrains.kotlin.android") {
-        configureKotlinOnce(this@spotless)
-    }
-    plugins.withId("kotlin-android") {
-        configureKotlinOnce(this@spotless)
-    }
+    configureKotlin(this@spotless)
     kotlinGradle {
         ktlint()
     }
@@ -59,15 +49,6 @@ if (project == rootProject) {
         kotlinGradle {
             ktlint()
         }
-    }
-}
-
-fun configureKotlinOnce(
-    spotlessExtension: SpotlessExtension,
-) {
-    if (!kotlinConfigured) {
-        kotlinConfigured = true
-        configureKotlin(spotlessExtension)
     }
 }
 

--- a/buildSrc/src/main/kotlin/otel.spotless-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/otel.spotless-conventions.gradle.kts
@@ -4,6 +4,8 @@ plugins {
     id("com.diffplug.spotless")
 }
 
+var kotlinConfigured = false
+
 spotless {
     java {
         googleJavaFormat().aosp()
@@ -11,10 +13,13 @@ spotless {
         target("src/**/*.java")
     }
     plugins.withId("org.jetbrains.kotlin.jvm") {
-        configureKotlin(this@spotless)
+        configureKotlinOnce(this@spotless)
     }
     plugins.withId("org.jetbrains.kotlin.android") {
-        configureKotlin(this@spotless)
+        configureKotlinOnce(this@spotless)
+    }
+    plugins.withId("kotlin-android") {
+        configureKotlinOnce(this@spotless)
     }
     kotlinGradle {
         ktlint()
@@ -54,6 +59,15 @@ if (project == rootProject) {
         kotlinGradle {
             ktlint()
         }
+    }
+}
+
+fun configureKotlinOnce(
+    spotlessExtension: SpotlessExtension,
+) {
+    if (!kotlinConfigured) {
+        kotlinConfigured = true
+        configureKotlin(spotlessExtension)
     }
 }
 

--- a/core/src/main/java/io/opentelemetry/android/internal/processors/NetworkAttributesLogRecordAppender.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/processors/NetworkAttributesLogRecordAppender.kt
@@ -15,8 +15,9 @@ class NetworkAttributesLogRecordAppender(
     private val currentNetworkProvider: CurrentNetworkProvider,
     private val networkAttributesExtractor: CurrentNetworkAttributesExtractor = CurrentNetworkAttributesExtractor(),
 ) : LogRecordProcessor {
-    constructor(networkProvider: CurrentNetworkProvider) : this(networkProvider,
-        CurrentNetworkAttributesExtractor()
+    constructor(networkProvider: CurrentNetworkProvider) : this(
+        networkProvider,
+        CurrentNetworkAttributesExtractor(),
     )
 
     override fun onEmit(

--- a/core/src/test/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfigTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfigTest.kt
@@ -5,9 +5,9 @@
 
 package io.opentelemetry.android.features.diskbuffering
 
-import java.util.concurrent.TimeUnit
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import java.util.concurrent.TimeUnit
 
 class DiskBufferingConfigTest {
     @Test

--- a/core/src/test/java/io/opentelemetry/android/features/diskbuffering/scheduler/DiskBufferingEnablementTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/features/diskbuffering/scheduler/DiskBufferingEnablementTest.kt
@@ -14,10 +14,10 @@ import io.mockk.verify
 import io.opentelemetry.android.features.diskbuffering.SignalFromDiskExporter
 import io.opentelemetry.android.internal.services.periodic.PeriodicRunnable
 import io.opentelemetry.android.internal.services.periodic.PeriodicTaskScheduler
-import kotlin.time.Duration.Companion.minutes
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.minutes
 
 class DiskBufferingEnablementTest {
     private lateinit var state: DiskBufferingEnablement

--- a/core/src/test/java/io/opentelemetry/android/internal/processors/NetworkAttributesSpanAppenderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/processors/NetworkAttributesSpanAppenderTest.kt
@@ -12,8 +12,8 @@ import io.mockk.impl.annotations.MockK
 import io.mockk.verify
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
 import io.opentelemetry.android.common.internal.features.networkattributes.data.NetworkState
-import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
+import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.context.Context
 import io.opentelemetry.kotlin.semconv.IncubatingApi

--- a/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimer.kt
+++ b/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/startup/AppStartupTimer.kt
@@ -10,8 +10,8 @@ import android.app.Application.ActivityLifecycleCallbacks
 import android.os.Bundle
 import android.util.Log
 import io.opentelemetry.android.common.RumConstants
-import io.opentelemetry.android.semconv.StartAttributes.START_TYPE_KEY
 import io.opentelemetry.android.internal.services.visiblescreen.activities.DefaultingActivityLifecycleCallbacks
+import io.opentelemetry.android.semconv.StartAttributes.START_TYPE_KEY
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.common.Clock

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityCallbacksTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityCallbacksTest.kt
@@ -8,12 +8,12 @@ package io.opentelemetry.android.instrumentation.activity
 import android.app.Activity
 import io.mockk.every
 import io.mockk.mockk
-import io.opentelemetry.android.semconv.LastAttributes.LAST_SCREEN_NAME_KEY
-import io.opentelemetry.android.semconv.ActivityAttributes.ACTIVITY_NAME_KEY
-import io.opentelemetry.android.semconv.StartAttributes.START_TYPE_KEY
 import io.opentelemetry.android.instrumentation.activity.startup.AppStartupTimer
 import io.opentelemetry.android.instrumentation.common.ScreenNameExtractor
 import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTracker
+import io.opentelemetry.android.semconv.ActivityAttributes.ACTIVITY_NAME_KEY
+import io.opentelemetry.android.semconv.LastAttributes.LAST_SCREEN_NAME_KEY
+import io.opentelemetry.android.semconv.StartAttributes.START_TYPE_KEY
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_NAME
 import io.opentelemetry.kotlin.semconv.IncubatingApi

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentationTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityLifecycleInstrumentationTest.kt
@@ -11,9 +11,9 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.opentelemetry.android.OpenTelemetryRum
-import io.opentelemetry.android.semconv.StartAttributes.START_TYPE_KEY
 import io.opentelemetry.android.internal.services.Services
 import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTracker
+import io.opentelemetry.android.semconv.StartAttributes.START_TYPE_KEY
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanBuilder

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityTracerTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityTracerTest.kt
@@ -10,11 +10,11 @@ import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
-import io.opentelemetry.android.semconv.LastAttributes.LAST_SCREEN_NAME_KEY
-import io.opentelemetry.android.semconv.StartAttributes.START_TYPE_KEY
 import io.opentelemetry.android.instrumentation.activity.startup.AppStartupTimer
 import io.opentelemetry.android.instrumentation.common.ActiveSpan
 import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTracker
+import io.opentelemetry.android.semconv.LastAttributes.LAST_SCREEN_NAME_KEY
+import io.opentelemetry.android.semconv.StartAttributes.START_TYPE_KEY
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_NAME

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/Pre29ActivityLifecycleCallbacksTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/Pre29ActivityLifecycleCallbacksTest.kt
@@ -10,12 +10,12 @@ import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
-import io.opentelemetry.android.semconv.LastAttributes.LAST_SCREEN_NAME_KEY
-import io.opentelemetry.android.semconv.ActivityAttributes.ACTIVITY_NAME_KEY
-import io.opentelemetry.android.semconv.StartAttributes.START_TYPE_KEY
 import io.opentelemetry.android.instrumentation.activity.startup.AppStartupTimer
 import io.opentelemetry.android.instrumentation.common.ScreenNameExtractor
 import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTracker
+import io.opentelemetry.android.semconv.ActivityAttributes.ACTIVITY_NAME_KEY
+import io.opentelemetry.android.semconv.LastAttributes.LAST_SCREEN_NAME_KEY
+import io.opentelemetry.android.semconv.StartAttributes.START_TYPE_KEY
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_NAME
 import io.opentelemetry.kotlin.semconv.IncubatingApi

--- a/instrumentation/android-log/testing/src/androidTest/kotlin/io/opentelemetry/instrumentation/library/log/testing/InstrumentationTest.kt
+++ b/instrumentation/android-log/testing/src/androidTest/kotlin/io/opentelemetry/instrumentation/library/log/testing/InstrumentationTest.kt
@@ -5,9 +5,9 @@
 
 package io.opentelemetry.instrumentation.library.log.testing
 
+import io.opentelemetry.android.semconv.AndroidAttributes.ANDROID_LOG_TAG_KEY
 import io.opentelemetry.android.test.common.OpenTelemetryRumRule
 import io.opentelemetry.api.logs.Severity
-import io.opentelemetry.android.semconv.AndroidAttributes.ANDROID_LOG_TAG_KEY
 import io.opentelemetry.instrumentation.library.log.LoggingTestUtil
 import io.opentelemetry.semconv.ExceptionAttributes
 import org.assertj.core.api.Assertions.assertThat

--- a/instrumentation/fragment/src/test/java/io/opentelemetry/android/instrumentation/fragment/FragmentTracerTest.kt
+++ b/instrumentation/fragment/src/test/java/io/opentelemetry/android/instrumentation/fragment/FragmentTracerTest.kt
@@ -8,9 +8,9 @@ package io.opentelemetry.android.instrumentation.fragment
 import androidx.fragment.app.Fragment
 import io.mockk.every
 import io.mockk.mockk
-import io.opentelemetry.android.semconv.LastAttributes.LAST_SCREEN_NAME_KEY
 import io.opentelemetry.android.instrumentation.common.ActiveSpan
 import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTracker
+import io.opentelemetry.android.semconv.LastAttributes.LAST_SCREEN_NAME_KEY
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
 import io.opentelemetry.sdk.trace.data.SpanData

--- a/instrumentation/fragment/src/test/java/io/opentelemetry/android/instrumentation/fragment/RumFragmentLifecycleCallbacksTest.kt
+++ b/instrumentation/fragment/src/test/java/io/opentelemetry/android/instrumentation/fragment/RumFragmentLifecycleCallbacksTest.kt
@@ -5,15 +5,15 @@
 
 package io.opentelemetry.android.instrumentation.fragment
 
-import io.opentelemetry.android.semconv.FragmentAttributes.FRAGMENT_NAME_KEY
 import androidx.fragment.app.Fragment
 import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
-import io.opentelemetry.android.semconv.LastAttributes.LAST_SCREEN_NAME_KEY
 import io.opentelemetry.android.instrumentation.common.ScreenNameExtractor
 import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTracker
+import io.opentelemetry.android.semconv.FragmentAttributes.FRAGMENT_NAME_KEY
+import io.opentelemetry.android.semconv.LastAttributes.LAST_SCREEN_NAME_KEY
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_NAME

--- a/instrumentation/httpurlconnection/testing/src/androidTest/kotlin/io/opentelemetry/instrumentation/library/httpurlconnection/InstrumentationTest.kt
+++ b/instrumentation/httpurlconnection/testing/src/androidTest/kotlin/io/opentelemetry/instrumentation/library/httpurlconnection/InstrumentationTest.kt
@@ -6,13 +6,13 @@
 package io.opentelemetry.instrumentation.library.httpurlconnection
 
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
-import java.util.ServiceLoader
 import io.opentelemetry.android.test.common.OpenTelemetryRumRule
 import io.opentelemetry.instrumentation.library.httpurlconnection.HttpUrlConnectionTestUtil.executeGet
 import io.opentelemetry.instrumentation.library.httpurlconnection.HttpUrlConnectionTestUtil.post
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
+import java.util.ServiceLoader
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
@@ -95,7 +95,8 @@ class InstrumentationTest {
 
         val instrumentation =
             checkNotNull(
-                ServiceLoader.load(AndroidInstrumentation::class.java)
+                ServiceLoader
+                    .load(AndroidInstrumentation::class.java)
                     .filterIsInstance<HttpUrlInstrumentation>()
                     .firstOrNull(),
             )

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkApplicationListener.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkApplicationListener.kt
@@ -6,9 +6,9 @@
 package io.opentelemetry.android.instrumentation.network
 
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
+import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateListener
 import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
 import io.opentelemetry.android.internal.services.network.NetworkChangeListener
-import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateListener
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Logger
 import java.util.concurrent.atomic.AtomicBoolean

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentation.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentation.kt
@@ -10,8 +10,8 @@ import com.google.auto.service.AutoService
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
-import io.opentelemetry.android.internal.services.network.NetworkProviderHolder
 import io.opentelemetry.android.internal.services.Services.Companion.get
+import io.opentelemetry.android.internal.services.network.NetworkProviderHolder
 import io.opentelemetry.api.common.AttributesBuilder
 
 /**

--- a/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentationTest.kt
+++ b/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentationTest.kt
@@ -7,7 +7,6 @@
 
 package io.opentelemetry.android.instrumentation.network
 
-import io.opentelemetry.android.semconv.NetworkAttributes.NETWORK_STATUS_KEY
 import android.app.Application
 import android.os.Build
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -22,12 +21,13 @@ import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.common.internal.features.networkattributes.data.Carrier
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
 import io.opentelemetry.android.common.internal.features.networkattributes.data.NetworkState
-import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
-import io.opentelemetry.android.internal.services.network.NetworkChangeListener
-import io.opentelemetry.android.internal.services.network.NetworkProviderHolder
 import io.opentelemetry.android.internal.services.Services
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle
 import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateListener
+import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
+import io.opentelemetry.android.internal.services.network.NetworkChangeListener
+import io.opentelemetry.android.internal.services.network.NetworkProviderHolder
+import io.opentelemetry.android.semconv.NetworkAttributes.NETWORK_STATUS_KEY
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.kotlin.semconv.IncubatingApi

--- a/instrumentation/okhttp3-websocket/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/websocket/InstrumentationTest.kt
+++ b/instrumentation/okhttp3-websocket/testing/src/androidTest/java/io/opentelemetry/instrumentation/library/okhttp/websocket/InstrumentationTest.kt
@@ -5,9 +5,9 @@
 
 package io.opentelemetry.instrumentation.library.okhttp.websocket
 
-import io.opentelemetry.android.test.common.OpenTelemetryRumRule
 import io.opentelemetry.android.semconv.WebsocketAttributes.WEBSOCKET_MESSAGE_SIZE_KEY
 import io.opentelemetry.android.semconv.WebsocketAttributes.WEBSOCKET_MESSAGE_TYPE_KEY
+import io.opentelemetry.android.test.common.OpenTelemetryRumRule
 import io.opentelemetry.instrumentation.library.okhttp.websocket.internal.WebsocketListenerWrapper
 import io.opentelemetry.semconv.HttpAttributes
 import io.opentelemetry.semconv.NetworkAttributes

--- a/instrumentation/power-save-mode/src/test/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeDetectorTest.kt
+++ b/instrumentation/power-save-mode/src/test/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeDetectorTest.kt
@@ -5,12 +5,12 @@
 
 package io.opentelemetry.android.instrumentation.powersavemode
 
-import io.opentelemetry.android.semconv.AndroidAttributes.ANDROID_POWER_SAVE_MODE_ENABLED_KEY
 import android.content.Context
 import android.content.Intent
 import android.os.PowerManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.opentelemetry.android.semconv.AndroidAttributes.ANDROID_POWER_SAVE_MODE_ENABLED_KEY
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before

--- a/instrumentation/power-save-mode/src/test/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeInstrumentationTest.kt
+++ b/instrumentation/power-save-mode/src/test/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeInstrumentationTest.kt
@@ -5,7 +5,6 @@
 
 package io.opentelemetry.android.instrumentation.powersavemode
 
-import io.opentelemetry.android.semconv.AndroidAttributes.ANDROID_POWER_SAVE_MODE_ENABLED_KEY
 import android.content.Context
 import android.content.Intent
 import android.os.Looper
@@ -16,6 +15,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.unmockkAll
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.semconv.AndroidAttributes.ANDROID_POWER_SAVE_MODE_ENABLED_KEY
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
@@ -28,10 +28,10 @@ import io.mockk.slot
 import io.mockk.verify
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_CLICK_EVENT_NAME
+import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_CLICK_EVENT_NAME
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_BUTTON_KEY
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_CLICKS_KEY
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_TYPE_KEY
-import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_CLICK_EVENT_NAME
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.common.AttributeKey.longKey
 import io.opentelemetry.api.common.AttributeKey.stringKey

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewLongPressInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewLongPressInstrumentationTest.kt
@@ -23,8 +23,8 @@ import io.mockk.slot
 import io.mockk.verify
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_LONG_PRESS_EVENT_NAME
-import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_TYPE_KEY
 import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_LONG_PRESS_EVENT_NAME
+import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_TYPE_KEY
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.common.AttributeKey.longKey
 import io.opentelemetry.api.common.AttributeKey.stringKey

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewScrollInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewScrollInstrumentationTest.kt
@@ -26,13 +26,13 @@ import io.mockk.verify
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_FLING_EVENT_NAME
 import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_SCROLL_EVENT_NAME
+import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_FLING_EVENT_NAME
+import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_SCROLL_EVENT_NAME
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_DISTANCE_X_KEY
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_DISTANCE_Y_KEY
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_TYPE_KEY
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_VELOCITY_X_KEY
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_VELOCITY_Y_KEY
-import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_FLING_EVENT_NAME
-import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_SCROLL_EVENT_NAME
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.common.AttributeKey.longKey
 import io.opentelemetry.api.common.AttributeKey.stringKey


### PR DESCRIPTION
resolves #1853

enables spotlessKotlin for Android modules. Once all the linting is done, we can rebase this and it should pass....but we can't merge this before that.

