### PR TITLE
Add stacktrace logging to snapshot publish

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
         working-directory: ./demo-app
         run: ./gradlew check assemble --stacktrace
       - name: publish snapshot
-        run: ./gradlew publishToSonatype
+        run: ./gradlew publishToSonatype --stacktrace --info
         env:
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}


### PR DESCRIPTION
The build is broken when trying to publish snapshots for :instrumentation:okhttp3-websocket:library. This adds --stacktrace and --info so that we can do additional troubleshooting.