### PR TITLE
Increase metaspace and stop daemon before publish

### DIFF
--- a/.github/scripts/dependencies.dockerfile
+++ b/.github/scripts/dependencies.dockerfile
@@ -1,3 +1,3 @@
 # this file exists so that Renovate can auto-update docker image versions that are then used elsewhere
 
-FROM lycheeverse/lychee:0.24.2@sha256:e2d19e57cf6ab037026f20b8e449a1f30d9d7f81eef4194763aab2eab20bd28d AS lychee
+FROM lycheeverse/lychee:sha-2aa22f8@sha256:2e3786630482c41f9f2dd081e06d7da1c36d66996e8cf6573409b8bc418d48c4 AS lychee

--- a/.github/scripts/dependencies.dockerfile
+++ b/.github/scripts/dependencies.dockerfile
@@ -1,3 +1,3 @@
 # this file exists so that Renovate can auto-update docker image versions that are then used elsewhere
 
-FROM lycheeverse/lychee:sha-2aa22f8@sha256:2e3786630482c41f9f2dd081e06d7da1c36d66996e8cf6573409b8bc418d48c4 AS lychee
+FROM lycheeverse/lychee:0.24.2@sha256:e2d19e57cf6ab037026f20b8e449a1f30d9d7f81eef4194763aab2eab20bd28d AS lychee

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,8 +37,14 @@ jobs:
       - name: build demo app
         working-directory: ./demo-app
         run: ./gradlew check assemble --stacktrace
+      - name: stop gradle daemons before publishing
+        # The previous Gradle invocations leave daemons with loaded Android/Dokka classloaders;
+        # publishToSonatype generates release docs and has been running out of metaspace.
+        run: ./gradlew --stop
       - name: publish snapshot
-        run: ./gradlew publishToSonatype --stacktrace --info
+        run: >
+          ./gradlew publishToSonatype --stacktrace --info
+          -Dorg.gradle.jvmargs="-Xmx4096M -XX:+UseParallelGC -XX:MaxMetaspaceSize=3g -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options=\"-Xmx4096M\""
         env:
           SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
           SONATYPE_KEY: ${{ secrets.SONATYPE_KEY }}


### PR DESCRIPTION
Well after much flailing, it looks like the next thing to try and fix the main build is to beef up the metaspace and to stop the daemon between the build and publish phases.