### PR TITLE
update lychee version

### DIFF
--- a/.github/scripts/dependencies.dockerfile
+++ b/.github/scripts/dependencies.dockerfile
@@ -1,3 +1,3 @@
 # this file exists so that Renovate can auto-update docker image versions that are then used elsewhere
 
-FROM lycheeverse/lychee:sha-2aa22f8@sha256:2e3786630482c41f9f2dd081e06d7da1c36d66996e8cf6573409b8bc418d48c4 AS lychee
+FROM lycheeverse/lychee:0.24.2@sha256:e2d19e57cf6ab037026f20b8e449a1f30d9d7f81eef4194763aab2eab20bd28d AS lychee


### PR DESCRIPTION
Renovate had not been updating lychee because of how we had the version expressed!

When a recent PR changed `= true` to `= full`', it broke the main build a yet another way. So this update should:

* get us on the latest
* fix the build
* allow renovate to update us with new versions.

<phew>