### PR TITLE
Anchor OtelAndroidClock to GNSS or Network time when available

### DIFF
--- a/android-agent/src/test/kotlin/io/opentelemetry/android/OtelAndroidClockTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/OtelAndroidClockTest.kt
@@ -5,14 +5,27 @@
 
 package io.opentelemetry.android
 
+import android.os.Build
 import android.os.SystemClock
+import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkStatic
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.time.Clock
 
+@RunWith(AndroidJUnit4::class)
 class OtelAndroidClockTest {
+    private val gnssMillis = 1_000L
+    private val networkMillis = 2_000L
+    private val gnssClock = mockk<Clock> { every { millis() } returns gnssMillis }
+    private val networkClock = mockk<Clock> { every { millis() } returns networkMillis }
+
     @Before
     fun setup() {
         mockkStatic(SystemClock::class)
@@ -26,5 +39,66 @@ class OtelAndroidClockTest {
         val clockNowMillis = clockNowNanos / 1_000_000 // convert nanos to ms
         val currentTimeMillis = System.currentTimeMillis() // returns millis
         assertThat(currentTimeMillis - clockNowMillis).isLessThan(5000)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.Q])
+    fun `uses GNSS time when available on API 29+`() {
+        every { SystemClock.currentGnssTimeClock() } returns gnssClock
+
+        val clock = OtelAndroidClock()
+
+        assertThat(clock.now()).isEqualTo(gnssMillis * 1_000_000)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    fun `prefers GNSS time over network time on API 33+`() {
+        every { SystemClock.currentGnssTimeClock() } returns gnssClock
+        every { SystemClock.currentNetworkTimeClock() } returns networkClock
+
+        val clock = OtelAndroidClock()
+
+        assertThat(clock.now()).isEqualTo(gnssMillis * 1_000_000)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    fun `falls back to network time when GNSS clock throws on API 33+`() {
+        every { SystemClock.currentGnssTimeClock() } throws RuntimeException("no gnss")
+        every { SystemClock.currentNetworkTimeClock() } returns networkClock
+
+        val clock = OtelAndroidClock()
+
+        assertThat(clock.now()).isEqualTo(networkMillis * 1_000_000)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.Q])
+    fun `falls back to system time when GNSS clock throws and network time is unavailable`() {
+        every { SystemClock.currentGnssTimeClock() } throws RuntimeException("no gnss")
+
+        val clock = OtelAndroidClock()
+
+        assertThat(clock.now() / 1_000_000).isCloseTo(System.currentTimeMillis(), within(5000L))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    fun `falls back to system time when both GNSS and network clocks throw on API 33+`() {
+        every { SystemClock.currentGnssTimeClock() } throws RuntimeException("no gnss")
+        every { SystemClock.currentNetworkTimeClock() } throws RuntimeException("no network")
+
+        val clock = OtelAndroidClock()
+
+        assertThat(clock.now() / 1_000_000).isCloseTo(System.currentTimeMillis(), within(5000L))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.P])
+    fun `uses system time directly below API 29`() {
+        val clock = OtelAndroidClock()
+
+        assertThat(clock.now() / 1_000_000).isCloseTo(System.currentTimeMillis(), within(5000L))
     }
 }

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/OtelAndroidClockTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/OtelAndroidClockTest.kt
@@ -46,7 +46,10 @@ class OtelAndroidClockTest {
     fun `uses GNSS time when available on API 29+`() {
         every { SystemClock.currentGnssTimeClock() } returns gnssClock
 
-        val clock = OtelAndroidClock()
+        val clock = OtelAndroidClock(
+            isGnssAnchorEnabled = true,
+            isNetworkAnchorEnabled = true,
+        )
 
         assertThat(clock.now()).isEqualTo(gnssMillis * 1_000_000)
     }
@@ -57,7 +60,10 @@ class OtelAndroidClockTest {
         every { SystemClock.currentGnssTimeClock() } returns gnssClock
         every { SystemClock.currentNetworkTimeClock() } returns networkClock
 
-        val clock = OtelAndroidClock()
+        val clock = OtelAndroidClock(
+            isGnssAnchorEnabled = true,
+            isNetworkAnchorEnabled = true,
+        )
 
         assertThat(clock.now()).isEqualTo(gnssMillis * 1_000_000)
     }
@@ -68,7 +74,10 @@ class OtelAndroidClockTest {
         every { SystemClock.currentGnssTimeClock() } throws RuntimeException("no gnss")
         every { SystemClock.currentNetworkTimeClock() } returns networkClock
 
-        val clock = OtelAndroidClock()
+        val clock = OtelAndroidClock(
+            isGnssAnchorEnabled = true,
+            isNetworkAnchorEnabled = true,
+        )
 
         assertThat(clock.now()).isEqualTo(networkMillis * 1_000_000)
     }
@@ -78,7 +87,10 @@ class OtelAndroidClockTest {
     fun `falls back to system time when GNSS clock throws and network time is unavailable`() {
         every { SystemClock.currentGnssTimeClock() } throws RuntimeException("no gnss")
 
-        val clock = OtelAndroidClock()
+        val clock = OtelAndroidClock(
+            isGnssAnchorEnabled = true,
+            isNetworkAnchorEnabled = true,
+        )
 
         assertThat(clock.now() / 1_000_000).isCloseTo(System.currentTimeMillis(), within(5000L))
     }
@@ -88,6 +100,20 @@ class OtelAndroidClockTest {
     fun `falls back to system time when both GNSS and network clocks throw on API 33+`() {
         every { SystemClock.currentGnssTimeClock() } throws RuntimeException("no gnss")
         every { SystemClock.currentNetworkTimeClock() } throws RuntimeException("no network")
+
+        val clock = OtelAndroidClock(
+            isGnssAnchorEnabled = true,
+            isNetworkAnchorEnabled = true,
+        )
+
+        assertThat(clock.now() / 1_000_000).isCloseTo(System.currentTimeMillis(), within(5000L))
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    fun `GNSS + network time are disabled by default`() {
+        every { SystemClock.currentGnssTimeClock() } returns gnssClock
+        every { SystemClock.currentNetworkTimeClock() } returns networkClock
 
         val clock = OtelAndroidClock()
 

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -29,6 +29,9 @@ public final class io/opentelemetry/android/OpenTelemetryRumBuilder$Companion {
 
 public final class io/opentelemetry/android/OtelAndroidClock : io/opentelemetry/sdk/common/Clock {
 	public fun <init> ()V
+	public fun <init> (Z)V
+	public fun <init> (ZZ)V
+	public synthetic fun <init> (ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun nanoTime ()J
 	public fun now ()J
 }

--- a/core/src/main/java/io/opentelemetry/android/OtelAndroidClock.kt
+++ b/core/src/main/java/io/opentelemetry/android/OtelAndroidClock.kt
@@ -5,22 +5,53 @@
 
 package io.opentelemetry.android
 
+import android.os.Build
 import android.os.SystemClock
+import androidx.annotation.RequiresApi
 import io.opentelemetry.sdk.common.Clock
 
 /**
  * An implementation of [Clock] that takes a baseline by subtracting
- * [SystemClock.elapsedRealtimeNanos] from [System.currentTimeMillis] and then
+ * [SystemClock.elapsedRealtimeNanos] from the best available wall time and then
  * adds that baseline to [SystemClock.elapsedRealtimeNanos] to provide a monotonic wall-clock time.
+ *
+ * When selecting the anchor clock we try (in order):
+ * - [SystemClock.currentGnssTimeClock]
+ * - [SystemClock.currentNetworkTimeClock]
+ * - [System.currentTimeMillis]
  *
  * This avoids the downside of [System.currentTimeMillis] not being monotonic on Android (i.e.
  * the clock doesn't consistently tick when the process is in the background or cached). It also
  * avoids the problem of [SystemClock.elapsedRealtimeNanos] not providing wall-clock time.
  */
 class OtelAndroidClock : Clock {
-    private val baselineNanos = System.currentTimeMillis() * 1_000_000 - nanoTime()
+    private val baselineNanos = currentTimeMillis() * 1_000_000 - nanoTime()
 
     override fun now(): Long = baselineNanos + nanoTime()
 
     override fun nanoTime(): Long = SystemClock.elapsedRealtimeNanos()
+
+    private fun currentTimeMillis(): Long {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            try {
+                return currentGnssTimeMillis()
+            } catch (_: Exception) {
+            }
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            try {
+                return currentNetworkTimeMillis()
+            } catch (_: Exception) {
+            }
+        }
+        
+        return System.currentTimeMillis()
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.Q)
+    private fun currentGnssTimeMillis(): Long = SystemClock.currentGnssTimeClock().millis()
+
+    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
+    private fun currentNetworkTimeMillis(): Long = SystemClock.currentNetworkTimeClock().millis()
 }

--- a/core/src/main/java/io/opentelemetry/android/OtelAndroidClock.kt
+++ b/core/src/main/java/io/opentelemetry/android/OtelAndroidClock.kt
@@ -24,7 +24,20 @@ import io.opentelemetry.sdk.common.Clock
  * the clock doesn't consistently tick when the process is in the background or cached). It also
  * avoids the problem of [SystemClock.elapsedRealtimeNanos] not providing wall-clock time.
  */
-class OtelAndroidClock : Clock {
+class OtelAndroidClock @JvmOverloads constructor(
+    /**
+     * Whether the [OtelAndroidClock] should attempt to anchor its monotonic time against
+     * [SystemClock.currentGnssTimeClock] on startup (when available). Setting to `true` does
+     * not guarantee a GNSS anchor.
+     */
+    private val isGnssAnchorEnabled: Boolean = false,
+    /**
+     * Whether the [OtelAndroidClock] should attempt to anchor its monotonic time against
+     * [SystemClock.currentNetworkTimeClock] on startup (when available). Setting to `true` does
+     * not guarantee a network time anchor.
+     */
+    private val isNetworkAnchorEnabled: Boolean = false,
+) : Clock {
     private val baselineNanos = currentTimeMillis() * 1_000_000 - nanoTime()
 
     override fun now(): Long = baselineNanos + nanoTime()
@@ -32,20 +45,20 @@ class OtelAndroidClock : Clock {
     override fun nanoTime(): Long = SystemClock.elapsedRealtimeNanos()
 
     private fun currentTimeMillis(): Long {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && isGnssAnchorEnabled) {
             try {
                 return currentGnssTimeMillis()
             } catch (_: Exception) {
             }
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && isNetworkAnchorEnabled) {
             try {
                 return currentNetworkTimeMillis()
             } catch (_: Exception) {
             }
         }
-        
+
         return System.currentTimeMillis()
     }
 


### PR DESCRIPTION
Addresses #197 by attempting to anchor the `OtelAndroidClock` against either the GNSS (navigation satellite) provided time, or the network time (NTP) when they are available on the device.

The priority order is:

- GNSS time
- Network time
- Device wall time

The PR doesn't attempt to identify which clock was used as the anchor point since the previous "wall time only" behaviour already caused drift problems, since its not clear what (if anything) could be done with that information and this should remain a generic implementation.