### PR TITLE
Remove anchor from google link, fix lychee

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ of API and idioms. More details about this policy can be found [here](./docs/KOT
 > Further, you must use AGP 8.3.0+ and set the `android.useFullClasspathForDexingTransform`
 > property in `gradle.properties` to `true` to ensure desugaring runs properly. For the full
 > context for this workaround, please see
-> [this issue](https://issuetracker.google.com/issues/230454566#comment18).
+> [this issue](https://issuetracker.google.com/issues/230454566) (comment 18).
 
 ## Gradle Setup
 

--- a/instrumentation/httpurlconnection/README.md
+++ b/instrumentation/httpurlconnection/README.md
@@ -87,7 +87,7 @@ Spans won't be automatically ended and reported otherwise. If any of your URLCon
 >
 > For the full context for these workaround, please see
 > [this issue](https://issuetracker.google.com/issues/334281968) for AGP <= 8.3.0
-> or [this issue](https://issuetracker.google.com/issues/230454566#comment18) for AGP > 8.3.0.
+> or [this issue](https://issuetracker.google.com/issues/230454566) (comment 18) for AGP > 8.3.0.
 
 ### Add these dependencies to your project
 


### PR DESCRIPTION
Builds are failing the link checker due to this dynamic anchor or whatever. I don't think it's that important, and I think it's newer behavior that started failing after our lychee upgrade yesterday.