### PR TITLE
feat(native-crash): add persisted crash replay

### DIFF
--- a/instrumentation/native-crash/README.md
+++ b/instrumentation/native-crash/README.md
@@ -1,0 +1,40 @@
+# Native Crash Instrumentation
+
+Status: development
+
+The native crash instrumentation replays a persisted native crash as an `app.crash` event when
+the application next starts.
+
+This first increment provides the module, persisted marker/context format, and replay path. Native
+signal capture is intentionally left for a follow-up change.
+
+## Telemetry
+
+The replayed event uses the original crash timestamp and includes:
+
+* `exception.type`
+* `exception.message`
+* `session.id`, when available
+* `app.build_id`, when available
+* `service.version`, when available
+* `os.name`
+* `os.version`
+
+The app and OS fields are persisted before a crash so the replayed event describes the process that
+crashed rather than the process that reports it.
+
+## Installation
+
+Add the instrumentation dependency:
+
+```kotlin
+implementation("io.opentelemetry.android.instrumentation:native-crash:1.5.0-alpha")
+```
+
+The module is discovered and installed automatically when it is present on the runtime classpath.
+
+## Limitations
+
+Native signal handling, native stack unwinding, symbol upload, and symbolication are not included
+in this increment. Until signal handling is added, this module only provides the replay side of the
+native crash reporting flow.

--- a/instrumentation/native-crash/README.md
+++ b/instrumentation/native-crash/README.md
@@ -5,8 +5,9 @@ Status: development
 The native crash instrumentation replays a persisted native crash as an `app.crash` event when
 the application next starts.
 
-This first increment provides the module, persisted marker/context format, and replay path. Native
-signal capture is intentionally left for a follow-up change.
+This first increment provides the module, persisted marker/context format, and replay path. Each
+crash uses a separate marker so unreadable records can be retried without blocking other crashes.
+Native signal capture is intentionally left for a follow-up change.
 
 ## Telemetry
 
@@ -37,8 +38,9 @@ The module is discovered and installed automatically when it is present on the r
 
 Native signal handling, native stack unwinding, symbol upload, and symbolication are not included
 in this increment. Until signal handling is added, this module only provides the replay side of the
-native crash reporting flow.
+native crash reporting flow. It does not emit native stack frames, so there is no native stack to
+symbolicate in this change.
 
-The persisted crash marker is deleted immediately after the event is emitted. Replay is therefore
-at most once: if the application exits before the telemetry is exported, the crash event may be
-lost.
+Each persisted crash marker is deleted immediately after its event is emitted. Replay is therefore
+at most once per marker: if the application exits before the telemetry is exported, that crash
+event may be lost.

--- a/instrumentation/native-crash/README.md
+++ b/instrumentation/native-crash/README.md
@@ -16,7 +16,6 @@ The replayed event uses the original crash timestamp and includes:
 * `exception.type`
 * `exception.message`
 * `session.id`, when available
-* `app.build_id`, when available
 * `service.version`, when available
 * `os.name`
 * `os.version`

--- a/instrumentation/native-crash/README.md
+++ b/instrumentation/native-crash/README.md
@@ -6,8 +6,9 @@ The native crash instrumentation replays a persisted native crash as an `app.cra
 the application next starts.
 
 This first increment provides the module, persisted marker/context format, and replay path. Each
-crash uses a separate marker so unreadable records can be retried without blocking other crashes.
-Native signal capture is intentionally left for a follow-up change.
+crash uses a separate marker containing its signal metadata and crash-time context. Unreadable
+records can be retried without blocking other crashes. Native signal capture is intentionally left
+for a follow-up change.
 
 ## Telemetry
 
@@ -20,8 +21,8 @@ The replayed event uses the original crash timestamp and includes:
 * `os.name`
 * `os.version`
 
-The app and OS fields are persisted before a crash so the replayed event describes the process that
-crashed rather than the process that reports it.
+The app and OS fields are stored with each crash marker so the replayed event describes the process
+that crashed rather than the process that reports it.
 
 ## Installation
 
@@ -35,10 +36,10 @@ The module is discovered and installed automatically when it is present on the r
 
 ## Limitations
 
-Native signal handling, native stack unwinding, symbol upload, and symbolication are not included
-in this increment. Until signal handling is added, this module only provides the replay side of the
-native crash reporting flow. It does not emit native stack frames, so there is no native stack to
-symbolicate in this change.
+Native signal handling and native stack capture are not included in this increment. Until signal
+handling is added, this module only provides the replay side of the native crash reporting flow.
+It does not create or attach a binary crash dump. Symbol upload and symbolication are downstream
+concerns and require a separate design once native stack frames are available.
 
 Each persisted crash marker is deleted immediately after its event is emitted. Replay is therefore
 at most once per marker: if the application exits before the telemetry is exported, that crash

--- a/instrumentation/native-crash/README.md
+++ b/instrumentation/native-crash/README.md
@@ -38,3 +38,7 @@ The module is discovered and installed automatically when it is present on the r
 Native signal handling, native stack unwinding, symbol upload, and symbolication are not included
 in this increment. Until signal handling is added, this module only provides the replay side of the
 native crash reporting flow.
+
+The persisted crash marker is deleted immediately after the event is emitted. Replay is therefore
+at most once: if the application exits before the telemetry is exported, the crash event may be
+lost.

--- a/instrumentation/native-crash/README.md
+++ b/instrumentation/native-crash/README.md
@@ -5,10 +5,9 @@ Status: development
 The native crash instrumentation replays a persisted native crash as an `app.crash` event when
 the application next starts.
 
-This first increment provides the module, persisted marker/context format, and replay path. Each
-crash uses a separate marker containing its signal metadata and crash-time context. Unreadable
-records can be retried without blocking other crashes. Native signal capture is intentionally left
-for a follow-up change.
+This first increment provides the module, persisted marker/context format, and replay path. It uses
+one marker for the most recent crash and a separate context snapshot maintained while the app is
+running. Native signal capture is intentionally left for a follow-up change.
 
 ## Telemetry
 
@@ -21,8 +20,8 @@ The replayed event uses the original crash timestamp and includes:
 * `os.name`
 * `os.version`
 
-The app and OS fields are stored with each crash marker so the replayed event describes the process
-that crashed rather than the process that reports it.
+The app and OS fields are read from the persisted crash-time context before it is replaced with the
+new process context, so the replayed event describes the process that crashed.
 
 ## Installation
 
@@ -41,6 +40,7 @@ handling is added, this module only provides the replay side of the native crash
 It does not create or attach a binary crash dump. Symbol upload and symbolication are downstream
 concerns and require a separate design once native stack frames are available.
 
-Each persisted crash marker is deleted immediately after its event is emitted. Replay is therefore
-at most once per marker: if the application exits before the telemetry is exported, that crash
-event may be lost.
+The persisted crash marker is deleted immediately after its event is emitted. Replay is therefore
+at most once: if the application exits before the telemetry is exported, that crash event may be
+lost. A later change may add support for preserving multiple consecutive startup crashes.
+Unreadable or malformed markers are discarded rather than retried.

--- a/instrumentation/native-crash/api/native-crash.api
+++ b/instrumentation/native-crash/api/native-crash.api
@@ -1,0 +1,6 @@
+public final class io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public fun <init> ()V
+	public fun getName ()Ljava/lang/String;
+	public fun install (Landroid/content/Context;Lio/opentelemetry/android/OpenTelemetryRum;)V
+}
+

--- a/instrumentation/native-crash/build.gradle.kts
+++ b/instrumentation/native-crash/build.gradle.kts
@@ -1,0 +1,26 @@
+plugins {
+    id("otel.android-library-conventions")
+    id("otel.publish-conventions")
+}
+
+description = "OpenTelemetry Android native crash instrumentation"
+
+android {
+    namespace = "io.opentelemetry.android.instrumentation.nativecrash"
+
+    defaultConfig {
+        consumerProguardFiles("consumer-rules.pro")
+    }
+}
+
+dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
+    implementation(project(":agent-api"))
+    implementation(project(":common"))
+    implementation(project(":instrumentation:android-instrumentation"))
+    implementation(project(":session"))
+    implementation(libs.androidx.core)
+    implementation(libs.opentelemetry.semconv.kotlin)
+
+    testImplementation(project(":test-common"))
+}

--- a/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
+++ b/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
@@ -31,6 +31,7 @@ import io.opentelemetry.kotlin.semconv.SessionAttributes.SESSION_ID
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
+import java.io.IOException
 import java.time.Instant
 import java.util.Properties
 
@@ -160,6 +161,7 @@ internal class FileNativeCrashStore(
         )
     }
 
+    @Synchronized
     override fun writeContext(context: NativeCrashContext) {
         runCatching {
             directory.mkdirs()
@@ -169,7 +171,15 @@ internal class FileNativeCrashStore(
             properties.setIfNotNull(SERVICE_VERSION, context.serviceVersion)
             properties.setIfNotNull(OS_NAME, context.osName)
             properties.setIfNotNull(OS_VERSION, context.osVersion)
-            FileOutputStream(contextPath).use { properties.store(it, null) }
+            val temporaryPath = File(directory, "${contextPath.name}.tmp")
+            try {
+                FileOutputStream(temporaryPath).use { properties.store(it, null) }
+                if (!temporaryPath.renameTo(contextPath)) {
+                    throw IOException("Failed to replace native crash context")
+                }
+            } finally {
+                temporaryPath.delete()
+            }
         }
     }
 

--- a/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
+++ b/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
@@ -58,7 +58,8 @@ class NativeCrashInstrumentation internal constructor(
             NativeCrashReporter(
                 store = store,
                 openTelemetryRum = openTelemetryRum,
-            ).install(crashContext)
+            ).replayPreviousCrash()
+            store.writeContext(crashContext)
 
             val sessionProvider = openTelemetryRum.sessionProvider
             if (sessionProvider is SessionPublisher) {
@@ -89,12 +90,7 @@ internal class NativeCrashReporter(
     private val store: NativeCrashStore,
     private val openTelemetryRum: OpenTelemetryRum,
 ) {
-    fun install(currentContext: NativeCrashContext) {
-        replayPreviousCrash()
-        store.writeContext(currentContext)
-    }
-
-    private fun replayPreviousCrash() {
+    fun replayPreviousCrash() {
         val crashContext = store.readContext()
         store.readCrashRecord()?.let { record -> replay(record, crashContext) }
     }
@@ -252,6 +248,8 @@ internal data class NativeCrashRecord(
             7 -> "SIGBUS"
             8 -> "SIGFPE"
             11 -> "SIGSEGV"
+            13 -> "SIGPIPE"
+            31 -> "SIGSYS"
             else -> "SIG$signalNumber"
         }
 }

--- a/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
+++ b/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
@@ -10,7 +10,6 @@ package io.opentelemetry.android.instrumentation.nativecrash
 import android.content.Context
 import android.os.Build
 import android.util.Log
-import androidx.core.content.pm.PackageInfoCompat
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.common.RumConstants
@@ -22,7 +21,6 @@ import io.opentelemetry.android.session.SessionPublisher
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.common.AttributesBuilder
-import io.opentelemetry.kotlin.semconv.AppAttributes.APP_BUILD_ID
 import io.opentelemetry.kotlin.semconv.ExceptionAttributes.EXCEPTION_MESSAGE
 import io.opentelemetry.kotlin.semconv.ExceptionAttributes.EXCEPTION_TYPE
 import io.opentelemetry.kotlin.semconv.IncubatingApi
@@ -197,7 +195,6 @@ internal class FileNativeCrashStore(
         val properties = runCatching { contextPath.readProperties() }.getOrNull() ?: return null
         return NativeCrashContext(
             sessionId = properties.nonBlankProperty(SESSION_ID),
-            appBuildId = properties.nonBlankProperty(APP_BUILD_ID),
             serviceVersion = properties.nonBlankProperty(SERVICE_VERSION),
             osName = properties.nonBlankProperty(OS_NAME),
             osVersion = properties.nonBlankProperty(OS_VERSION),
@@ -210,7 +207,6 @@ internal class FileNativeCrashStore(
             directory.mkdirs()
             val properties = Properties()
             properties.setIfNotNull(SESSION_ID, context.sessionId)
-            properties.setIfNotNull(APP_BUILD_ID, context.appBuildId)
             properties.setIfNotNull(SERVICE_VERSION, context.serviceVersion)
             properties.setIfNotNull(OS_NAME, context.osName)
             properties.setIfNotNull(OS_VERSION, context.osVersion)
@@ -277,14 +273,12 @@ internal data class NativeCrashRecord(
 
 internal data class NativeCrashContext(
     val sessionId: String?,
-    val appBuildId: String?,
     val serviceVersion: String?,
     val osName: String?,
     val osVersion: String?,
 ) {
     fun addTo(attributes: AttributesBuilder) {
         attributes.putIfNotNull(SESSION_ID, sessionId)
-        attributes.putIfNotNull(APP_BUILD_ID, appBuildId)
         attributes.putIfNotNull(SERVICE_VERSION, serviceVersion)
         attributes.putIfNotNull(OS_NAME, osName)
         attributes.putIfNotNull(OS_VERSION, osVersion)
@@ -295,7 +289,6 @@ private fun Context.currentCrashContext(openTelemetryRum: OpenTelemetryRum): Nat
     val packageInfo = runCatching { packageManager.getPackageInfo(packageName, 0) }.getOrNull()
     return NativeCrashContext(
         sessionId = openTelemetryRum.sessionProvider.getSessionId().takeIf { it.isNotBlank() },
-        appBuildId = packageInfo?.let { PackageInfoCompat.getLongVersionCode(it).toString() },
         serviceVersion = packageInfo?.versionName,
         osName = "Android",
         osVersion = Build.VERSION.RELEASE,

--- a/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
+++ b/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
@@ -90,22 +90,26 @@ internal class NativeCrashReporter(
     private val openTelemetryRum: OpenTelemetryRum,
 ) {
     fun install(currentContext: NativeCrashContext) {
-        replayPreviousCrashes()
+        replayPreviousCrash()
         store.writeContext(currentContext)
     }
 
-    private fun replayPreviousCrashes() {
-        store.readCrashRecords().forEach(::replay)
+    private fun replayPreviousCrash() {
+        val crashContext = store.readContext()
+        store.readCrashRecord()?.let { record -> replay(record, crashContext) }
     }
 
-    private fun replay(record: NativeCrashRecord) {
+    private fun replay(
+        record: NativeCrashRecord,
+        crashContext: NativeCrashContext?,
+    ) {
         val attributes = Attributes.builder()
         attributes.put(stringKey(EXCEPTION_TYPE), record.signalName)
         attributes.put(
             stringKey(EXCEPTION_MESSAGE),
             "Native crash signal ${record.signalName} (${record.signalNumber})",
         )
-        record.crashContext?.addTo(attributes)
+        crashContext?.addTo(attributes)
 
         openTelemetryRum.openTelemetry.logsBridge
             .loggerBuilder("io.opentelemetry.native-crash")
@@ -115,14 +119,14 @@ internal class NativeCrashReporter(
             .setTimestamp(record.timestamp)
             .setAllAttributes(attributes.build())
             .emit()
-        store.deleteCrashRecord(record)
+        store.deleteCrashRecord()
     }
 }
 
 internal interface NativeCrashStore {
-    fun readCrashRecords(): List<NativeCrashRecord>
+    fun readCrashRecord(): NativeCrashRecord?
 
-    fun deleteCrashRecord(record: NativeCrashRecord)
+    fun deleteCrashRecord()
 
     fun readContext(): NativeCrashContext?
 
@@ -131,100 +135,45 @@ internal interface NativeCrashStore {
 
 internal class FileNativeCrashStore(
     private val directory: File,
-    private val crashRecordReader: (File) -> Properties = { path -> path.readProperties() },
 ) : NativeCrashStore {
     private val contextPath = File(directory, "native-crash-context.properties")
+    private val crashRecordPath = File(directory, "native-crash-record.properties")
 
-    override fun readCrashRecords(): List<NativeCrashRecord> {
-        val paths =
-            directory.listFiles { path ->
-                path.isFile &&
-                    path.name.startsWith(CRASH_RECORD_PREFIX) &&
-                    path.name.endsWith(PROPERTIES_SUFFIX)
-            } ?: return emptyList()
-
-        return paths.sortedBy { it.name }.mapNotNull { path -> readCrashRecord(path) }
-    }
-
-    override fun deleteCrashRecord(record: NativeCrashRecord) {
-        val markerName = record.markerName ?: return
-        deleteCrashRecord(File(directory, markerName))
-    }
-
-    private fun readCrashRecord(path: File): NativeCrashRecord? {
+    override fun readCrashRecord(): NativeCrashRecord? {
+        if (!crashRecordPath.isFile) {
+            return null
+        }
         val properties =
             try {
-                crashRecordReader(path)
+                crashRecordPath.readProperties()
             } catch (error: IllegalArgumentException) {
-                deleteCrashRecord(path)
+                deleteCrashRecord()
                 return null
             } catch (error: IOException) {
-                recordReadFailure(path, error)
+                Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to read native crash marker", error)
+                deleteCrashRecord()
                 return null
             } catch (error: SecurityException) {
                 Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to read native crash marker", error)
-                deleteCrashRecord(path)
+                deleteCrashRecord()
                 return null
             }
-        deleteReadFailureCount(path)
         val record = properties.toCrashRecordOrNull()
         if (record == null) {
-            deleteCrashRecord(path)
+            deleteCrashRecord()
         }
-        return record?.copy(markerName = path.name)
+        return record
     }
 
-    private fun deleteCrashRecord(path: File) {
-        deleteFile(path, "native crash marker")
-        deleteReadFailureCount(path)
-    }
-
-    private fun deleteReadFailureCount(path: File) {
-        deleteFile(readFailurePath(path), "native crash marker retry state")
-    }
-
-    private fun deleteFile(
-        path: File,
-        description: String,
-    ) {
+    override fun deleteCrashRecord() {
         runCatching {
-            if (path.isFile && !path.delete()) {
-                throw IOException("Failed to delete $description")
+            if (crashRecordPath.isFile && !crashRecordPath.delete()) {
+                throw IOException("Failed to delete native crash marker")
             }
         }.onFailure { error ->
-            Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to delete $description", error)
+            Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to delete native crash marker", error)
         }
     }
-
-    private fun recordReadFailure(
-        path: File,
-        error: IOException,
-    ) {
-        Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to read native crash marker", error)
-        val failurePath = readFailurePath(path)
-        val failureCount =
-            runCatching { failurePath.readText().toInt() }
-                .getOrDefault(0) + 1
-        if (failureCount >= MAX_READ_ATTEMPTS) {
-            Log.w(
-                RumConstants.OTEL_RUM_LOG_TAG,
-                "Discarding native crash marker after $failureCount failed read attempts",
-            )
-            deleteCrashRecord(path)
-            return
-        }
-
-        runCatching { failurePath.writeText(failureCount.toString()) }
-            .onFailure { retryError ->
-                Log.w(
-                    RumConstants.OTEL_RUM_LOG_TAG,
-                    "Failed to persist native crash marker retry state",
-                    retryError,
-                )
-            }
-    }
-
-    private fun readFailurePath(path: File): File = File(directory, "${path.name}.read-failures")
 
     override fun readContext(): NativeCrashContext? {
         val properties = runCatching { contextPath.readProperties() }.getOrNull() ?: return null
@@ -270,7 +219,6 @@ internal class FileNativeCrashStore(
             NativeCrashRecord(
                 signalNumber = signalNumber,
                 timestamp = timestamp,
-                crashContext = toCrashContextOrNull(),
             )
         }.getOrNull()
     }
@@ -287,19 +235,14 @@ internal class FileNativeCrashStore(
     }
 
     private companion object {
-        const val CRASH_RECORD_PREFIX = "native-crash-record-"
-        const val PROPERTIES_SUFFIX = ".properties"
         const val SIGNAL_NUMBER_KEY = "signal.number"
         const val TIMESTAMP_EPOCH_NANOS_KEY = "timestamp.epoch_nanos"
-        const val MAX_READ_ATTEMPTS = 3
     }
 }
 
 internal data class NativeCrashRecord(
     val signalNumber: Int,
     val timestamp: Instant,
-    val crashContext: NativeCrashContext? = null,
-    internal val markerName: String? = null,
 ) {
     val signalName: String =
         when (signalNumber) {

--- a/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
+++ b/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
@@ -45,13 +45,6 @@ class NativeCrashInstrumentation internal constructor(
     },
     private val executor: Executor = Executors.newSingleThreadExecutor(),
 ) : AndroidInstrumentation {
-    constructor() : this(
-        storeFactory = { context ->
-            FileNativeCrashStore(File(context.filesDir, "opentelemetry/native-crash"))
-        },
-        executor = Executors.newSingleThreadExecutor(),
-    )
-
     override val name: String = "native-crash"
 
     override fun install(
@@ -62,14 +55,15 @@ class NativeCrashInstrumentation internal constructor(
         executor.execute {
             val store = storeFactory(applicationContext)
             val crashContext = applicationContext.currentCrashContext(openTelemetryRum)
-            val sessionProvider = openTelemetryRum.sessionProvider
-            if (sessionProvider is SessionPublisher) {
-                sessionProvider.addObserver(NativeCrashSessionObserver(store, crashContext, executor))
-            }
             NativeCrashReporter(
                 store = store,
                 openTelemetryRum = openTelemetryRum,
             ).install(crashContext)
+
+            val sessionProvider = openTelemetryRum.sessionProvider
+            if (sessionProvider is SessionPublisher) {
+                sessionProvider.addObserver(NativeCrashSessionObserver(store, crashContext, executor))
+            }
         }
     }
 }
@@ -101,21 +95,17 @@ internal class NativeCrashReporter(
     }
 
     private fun replayPreviousCrashes() {
-        val crashContext = store.readContext()
-        store.readCrashRecords().forEach { record -> replay(record, crashContext) }
+        store.readCrashRecords().forEach(::replay)
     }
 
-    private fun replay(
-        record: NativeCrashRecord,
-        crashContext: NativeCrashContext?,
-    ) {
+    private fun replay(record: NativeCrashRecord) {
         val attributes = Attributes.builder()
         attributes.put(stringKey(EXCEPTION_TYPE), record.signalName)
         attributes.put(
             stringKey(EXCEPTION_MESSAGE),
             "Native crash signal ${record.signalName} (${record.signalNumber})",
         )
-        crashContext?.addTo(attributes)
+        record.crashContext?.addTo(attributes)
 
         openTelemetryRum.openTelemetry.logsBridge
             .loggerBuilder("io.opentelemetry.native-crash")
@@ -141,6 +131,7 @@ internal interface NativeCrashStore {
 
 internal class FileNativeCrashStore(
     private val directory: File,
+    private val crashRecordReader: (File) -> Properties = { path -> path.readProperties() },
 ) : NativeCrashStore {
     private val contextPath = File(directory, "native-crash-context.properties")
 
@@ -163,17 +154,19 @@ internal class FileNativeCrashStore(
     private fun readCrashRecord(path: File): NativeCrashRecord? {
         val properties =
             try {
-                path.readProperties()
+                crashRecordReader(path)
             } catch (error: IllegalArgumentException) {
                 deleteCrashRecord(path)
                 return null
             } catch (error: IOException) {
-                Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to read native crash marker", error)
+                recordReadFailure(path, error)
                 return null
             } catch (error: SecurityException) {
                 Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to read native crash marker", error)
+                deleteCrashRecord(path)
                 return null
             }
+        deleteReadFailureCount(path)
         val record = properties.toCrashRecordOrNull()
         if (record == null) {
             deleteCrashRecord(path)
@@ -182,23 +175,60 @@ internal class FileNativeCrashStore(
     }
 
     private fun deleteCrashRecord(path: File) {
+        deleteFile(path, "native crash marker")
+        deleteReadFailureCount(path)
+    }
+
+    private fun deleteReadFailureCount(path: File) {
+        deleteFile(readFailurePath(path), "native crash marker retry state")
+    }
+
+    private fun deleteFile(
+        path: File,
+        description: String,
+    ) {
         runCatching {
             if (path.isFile && !path.delete()) {
-                throw IOException("Failed to delete native crash marker")
+                throw IOException("Failed to delete $description")
             }
         }.onFailure { error ->
-            Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to delete native crash marker", error)
+            Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to delete $description", error)
         }
     }
 
+    private fun recordReadFailure(
+        path: File,
+        error: IOException,
+    ) {
+        Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to read native crash marker", error)
+        val failurePath = readFailurePath(path)
+        val failureCount =
+            runCatching { failurePath.readText().toInt() }
+                .getOrDefault(0) + 1
+        if (failureCount >= MAX_READ_ATTEMPTS) {
+            Log.w(
+                RumConstants.OTEL_RUM_LOG_TAG,
+                "Discarding native crash marker after $failureCount failed read attempts",
+            )
+            deleteCrashRecord(path)
+            return
+        }
+
+        runCatching { failurePath.writeText(failureCount.toString()) }
+            .onFailure { retryError ->
+                Log.w(
+                    RumConstants.OTEL_RUM_LOG_TAG,
+                    "Failed to persist native crash marker retry state",
+                    retryError,
+                )
+            }
+    }
+
+    private fun readFailurePath(path: File): File = File(directory, "${path.name}.read-failures")
+
     override fun readContext(): NativeCrashContext? {
         val properties = runCatching { contextPath.readProperties() }.getOrNull() ?: return null
-        return NativeCrashContext(
-            sessionId = properties.nonBlankProperty(SESSION_ID),
-            serviceVersion = properties.nonBlankProperty(SERVICE_VERSION),
-            osName = properties.nonBlankProperty(OS_NAME),
-            osVersion = properties.nonBlankProperty(OS_VERSION),
-        )
+        return properties.toCrashContextOrNull()
     }
 
     @Synchronized
@@ -237,26 +267,38 @@ internal class FileNativeCrashStore(
                     ?.takeIf { it > 0 }
                     ?.toInstant()
                     ?: return null
-            NativeCrashRecord(signalNumber, timestamp)
+            NativeCrashRecord(
+                signalNumber = signalNumber,
+                timestamp = timestamp,
+                crashContext = toCrashContextOrNull(),
+            )
         }.getOrNull()
     }
 
-    private fun File.readProperties(): Properties =
-        Properties().also { properties ->
-            FileInputStream(this).use { properties.load(it) }
-        }
+    private fun Properties.toCrashContextOrNull(): NativeCrashContext? {
+        val context =
+            NativeCrashContext(
+                sessionId = nonBlankProperty(SESSION_ID),
+                serviceVersion = nonBlankProperty(SERVICE_VERSION),
+                osName = nonBlankProperty(OS_NAME),
+                osVersion = nonBlankProperty(OS_VERSION),
+            )
+        return context.takeUnless { it.isEmpty() }
+    }
 
     private companion object {
         const val CRASH_RECORD_PREFIX = "native-crash-record-"
         const val PROPERTIES_SUFFIX = ".properties"
         const val SIGNAL_NUMBER_KEY = "signal.number"
         const val TIMESTAMP_EPOCH_NANOS_KEY = "timestamp.epoch_nanos"
+        const val MAX_READ_ATTEMPTS = 3
     }
 }
 
 internal data class NativeCrashRecord(
     val signalNumber: Int,
     val timestamp: Instant,
+    val crashContext: NativeCrashContext? = null,
     internal val markerName: String? = null,
 ) {
     val signalName: String =
@@ -277,6 +319,12 @@ internal data class NativeCrashContext(
     val osName: String?,
     val osVersion: String?,
 ) {
+    fun isEmpty(): Boolean =
+        sessionId == null &&
+            serviceVersion == null &&
+            osName == null &&
+            osVersion == null
+
     fun addTo(attributes: AttributesBuilder) {
         attributes.putIfNotNull(SESSION_ID, sessionId)
         attributes.putIfNotNull(SERVICE_VERSION, serviceVersion)
@@ -310,6 +358,11 @@ private fun Properties.setIfNotNull(
 }
 
 private fun Properties.nonBlankProperty(key: String): String? = getProperty(key)?.takeIf { it.isNotBlank() }
+
+private fun File.readProperties(): Properties =
+    Properties().also { properties ->
+        FileInputStream(this).use { properties.load(it) }
+    }
 
 private const val NANOS_PER_SECOND = 1_000_000_000L
 

--- a/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
+++ b/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
@@ -1,0 +1,271 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+@file:OptIn(IncubatingApi::class)
+
+package io.opentelemetry.android.instrumentation.nativecrash
+
+import android.content.Context
+import android.os.Build
+import androidx.core.content.pm.PackageInfoCompat
+import com.google.auto.service.AutoService
+import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.common.internal.SemconvCompat.Companion.map
+import io.opentelemetry.android.instrumentation.AndroidInstrumentation
+import io.opentelemetry.android.session.Session
+import io.opentelemetry.android.session.SessionObserver
+import io.opentelemetry.android.session.SessionPublisher
+import io.opentelemetry.api.common.AttributeKey.stringKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.common.AttributesBuilder
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_BUILD_ID
+import io.opentelemetry.kotlin.semconv.ExceptionAttributes.EXCEPTION_MESSAGE
+import io.opentelemetry.kotlin.semconv.ExceptionAttributes.EXCEPTION_TYPE
+import io.opentelemetry.kotlin.semconv.IncubatingApi
+import io.opentelemetry.kotlin.semconv.OsAttributes.OS_NAME
+import io.opentelemetry.kotlin.semconv.OsAttributes.OS_VERSION
+import io.opentelemetry.kotlin.semconv.ServiceAttributes.SERVICE_VERSION
+import io.opentelemetry.kotlin.semconv.SessionAttributes.SESSION_ID
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.time.Instant
+import java.util.Properties
+
+/** Entry point for replaying native crashes captured by a previous app process. */
+@AutoService(AndroidInstrumentation::class)
+class NativeCrashInstrumentation internal constructor(
+    private val storeFactory: (Context) -> NativeCrashStore = { context ->
+        FileNativeCrashStore(File(context.filesDir, "opentelemetry/native-crash"))
+    },
+) : AndroidInstrumentation {
+    constructor() : this(
+        storeFactory = { context ->
+            FileNativeCrashStore(File(context.filesDir, "opentelemetry/native-crash"))
+        },
+    )
+
+    override val name: String = "native-crash"
+
+    override fun install(
+        context: Context,
+        openTelemetryRum: OpenTelemetryRum,
+    ) {
+        val applicationContext = context.applicationContext
+        val store = storeFactory(applicationContext)
+        val crashContext = applicationContext.currentCrashContext(openTelemetryRum)
+        NativeCrashReporter(
+            store = store,
+            openTelemetryRum = openTelemetryRum,
+        ).install(crashContext)
+
+        val sessionProvider = openTelemetryRum.sessionProvider
+        if (sessionProvider is SessionPublisher) {
+            sessionProvider.addObserver(NativeCrashSessionObserver(store, crashContext))
+        }
+    }
+}
+
+internal class NativeCrashSessionObserver(
+    private val store: NativeCrashStore,
+    private val crashContext: NativeCrashContext,
+) : SessionObserver {
+    override fun onSessionStarted(
+        newSession: Session,
+        previousSession: Session,
+    ) {
+        store.writeContext(crashContext.copy(sessionId = newSession.id))
+    }
+
+    override fun onSessionEnded(session: Session) {}
+}
+
+internal class NativeCrashReporter(
+    private val store: NativeCrashStore,
+    private val openTelemetryRum: OpenTelemetryRum,
+) {
+    fun install(currentContext: NativeCrashContext) {
+        replayPreviousCrash()
+        store.writeContext(currentContext)
+    }
+
+    private fun replayPreviousCrash() {
+        val record = store.readCrashRecord() ?: return
+        val attributes = Attributes.builder()
+        attributes.put(stringKey(EXCEPTION_TYPE), "signal.${record.signalName}")
+        attributes.put(
+            stringKey(EXCEPTION_MESSAGE),
+            "Native crash signal ${record.signalName} (${record.signalNumber})",
+        )
+        store.readContext()?.addTo(attributes)
+
+        openTelemetryRum.openTelemetry.logsBridge
+            .loggerBuilder("io.opentelemetry.native-crash")
+            .build()
+            .logRecordBuilder()
+            .setEventName(map("app.crash"))
+            .setTimestamp(record.timestamp)
+            .setAllAttributes(attributes.build())
+            .emit()
+        store.deleteCrashRecord()
+    }
+}
+
+internal interface NativeCrashStore {
+    fun readCrashRecord(): NativeCrashRecord?
+
+    fun deleteCrashRecord()
+
+    fun readContext(): NativeCrashContext?
+
+    fun writeContext(context: NativeCrashContext)
+}
+
+internal class FileNativeCrashStore(
+    private val directory: File,
+) : NativeCrashStore {
+    private val crashRecordPath = File(directory, "native-crash.properties")
+    private val contextPath = File(directory, "native-crash-context.properties")
+
+    override fun readCrashRecord(): NativeCrashRecord? {
+        if (!crashRecordPath.isFile) {
+            return null
+        }
+        val properties = crashRecordPath.readPropertiesOrNull()
+        if (properties == null) {
+            deleteCrashRecord()
+            return null
+        }
+        val record = properties.toCrashRecordOrNull()
+        if (record == null) {
+            deleteCrashRecord()
+        }
+        return record
+    }
+
+    override fun deleteCrashRecord() {
+        runCatching { crashRecordPath.delete() }
+    }
+
+    override fun readContext(): NativeCrashContext? {
+        val properties = contextPath.readPropertiesOrNull() ?: return null
+        return NativeCrashContext(
+            sessionId = properties.nonBlankProperty(SESSION_ID),
+            appBuildId = properties.nonBlankProperty(APP_BUILD_ID),
+            serviceVersion = properties.nonBlankProperty(SERVICE_VERSION),
+            osName = properties.nonBlankProperty(OS_NAME),
+            osVersion = properties.nonBlankProperty(OS_VERSION),
+        )
+    }
+
+    override fun writeContext(context: NativeCrashContext) {
+        runCatching {
+            directory.mkdirs()
+            val properties = Properties()
+            properties.setIfNotNull(SESSION_ID, context.sessionId)
+            properties.setIfNotNull(APP_BUILD_ID, context.appBuildId)
+            properties.setIfNotNull(SERVICE_VERSION, context.serviceVersion)
+            properties.setIfNotNull(OS_NAME, context.osName)
+            properties.setIfNotNull(OS_VERSION, context.osVersion)
+            FileOutputStream(contextPath).use { properties.store(it, null) }
+        }
+    }
+
+    private fun Properties.toCrashRecordOrNull(): NativeCrashRecord? {
+        return runCatching {
+            val signalNumber =
+                getProperty(SIGNAL_NUMBER_KEY)
+                    ?.toIntOrNull()
+                    ?.takeIf { it > 0 }
+                    ?: return null
+            val timestamp =
+                getProperty(TIMESTAMP_EPOCH_NANOS_KEY)
+                    ?.toLongOrNull()
+                    ?.takeIf { it > 0 }
+                    ?.toInstant()
+                    ?: return null
+            NativeCrashRecord(signalNumber, timestamp)
+        }.getOrNull()
+    }
+
+    private fun File.readPropertiesOrNull(): Properties? {
+        if (!isFile) {
+            return null
+        }
+        return runCatching {
+            Properties().also { properties ->
+                FileInputStream(this).use { properties.load(it) }
+            }
+        }.getOrNull()
+    }
+
+    private companion object {
+        const val SIGNAL_NUMBER_KEY = "signal.number"
+        const val TIMESTAMP_EPOCH_NANOS_KEY = "timestamp.epoch_nanos"
+    }
+}
+
+internal data class NativeCrashRecord(
+    val signalNumber: Int,
+    val timestamp: Instant,
+) {
+    val signalName: String =
+        when (signalNumber) {
+            4 -> "SIGILL"
+            5 -> "SIGTRAP"
+            6 -> "SIGABRT"
+            7 -> "SIGBUS"
+            8 -> "SIGFPE"
+            11 -> "SIGSEGV"
+            else -> "SIG$signalNumber"
+        }
+}
+
+internal data class NativeCrashContext(
+    val sessionId: String?,
+    val appBuildId: String?,
+    val serviceVersion: String?,
+    val osName: String?,
+    val osVersion: String?,
+) {
+    fun addTo(attributes: AttributesBuilder) {
+        attributes.putIfNotNull(SESSION_ID, sessionId)
+        attributes.putIfNotNull(APP_BUILD_ID, appBuildId)
+        attributes.putIfNotNull(SERVICE_VERSION, serviceVersion)
+        attributes.putIfNotNull(OS_NAME, osName)
+        attributes.putIfNotNull(OS_VERSION, osVersion)
+    }
+}
+
+private fun Context.currentCrashContext(openTelemetryRum: OpenTelemetryRum): NativeCrashContext {
+    val packageInfo = runCatching { packageManager.getPackageInfo(packageName, 0) }.getOrNull()
+    return NativeCrashContext(
+        sessionId = openTelemetryRum.sessionProvider.getSessionId().takeIf { it.isNotBlank() },
+        appBuildId = packageInfo?.let { PackageInfoCompat.getLongVersionCode(it).toString() },
+        serviceVersion = packageInfo?.versionName,
+        osName = "Android",
+        osVersion = Build.VERSION.RELEASE,
+    )
+}
+
+private fun AttributesBuilder.putIfNotNull(
+    key: String,
+    value: String?,
+) {
+    value?.takeIf { it.isNotBlank() }?.let { put(stringKey(key), it) }
+}
+
+private fun Properties.setIfNotNull(
+    key: String,
+    value: String?,
+) {
+    value?.takeIf { it.isNotBlank() }?.let { setProperty(key, it) }
+}
+
+private fun Properties.nonBlankProperty(key: String): String? = getProperty(key)?.takeIf { it.isNotBlank() }
+
+private const val NANOS_PER_SECOND = 1_000_000_000L
+
+private fun Long.toInstant(): Instant = Instant.ofEpochSecond(Math.floorDiv(this, NANOS_PER_SECOND), Math.floorMod(this, NANOS_PER_SECOND))

--- a/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
+++ b/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
@@ -9,9 +9,11 @@ package io.opentelemetry.android.instrumentation.nativecrash
 
 import android.content.Context
 import android.os.Build
+import android.util.Log
 import androidx.core.content.pm.PackageInfoCompat
 import com.google.auto.service.AutoService
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.common.RumConstants
 import io.opentelemetry.android.common.internal.SemconvCompat.Companion.map
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.session.Session
@@ -147,7 +149,13 @@ internal class FileNativeCrashStore(
     }
 
     override fun deleteCrashRecord() {
-        runCatching { crashRecordPath.delete() }
+        runCatching {
+            if (crashRecordPath.isFile && !crashRecordPath.delete()) {
+                throw IOException("Failed to delete native crash marker")
+            }
+        }.onFailure { error ->
+            Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to delete native crash marker", error)
+        }
     }
 
     override fun readContext(): NativeCrashContext? {
@@ -180,6 +188,8 @@ internal class FileNativeCrashStore(
             } finally {
                 temporaryPath.delete()
             }
+        }.onFailure { error ->
+            Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to persist native crash context", error)
         }
     }
 

--- a/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
+++ b/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
@@ -36,6 +36,8 @@ import java.io.FileOutputStream
 import java.io.IOException
 import java.time.Instant
 import java.util.Properties
+import java.util.concurrent.Executor
+import java.util.concurrent.Executors
 
 /** Entry point for replaying native crashes captured by a previous app process. */
 @AutoService(AndroidInstrumentation::class)
@@ -43,11 +45,13 @@ class NativeCrashInstrumentation internal constructor(
     private val storeFactory: (Context) -> NativeCrashStore = { context ->
         FileNativeCrashStore(File(context.filesDir, "opentelemetry/native-crash"))
     },
+    private val executor: Executor = Executors.newSingleThreadExecutor(),
 ) : AndroidInstrumentation {
     constructor() : this(
         storeFactory = { context ->
             FileNativeCrashStore(File(context.filesDir, "opentelemetry/native-crash"))
         },
+        executor = Executors.newSingleThreadExecutor(),
     )
 
     override val name: String = "native-crash"
@@ -57,16 +61,17 @@ class NativeCrashInstrumentation internal constructor(
         openTelemetryRum: OpenTelemetryRum,
     ) {
         val applicationContext = context.applicationContext
-        val store = storeFactory(applicationContext)
-        val crashContext = applicationContext.currentCrashContext(openTelemetryRum)
-        NativeCrashReporter(
-            store = store,
-            openTelemetryRum = openTelemetryRum,
-        ).install(crashContext)
-
-        val sessionProvider = openTelemetryRum.sessionProvider
-        if (sessionProvider is SessionPublisher) {
-            sessionProvider.addObserver(NativeCrashSessionObserver(store, crashContext))
+        executor.execute {
+            val store = storeFactory(applicationContext)
+            val crashContext = applicationContext.currentCrashContext(openTelemetryRum)
+            val sessionProvider = openTelemetryRum.sessionProvider
+            if (sessionProvider is SessionPublisher) {
+                sessionProvider.addObserver(NativeCrashSessionObserver(store, crashContext, executor))
+            }
+            NativeCrashReporter(
+                store = store,
+                openTelemetryRum = openTelemetryRum,
+            ).install(crashContext)
         }
     }
 }
@@ -74,12 +79,15 @@ class NativeCrashInstrumentation internal constructor(
 internal class NativeCrashSessionObserver(
     private val store: NativeCrashStore,
     private val crashContext: NativeCrashContext,
+    private val executor: Executor,
 ) : SessionObserver {
     override fun onSessionStarted(
         newSession: Session,
         previousSession: Session,
     ) {
-        store.writeContext(crashContext.copy(sessionId = newSession.id))
+        executor.execute {
+            store.writeContext(crashContext.copy(sessionId = newSession.id))
+        }
     }
 
     override fun onSessionEnded(session: Session) {}
@@ -90,19 +98,26 @@ internal class NativeCrashReporter(
     private val openTelemetryRum: OpenTelemetryRum,
 ) {
     fun install(currentContext: NativeCrashContext) {
-        replayPreviousCrash()
+        replayPreviousCrashes()
         store.writeContext(currentContext)
     }
 
-    private fun replayPreviousCrash() {
-        val record = store.readCrashRecord() ?: return
+    private fun replayPreviousCrashes() {
+        val crashContext = store.readContext()
+        store.readCrashRecords().forEach { record -> replay(record, crashContext) }
+    }
+
+    private fun replay(
+        record: NativeCrashRecord,
+        crashContext: NativeCrashContext?,
+    ) {
         val attributes = Attributes.builder()
-        attributes.put(stringKey(EXCEPTION_TYPE), "signal.${record.signalName}")
+        attributes.put(stringKey(EXCEPTION_TYPE), record.signalName)
         attributes.put(
             stringKey(EXCEPTION_MESSAGE),
             "Native crash signal ${record.signalName} (${record.signalNumber})",
         )
-        store.readContext()?.addTo(attributes)
+        crashContext?.addTo(attributes)
 
         openTelemetryRum.openTelemetry.logsBridge
             .loggerBuilder("io.opentelemetry.native-crash")
@@ -112,14 +127,14 @@ internal class NativeCrashReporter(
             .setTimestamp(record.timestamp)
             .setAllAttributes(attributes.build())
             .emit()
-        store.deleteCrashRecord()
+        store.deleteCrashRecord(record)
     }
 }
 
 internal interface NativeCrashStore {
-    fun readCrashRecord(): NativeCrashRecord?
+    fun readCrashRecords(): List<NativeCrashRecord>
 
-    fun deleteCrashRecord()
+    fun deleteCrashRecord(record: NativeCrashRecord)
 
     fun readContext(): NativeCrashContext?
 
@@ -129,28 +144,48 @@ internal interface NativeCrashStore {
 internal class FileNativeCrashStore(
     private val directory: File,
 ) : NativeCrashStore {
-    private val crashRecordPath = File(directory, "native-crash.properties")
     private val contextPath = File(directory, "native-crash-context.properties")
 
-    override fun readCrashRecord(): NativeCrashRecord? {
-        if (!crashRecordPath.isFile) {
-            return null
-        }
-        val properties = crashRecordPath.readPropertiesOrNull()
-        if (properties == null) {
-            deleteCrashRecord()
-            return null
-        }
-        val record = properties.toCrashRecordOrNull()
-        if (record == null) {
-            deleteCrashRecord()
-        }
-        return record
+    override fun readCrashRecords(): List<NativeCrashRecord> {
+        val paths =
+            directory.listFiles { path ->
+                path.isFile &&
+                    path.name.startsWith(CRASH_RECORD_PREFIX) &&
+                    path.name.endsWith(PROPERTIES_SUFFIX)
+            } ?: return emptyList()
+
+        return paths.sortedBy { it.name }.mapNotNull { path -> readCrashRecord(path) }
     }
 
-    override fun deleteCrashRecord() {
+    override fun deleteCrashRecord(record: NativeCrashRecord) {
+        val markerName = record.markerName ?: return
+        deleteCrashRecord(File(directory, markerName))
+    }
+
+    private fun readCrashRecord(path: File): NativeCrashRecord? {
+        val properties =
+            try {
+                path.readProperties()
+            } catch (error: IllegalArgumentException) {
+                deleteCrashRecord(path)
+                return null
+            } catch (error: IOException) {
+                Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to read native crash marker", error)
+                return null
+            } catch (error: SecurityException) {
+                Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to read native crash marker", error)
+                return null
+            }
+        val record = properties.toCrashRecordOrNull()
+        if (record == null) {
+            deleteCrashRecord(path)
+        }
+        return record?.copy(markerName = path.name)
+    }
+
+    private fun deleteCrashRecord(path: File) {
         runCatching {
-            if (crashRecordPath.isFile && !crashRecordPath.delete()) {
+            if (path.isFile && !path.delete()) {
                 throw IOException("Failed to delete native crash marker")
             }
         }.onFailure { error ->
@@ -159,7 +194,7 @@ internal class FileNativeCrashStore(
     }
 
     override fun readContext(): NativeCrashContext? {
-        val properties = contextPath.readPropertiesOrNull() ?: return null
+        val properties = runCatching { contextPath.readProperties() }.getOrNull() ?: return null
         return NativeCrashContext(
             sessionId = properties.nonBlankProperty(SESSION_ID),
             appBuildId = properties.nonBlankProperty(APP_BUILD_ID),
@@ -210,18 +245,14 @@ internal class FileNativeCrashStore(
         }.getOrNull()
     }
 
-    private fun File.readPropertiesOrNull(): Properties? {
-        if (!isFile) {
-            return null
+    private fun File.readProperties(): Properties =
+        Properties().also { properties ->
+            FileInputStream(this).use { properties.load(it) }
         }
-        return runCatching {
-            Properties().also { properties ->
-                FileInputStream(this).use { properties.load(it) }
-            }
-        }.getOrNull()
-    }
 
     private companion object {
+        const val CRASH_RECORD_PREFIX = "native-crash-record-"
+        const val PROPERTIES_SUFFIX = ".properties"
         const val SIGNAL_NUMBER_KEY = "signal.number"
         const val TIMESTAMP_EPOCH_NANOS_KEY = "timestamp.epoch_nanos"
     }
@@ -230,6 +261,7 @@ internal class FileNativeCrashStore(
 internal data class NativeCrashRecord(
     val signalNumber: Int,
     val timestamp: Instant,
+    internal val markerName: String? = null,
 ) {
     val signalName: String =
         when (signalNumber) {

--- a/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
+++ b/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
@@ -40,12 +40,9 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
-import java.io.FileInputStream
 import java.io.FileOutputStream
-import java.io.IOException
 import java.time.Instant
 import java.util.Properties
-import java.util.concurrent.atomic.AtomicInteger
 
 class NativeCrashReporterTest {
     @TempDir
@@ -119,8 +116,8 @@ class NativeCrashReporterTest {
         writeMarker(
             signalNumber = 11,
             timestampNanos = 1_783_598_400_000_000_000L,
-            crashContext = crashContext("crashed"),
         )
+        writeContext(crashContext("crashed"))
 
         reporter(store).install(crashContext("current"))
 
@@ -135,7 +132,7 @@ class NativeCrashReporterTest {
         assertThat(log.attributes.get(stringKey(SERVICE_VERSION))).isEqualTo("crashed-version")
         assertThat(log.attributes.get(stringKey(OS_NAME))).isEqualTo("crashed-os")
         assertThat(log.attributes.get(stringKey(OS_VERSION))).isEqualTo("crashed-os-version")
-        assertThat(store.readCrashRecords()).isEmpty()
+        assertThat(store.readCrashRecord()).isNull()
         assertThat(store.readContext()).isEqualTo(crashContext("current"))
     }
 
@@ -223,7 +220,7 @@ class NativeCrashReporterTest {
                 )
             }
 
-            assertThat(store.readCrashRecords()).isEmpty()
+            assertThat(store.readCrashRecord()).isNull()
             assertThat(markerFile()).doesNotExist()
         }
     }
@@ -234,8 +231,8 @@ class NativeCrashReporterTest {
         writeMarker(
             signalNumber = 6,
             timestampNanos = 1_783_598_400_000_000_000L,
-            crashContext = crashContext("crashed"),
         )
+        writeContext(crashContext("crashed"))
         val reporter = reporter(store)
 
         reporter.install(crashContext("current"))
@@ -243,81 +240,6 @@ class NativeCrashReporterTest {
 
         assertThat(otelTesting.logRecords).hasSize(1)
         assertThat(store.readContext()).isEqualTo(crashContext("later"))
-    }
-
-    @Test
-    fun `replays multiple markers without one malformed marker blocking the others`() {
-        val store = FileNativeCrashStore(tempDir)
-        writeMarker(
-            signalNumber = 11,
-            timestampNanos = 1_783_598_400_000_000_000L,
-            markerId = "one",
-            crashContext = crashContext("first"),
-        )
-        markerFile("two").writeText("signal.number=invalid\ntimestamp.epoch_nanos=123\n")
-        writeMarker(
-            signalNumber = 6,
-            timestampNanos = 1_783_598_401_000_000_000L,
-            markerId = "three",
-            crashContext = crashContext("third"),
-        )
-
-        reporter(store).install(crashContext("current"))
-
-        assertThat(otelTesting.logRecords.map { it.attributes.get(stringKey(EXCEPTION_TYPE)) })
-            .containsExactly("SIGSEGV", "SIGABRT")
-        assertThat(otelTesting.logRecords.map { it.attributes.get(stringKey(SESSION_ID)) })
-            .containsExactly("first-session", "third-session")
-        assertThat(store.readCrashRecords()).isEmpty()
-        assertThat(markerFile("two")).doesNotExist()
-    }
-
-    @Test
-    fun `removes a marker after repeated read failures`() {
-        val readAttempts = AtomicInteger()
-        val store =
-            FileNativeCrashStore(
-                directory = tempDir,
-                crashRecordReader = {
-                    readAttempts.incrementAndGet()
-                    throw IOException("temporary read failure")
-                },
-            )
-        writeMarker(signalNumber = 11, timestampNanos = 1_783_598_400_000_000_000L)
-
-        repeat(2) {
-            assertThat(store.readCrashRecords()).isEmpty()
-            assertThat(markerFile()).exists()
-        }
-        assertThat(store.readCrashRecords()).isEmpty()
-
-        assertThat(readAttempts).hasValue(3)
-        assertThat(markerFile()).doesNotExist()
-        assertThat(readFailureFile()).doesNotExist()
-    }
-
-    @Test
-    fun `clears the failure count after a marker can be read`() {
-        val readAttempts = AtomicInteger()
-        val store =
-            FileNativeCrashStore(
-                directory = tempDir,
-                crashRecordReader = { path ->
-                    if (readAttempts.incrementAndGet() == 1) {
-                        throw IOException("temporary read failure")
-                    }
-                    Properties().also { properties ->
-                        FileInputStream(path).use { properties.load(it) }
-                    }
-                },
-            )
-        writeMarker(signalNumber = 11, timestampNanos = 1_783_598_400_000_000_000L)
-
-        assertThat(store.readCrashRecords()).isEmpty()
-        assertThat(readFailureFile()).exists()
-
-        assertThat(store.readCrashRecords()).hasSize(1)
-        assertThat(readFailureFile()).doesNotExist()
     }
 
     @Test
@@ -335,28 +257,24 @@ class NativeCrashReporterTest {
     private fun writeMarker(
         signalNumber: Int,
         timestampNanos: Long,
-        markerId: String = "test",
-        crashContext: NativeCrashContext? = null,
     ) {
         val path =
-            markerFile(markerId).apply {
+            markerFile().apply {
                 parentFile?.mkdirs()
             }
         val properties =
             Properties().apply {
                 setProperty("signal.number", signalNumber.toString())
                 setProperty("timestamp.epoch_nanos", timestampNanos.toString())
-                crashContext?.sessionId?.let { setProperty(SESSION_ID, it) }
-                crashContext?.serviceVersion?.let { setProperty(SERVICE_VERSION, it) }
-                crashContext?.osName?.let { setProperty(OS_NAME, it) }
-                crashContext?.osVersion?.let { setProperty(OS_VERSION, it) }
             }
         FileOutputStream(path).use { properties.store(it, null) }
     }
 
-    private fun markerFile(markerId: String = "test"): File = File(tempDir, "native-crash-record-$markerId.properties")
+    private fun writeContext(context: NativeCrashContext) {
+        FileNativeCrashStore(tempDir).writeContext(context)
+    }
 
-    private fun readFailureFile(markerId: String = "test"): File = File(tempDir, "native-crash-record-$markerId.properties.read-failures")
+    private fun markerFile(): File = File(tempDir, "native-crash-record.properties")
 
     private fun contextFile(): File = File(tempDir, "native-crash-context.properties")
 

--- a/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
+++ b/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
@@ -11,8 +11,11 @@ import android.content.Context
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.os.Build
+import android.util.Log
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.session.Session
 import io.opentelemetry.android.session.SessionObserver
@@ -32,19 +35,33 @@ import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.IOException
 import java.time.Instant
+import java.util.Properties
+import java.util.concurrent.atomic.AtomicInteger
 
 class NativeCrashReporterTest {
     @TempDir
     lateinit var tempDir: File
 
+    @BeforeEach
+    fun setUp() {
+        mockkStatic(Log::class)
+        every { Log.w(any<String>(), any<String>()) } returns 0
+        every { Log.w(any<String>(), any<String>(), any<Throwable>()) } returns 0
+    }
+
     @AfterEach
     fun cleanup() {
         otelTesting.clearLogRecords()
+        unmockkStatic(Log::class)
     }
 
     @Test
@@ -67,7 +84,11 @@ class NativeCrashReporterTest {
         every { applicationContext.packageManager } returns packageManager
         every { applicationContext.packageName } returns "test.app"
         every { packageManager.getPackageInfo("test.app", 0) } returns packageInfo
-        val sessionProvider = RecordingSessionProvider("install-session")
+        val sessionProvider =
+            RecordingSessionProvider(
+                sessionId = "install-session",
+                sessionStartedOnRegistration = "started-session",
+            )
         val instrumentation =
             NativeCrashInstrumentation(
                 storeFactory = { actualContext ->
@@ -83,7 +104,7 @@ class NativeCrashReporterTest {
         assertThat(store.readContext())
             .isEqualTo(
                 NativeCrashContext(
-                    sessionId = "install-session",
+                    sessionId = "started-session",
                     serviceVersion = "1.2.3",
                     osName = "Android",
                     osVersion = Build.VERSION.RELEASE,
@@ -95,8 +116,11 @@ class NativeCrashReporterTest {
     @Test
     fun `replays a valid marker with crash-time context`() {
         val store = FileNativeCrashStore(tempDir)
-        store.writeContext(crashContext("crashed"))
-        writeMarker(signalNumber = 11, timestampNanos = 1_783_598_400_000_000_000L)
+        writeMarker(
+            signalNumber = 11,
+            timestampNanos = 1_783_598_400_000_000_000L,
+            crashContext = crashContext("crashed"),
+        )
 
         reporter(store).install(crashContext("current"))
 
@@ -207,8 +231,11 @@ class NativeCrashReporterTest {
     @Test
     fun `does not replay an already consumed marker`() {
         val store = FileNativeCrashStore(tempDir)
-        store.writeContext(crashContext("crashed"))
-        writeMarker(signalNumber = 6, timestampNanos = 1_783_598_400_000_000_000L)
+        writeMarker(
+            signalNumber = 6,
+            timestampNanos = 1_783_598_400_000_000_000L,
+            crashContext = crashContext("crashed"),
+        )
         val reporter = reporter(store)
 
         reporter.install(crashContext("current"))
@@ -221,17 +248,76 @@ class NativeCrashReporterTest {
     @Test
     fun `replays multiple markers without one malformed marker blocking the others`() {
         val store = FileNativeCrashStore(tempDir)
-        store.writeContext(crashContext("crashed"))
-        writeMarker(signalNumber = 11, timestampNanos = 1_783_598_400_000_000_000L, markerId = "one")
+        writeMarker(
+            signalNumber = 11,
+            timestampNanos = 1_783_598_400_000_000_000L,
+            markerId = "one",
+            crashContext = crashContext("first"),
+        )
         markerFile("two").writeText("signal.number=invalid\ntimestamp.epoch_nanos=123\n")
-        writeMarker(signalNumber = 6, timestampNanos = 1_783_598_401_000_000_000L, markerId = "three")
+        writeMarker(
+            signalNumber = 6,
+            timestampNanos = 1_783_598_401_000_000_000L,
+            markerId = "three",
+            crashContext = crashContext("third"),
+        )
 
         reporter(store).install(crashContext("current"))
 
         assertThat(otelTesting.logRecords.map { it.attributes.get(stringKey(EXCEPTION_TYPE)) })
             .containsExactly("SIGSEGV", "SIGABRT")
+        assertThat(otelTesting.logRecords.map { it.attributes.get(stringKey(SESSION_ID)) })
+            .containsExactly("first-session", "third-session")
         assertThat(store.readCrashRecords()).isEmpty()
         assertThat(markerFile("two")).doesNotExist()
+    }
+
+    @Test
+    fun `removes a marker after repeated read failures`() {
+        val readAttempts = AtomicInteger()
+        val store =
+            FileNativeCrashStore(
+                directory = tempDir,
+                crashRecordReader = {
+                    readAttempts.incrementAndGet()
+                    throw IOException("temporary read failure")
+                },
+            )
+        writeMarker(signalNumber = 11, timestampNanos = 1_783_598_400_000_000_000L)
+
+        repeat(2) {
+            assertThat(store.readCrashRecords()).isEmpty()
+            assertThat(markerFile()).exists()
+        }
+        assertThat(store.readCrashRecords()).isEmpty()
+
+        assertThat(readAttempts).hasValue(3)
+        assertThat(markerFile()).doesNotExist()
+        assertThat(readFailureFile()).doesNotExist()
+    }
+
+    @Test
+    fun `clears the failure count after a marker can be read`() {
+        val readAttempts = AtomicInteger()
+        val store =
+            FileNativeCrashStore(
+                directory = tempDir,
+                crashRecordReader = { path ->
+                    if (readAttempts.incrementAndGet() == 1) {
+                        throw IOException("temporary read failure")
+                    }
+                    Properties().also { properties ->
+                        FileInputStream(path).use { properties.load(it) }
+                    }
+                },
+            )
+        writeMarker(signalNumber = 11, timestampNanos = 1_783_598_400_000_000_000L)
+
+        assertThat(store.readCrashRecords()).isEmpty()
+        assertThat(readFailureFile()).exists()
+
+        assertThat(store.readCrashRecords()).hasSize(1)
+        assertThat(readFailureFile()).doesNotExist()
     }
 
     @Test
@@ -250,14 +336,27 @@ class NativeCrashReporterTest {
         signalNumber: Int,
         timestampNanos: Long,
         markerId: String = "test",
+        crashContext: NativeCrashContext? = null,
     ) {
-        markerFile(markerId).apply {
-            parentFile?.mkdirs()
-            writeText("signal.number=$signalNumber\ntimestamp.epoch_nanos=$timestampNanos\n")
-        }
+        val path =
+            markerFile(markerId).apply {
+                parentFile?.mkdirs()
+            }
+        val properties =
+            Properties().apply {
+                setProperty("signal.number", signalNumber.toString())
+                setProperty("timestamp.epoch_nanos", timestampNanos.toString())
+                crashContext?.sessionId?.let { setProperty(SESSION_ID, it) }
+                crashContext?.serviceVersion?.let { setProperty(SERVICE_VERSION, it) }
+                crashContext?.osName?.let { setProperty(OS_NAME, it) }
+                crashContext?.osVersion?.let { setProperty(OS_VERSION, it) }
+            }
+        FileOutputStream(path).use { properties.store(it, null) }
     }
 
     private fun markerFile(markerId: String = "test"): File = File(tempDir, "native-crash-record-$markerId.properties")
+
+    private fun readFailureFile(markerId: String = "test"): File = File(tempDir, "native-crash-record-$markerId.properties.read-failures")
 
     private fun contextFile(): File = File(tempDir, "native-crash-context.properties")
 
@@ -292,6 +391,7 @@ class NativeCrashReporterTest {
 
     private class RecordingSessionProvider(
         private val sessionId: String,
+        private val sessionStartedOnRegistration: String? = null,
     ) : SessionProvider,
         SessionPublisher {
         var observer: SessionObserver? = null
@@ -300,6 +400,18 @@ class NativeCrashReporterTest {
 
         override fun addObserver(observer: SessionObserver) {
             this.observer = observer
+            sessionStartedOnRegistration?.let { newSessionId ->
+                observer.onSessionStarted(
+                    object : Session {
+                        override val id: String = newSessionId
+                        override val startTimestamp: Long = 0
+                    },
+                    object : Session {
+                        override val id: String = sessionId
+                        override val startTimestamp: Long = 0
+                    },
+                )
+            }
         }
     }
 

--- a/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
+++ b/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
@@ -7,9 +7,17 @@
 
 package io.opentelemetry.android.instrumentation.nativecrash
 
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.content.pm.PackageManager
+import android.os.Build
+import io.mockk.every
+import io.mockk.mockk
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.session.Session
+import io.opentelemetry.android.session.SessionObserver
 import io.opentelemetry.android.session.SessionProvider
+import io.opentelemetry.android.session.SessionPublisher
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.api.common.Attributes
@@ -38,6 +46,54 @@ class NativeCrashReporterTest {
     @AfterEach
     fun cleanup() {
         otelTesting.clearLogRecords()
+    }
+
+    @Test
+    fun `has a stable instrumentation name`() {
+        assertThat(NativeCrashInstrumentation().name).isEqualTo("native-crash")
+    }
+
+    @Test
+    fun `installs replay and session observer using the application context`() {
+        val store = FileNativeCrashStore(tempDir)
+        writeMarker(signalNumber = 11, timestampNanos = 1_783_598_400_000_000_000L)
+        val packageInfo =
+            PackageInfo().apply {
+                versionName = "1.2.3"
+                @Suppress("DEPRECATION")
+                versionCode = 42
+            }
+        val packageManager = mockk<PackageManager>()
+        val applicationContext = mockk<Context>()
+        val context = mockk<Context>()
+        every { context.applicationContext } returns applicationContext
+        every { applicationContext.packageManager } returns packageManager
+        every { applicationContext.packageName } returns "test.app"
+        every { packageManager.getPackageInfo("test.app", 0) } returns packageInfo
+        val sessionProvider = RecordingSessionProvider("install-session")
+        val instrumentation =
+            NativeCrashInstrumentation(
+                storeFactory = { actualContext ->
+                    assertThat(actualContext).isSameAs(applicationContext)
+                    store
+                },
+                executor = directExecutor,
+            )
+
+        instrumentation.install(context, fakeRum(sessionProvider))
+
+        assertThat(otelTesting.logRecords).hasSize(1)
+        assertThat(store.readContext())
+            .isEqualTo(
+                NativeCrashContext(
+                    sessionId = "install-session",
+                    appBuildId = "42",
+                    serviceVersion = "1.2.3",
+                    osName = "Android",
+                    osVersion = Build.VERSION.RELEASE,
+                ),
+            )
+        assertThat(sessionProvider.observer).isNotNull()
     }
 
     @Test
@@ -226,10 +282,10 @@ class NativeCrashReporterTest {
             osVersion = "$prefix-os-version",
         )
 
-    private fun fakeRum(): OpenTelemetryRum =
+    private fun fakeRum(sessionProvider: SessionProvider = SessionProvider { "current-session" }): OpenTelemetryRum =
         object : OpenTelemetryRum {
             override val openTelemetry: OpenTelemetry = otelTesting.openTelemetry
-            override val sessionProvider: SessionProvider = SessionProvider { "current-session" }
+            override val sessionProvider: SessionProvider = sessionProvider
             override val clock: Clock = Clock.getDefault()
 
             override fun emitEvent(
@@ -240,6 +296,19 @@ class NativeCrashReporterTest {
 
             override fun shutdown() {}
         }
+
+    private class RecordingSessionProvider(
+        private val sessionId: String,
+    ) : SessionProvider,
+        SessionPublisher {
+        var observer: SessionObserver? = null
+
+        override fun getSessionId(): String = sessionId
+
+        override fun addObserver(observer: SessionObserver) {
+            this.observer = observer
+        }
+    }
 
     private companion object {
         val directExecutor = java.util.concurrent.Executor { command -> command.run() }

--- a/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
+++ b/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
@@ -52,7 +52,7 @@ class NativeCrashReporterTest {
         val log = otelTesting.logRecords.single()
         assertThat(log.eventName).isEqualTo("app.crash")
         assertThat(log.timestampEpochNanos).isEqualTo(1_783_598_400_000_000_000L)
-        assertThat(log.attributes.get(stringKey(EXCEPTION_TYPE))).isEqualTo("signal.SIGSEGV")
+        assertThat(log.attributes.get(stringKey(EXCEPTION_TYPE))).isEqualTo("SIGSEGV")
         assertThat(log.attributes.get(stringKey(EXCEPTION_MESSAGE)))
             .isEqualTo("Native crash signal SIGSEGV (11)")
         assertThat(log.attributes.get(stringKey(SESSION_ID))).isEqualTo("crashed-session")
@@ -60,7 +60,7 @@ class NativeCrashReporterTest {
         assertThat(log.attributes.get(stringKey(SERVICE_VERSION))).isEqualTo("crashed-version")
         assertThat(log.attributes.get(stringKey(OS_NAME))).isEqualTo("crashed-os")
         assertThat(log.attributes.get(stringKey(OS_VERSION))).isEqualTo("crashed-os-version")
-        assertThat(store.readCrashRecord()).isNull()
+        assertThat(store.readCrashRecords()).isEmpty()
         assertThat(store.readContext()).isEqualTo(crashContext("current"))
     }
 
@@ -149,7 +149,7 @@ class NativeCrashReporterTest {
                 )
             }
 
-            assertThat(store.readCrashRecord()).isNull()
+            assertThat(store.readCrashRecords()).isEmpty()
             assertThat(markerFile()).doesNotExist()
         }
     }
@@ -169,9 +169,25 @@ class NativeCrashReporterTest {
     }
 
     @Test
+    fun `replays multiple markers without one malformed marker blocking the others`() {
+        val store = FileNativeCrashStore(tempDir)
+        store.writeContext(crashContext("crashed"))
+        writeMarker(signalNumber = 11, timestampNanos = 1_783_598_400_000_000_000L, markerId = "one")
+        markerFile("two").writeText("signal.number=invalid\ntimestamp.epoch_nanos=123\n")
+        writeMarker(signalNumber = 6, timestampNanos = 1_783_598_401_000_000_000L, markerId = "three")
+
+        reporter(store).install(crashContext("current"))
+
+        assertThat(otelTesting.logRecords.map { it.attributes.get(stringKey(EXCEPTION_TYPE)) })
+            .containsExactly("SIGSEGV", "SIGABRT")
+        assertThat(store.readCrashRecords()).isEmpty()
+        assertThat(markerFile("two")).doesNotExist()
+    }
+
+    @Test
     fun `updates persisted context when the session changes`() {
         val store = FileNativeCrashStore(tempDir)
-        val observer = NativeCrashSessionObserver(store, crashContext("original"))
+        val observer = NativeCrashSessionObserver(store, crashContext("original"), directExecutor)
 
         observer.onSessionStarted(session("new-session"), session("old-session"))
 
@@ -183,14 +199,15 @@ class NativeCrashReporterTest {
     private fun writeMarker(
         signalNumber: Int,
         timestampNanos: Long,
+        markerId: String = "test",
     ) {
-        markerFile().apply {
+        markerFile(markerId).apply {
             parentFile?.mkdirs()
             writeText("signal.number=$signalNumber\ntimestamp.epoch_nanos=$timestampNanos\n")
         }
     }
 
-    private fun markerFile(): File = File(tempDir, "native-crash.properties")
+    private fun markerFile(markerId: String = "test"): File = File(tempDir, "native-crash-record-$markerId.properties")
 
     private fun contextFile(): File = File(tempDir, "native-crash-context.properties")
 
@@ -225,6 +242,8 @@ class NativeCrashReporterTest {
         }
 
     private companion object {
+        val directExecutor = java.util.concurrent.Executor { command -> command.run() }
+
         @RegisterExtension
         val otelTesting: OpenTelemetryExtension = OpenTelemetryExtension.create()
     }

--- a/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
+++ b/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+@file:OptIn(IncubatingApi::class)
+
+package io.opentelemetry.android.instrumentation.nativecrash
+
+import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.session.Session
+import io.opentelemetry.android.session.SessionProvider
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.common.AttributeKey.stringKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_BUILD_ID
+import io.opentelemetry.kotlin.semconv.ExceptionAttributes.EXCEPTION_MESSAGE
+import io.opentelemetry.kotlin.semconv.ExceptionAttributes.EXCEPTION_TYPE
+import io.opentelemetry.kotlin.semconv.IncubatingApi
+import io.opentelemetry.kotlin.semconv.OsAttributes.OS_NAME
+import io.opentelemetry.kotlin.semconv.OsAttributes.OS_VERSION
+import io.opentelemetry.kotlin.semconv.ServiceAttributes.SERVICE_VERSION
+import io.opentelemetry.kotlin.semconv.SessionAttributes.SESSION_ID
+import io.opentelemetry.sdk.common.Clock
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+
+class NativeCrashReporterTest {
+    @TempDir
+    lateinit var tempDir: File
+
+    @AfterEach
+    fun cleanup() {
+        otelTesting.clearLogRecords()
+    }
+
+    @Test
+    fun `replays a valid marker with crash-time context`() {
+        val store = FileNativeCrashStore(tempDir)
+        store.writeContext(crashContext("crashed"))
+        writeMarker(signalNumber = 11, timestampNanos = 1_783_598_400_000_000_000L)
+
+        reporter(store).install(crashContext("current"))
+
+        assertThat(otelTesting.logRecords).hasSize(1)
+        val log = otelTesting.logRecords.single()
+        assertThat(log.eventName).isEqualTo("app.crash")
+        assertThat(log.timestampEpochNanos).isEqualTo(1_783_598_400_000_000_000L)
+        assertThat(log.attributes.get(stringKey(EXCEPTION_TYPE))).isEqualTo("signal.SIGSEGV")
+        assertThat(log.attributes.get(stringKey(EXCEPTION_MESSAGE)))
+            .isEqualTo("Native crash signal SIGSEGV (11)")
+        assertThat(log.attributes.get(stringKey(SESSION_ID))).isEqualTo("crashed-session")
+        assertThat(log.attributes.get(stringKey(APP_BUILD_ID))).isEqualTo("crashed-build")
+        assertThat(log.attributes.get(stringKey(SERVICE_VERSION))).isEqualTo("crashed-version")
+        assertThat(log.attributes.get(stringKey(OS_NAME))).isEqualTo("crashed-os")
+        assertThat(log.attributes.get(stringKey(OS_VERSION))).isEqualTo("crashed-os-version")
+        assertThat(store.readCrashRecord()).isNull()
+        assertThat(store.readContext()).isEqualTo(crashContext("current"))
+    }
+
+    @Test
+    fun `does not emit when the marker is missing`() {
+        val store = FileNativeCrashStore(tempDir)
+
+        reporter(store).install(crashContext("current"))
+
+        assertThat(otelTesting.logRecords).isEmpty()
+        assertThat(store.readContext()).isEqualTo(crashContext("current"))
+    }
+
+    @Test
+    fun `ignores and removes a malformed marker`() {
+        val store = FileNativeCrashStore(tempDir)
+        markerFile().apply {
+            parentFile?.mkdirs()
+            writeText("signal.number=not-a-number\ntimestamp.epoch_nanos=123\n")
+        }
+
+        reporter(store).install(crashContext("current"))
+
+        assertThat(otelTesting.logRecords).isEmpty()
+        assertThat(markerFile()).doesNotExist()
+    }
+
+    @Test
+    fun `does not replay an already consumed marker`() {
+        val store = FileNativeCrashStore(tempDir)
+        store.writeContext(crashContext("crashed"))
+        writeMarker(signalNumber = 6, timestampNanos = 1_783_598_400_000_000_000L)
+        val reporter = reporter(store)
+
+        reporter.install(crashContext("current"))
+        reporter.install(crashContext("later"))
+
+        assertThat(otelTesting.logRecords).hasSize(1)
+        assertThat(store.readContext()).isEqualTo(crashContext("later"))
+    }
+
+    @Test
+    fun `updates persisted context when the session changes`() {
+        val store = FileNativeCrashStore(tempDir)
+        val observer = NativeCrashSessionObserver(store, crashContext("original"))
+
+        observer.onSessionStarted(session("new-session"), session("old-session"))
+
+        assertThat(store.readContext()).isEqualTo(crashContext("original").copy(sessionId = "new-session"))
+    }
+
+    private fun reporter(store: NativeCrashStore): NativeCrashReporter = NativeCrashReporter(store, fakeRum())
+
+    private fun writeMarker(
+        signalNumber: Int,
+        timestampNanos: Long,
+    ) {
+        markerFile().apply {
+            parentFile?.mkdirs()
+            writeText("signal.number=$signalNumber\ntimestamp.epoch_nanos=$timestampNanos\n")
+        }
+    }
+
+    private fun markerFile(): File = File(tempDir, "native-crash.properties")
+
+    private fun session(sessionId: String): Session =
+        object : Session {
+            override val id: String = sessionId
+            override val startTimestamp: Long = 0
+        }
+
+    private fun crashContext(prefix: String): NativeCrashContext =
+        NativeCrashContext(
+            sessionId = "$prefix-session",
+            appBuildId = "$prefix-build",
+            serviceVersion = "$prefix-version",
+            osName = "$prefix-os",
+            osVersion = "$prefix-os-version",
+        )
+
+    private fun fakeRum(): OpenTelemetryRum =
+        object : OpenTelemetryRum {
+            override val openTelemetry: OpenTelemetry = otelTesting.openTelemetry
+            override val sessionProvider: SessionProvider = SessionProvider { "current-session" }
+            override val clock: Clock = Clock.getDefault()
+
+            override fun emitEvent(
+                eventName: String,
+                body: String,
+                attributes: Attributes,
+            ) {}
+
+            override fun shutdown() {}
+        }
+
+    private companion object {
+        @RegisterExtension
+        val otelTesting: OpenTelemetryExtension = OpenTelemetryExtension.create()
+    }
+}

--- a/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
+++ b/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
@@ -119,7 +119,8 @@ class NativeCrashReporterTest {
         )
         writeContext(crashContext("crashed"))
 
-        reporter(store).install(crashContext("current"))
+        reporter(store).replayPreviousCrash()
+        store.writeContext(crashContext("current"))
 
         assertThat(otelTesting.logRecords).hasSize(1)
         val log = otelTesting.logRecords.single()
@@ -141,7 +142,7 @@ class NativeCrashReporterTest {
         val store = FileNativeCrashStore(tempDir)
         writeMarker(signalNumber = 11, timestampNanos = 1_783_598_400_000_000_000L)
 
-        reporter(store).install(crashContext("current"))
+        reporter(store).replayPreviousCrash()
 
         val attributes = otelTesting.logRecords.single().attributes
         assertThat(attributes.get(stringKey(SESSION_ID))).isNull()
@@ -159,7 +160,8 @@ class NativeCrashReporterTest {
         }
         writeMarker(signalNumber = 11, timestampNanos = 1_783_598_400_000_000_000L)
 
-        reporter(store).install(crashContext("current"))
+        reporter(store).replayPreviousCrash()
+        store.writeContext(crashContext("current"))
 
         assertThat(
             otelTesting.logRecords
@@ -172,19 +174,30 @@ class NativeCrashReporterTest {
 
     @Test
     fun `maps native signal numbers to names`() {
-        val signalNumbers = listOf(4, 5, 6, 7, 8, 11, 15)
+        val signalNumbers = listOf(4, 5, 6, 7, 8, 11, 13, 31, 15)
 
         val signalNames = signalNumbers.map { NativeCrashRecord(it, Instant.EPOCH).signalName }
 
         assertThat(signalNames)
-            .containsExactly("SIGILL", "SIGTRAP", "SIGABRT", "SIGBUS", "SIGFPE", "SIGSEGV", "SIG15")
+            .containsExactly(
+                "SIGILL",
+                "SIGTRAP",
+                "SIGABRT",
+                "SIGBUS",
+                "SIGFPE",
+                "SIGSEGV",
+                "SIGPIPE",
+                "SIGSYS",
+                "SIG15",
+            )
     }
 
     @Test
     fun `does not emit when the marker is missing`() {
         val store = FileNativeCrashStore(tempDir)
 
-        reporter(store).install(crashContext("current"))
+        reporter(store).replayPreviousCrash()
+        store.writeContext(crashContext("current"))
 
         assertThat(otelTesting.logRecords).isEmpty()
         assertThat(store.readContext()).isEqualTo(crashContext("current"))
@@ -198,7 +211,8 @@ class NativeCrashReporterTest {
             writeText("signal.number=not-a-number\ntimestamp.epoch_nanos=123\n")
         }
 
-        reporter(store).install(crashContext("current"))
+        reporter(store).replayPreviousCrash()
+        store.writeContext(crashContext("current"))
 
         assertThat(otelTesting.logRecords).isEmpty()
         assertThat(markerFile()).doesNotExist()
@@ -235,8 +249,10 @@ class NativeCrashReporterTest {
         writeContext(crashContext("crashed"))
         val reporter = reporter(store)
 
-        reporter.install(crashContext("current"))
-        reporter.install(crashContext("later"))
+        reporter.replayPreviousCrash()
+        store.writeContext(crashContext("current"))
+        reporter.replayPreviousCrash()
+        store.writeContext(crashContext("later"))
 
         assertThat(otelTesting.logRecords).hasSize(1)
         assertThat(store.readContext()).isEqualTo(crashContext("later"))

--- a/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
+++ b/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
@@ -65,6 +65,41 @@ class NativeCrashReporterTest {
     }
 
     @Test
+    fun `replays a valid marker without crash-time context`() {
+        val store = FileNativeCrashStore(tempDir)
+        writeMarker(signalNumber = 11, timestampNanos = 1_783_598_400_000_000_000L)
+
+        reporter(store).install(crashContext("current"))
+
+        val attributes = otelTesting.logRecords.single().attributes
+        assertThat(attributes.get(stringKey(SESSION_ID))).isNull()
+        assertThat(attributes.get(stringKey(APP_BUILD_ID))).isNull()
+        assertThat(attributes.get(stringKey(SERVICE_VERSION))).isNull()
+        assertThat(attributes.get(stringKey(OS_NAME))).isNull()
+        assertThat(attributes.get(stringKey(OS_VERSION))).isNull()
+    }
+
+    @Test
+    fun `replays a valid marker when crash-time context is corrupt`() {
+        val store = FileNativeCrashStore(tempDir)
+        contextFile().apply {
+            parentFile?.mkdirs()
+            writeText("session.id=\\uZZZZ\n")
+        }
+        writeMarker(signalNumber = 11, timestampNanos = 1_783_598_400_000_000_000L)
+
+        reporter(store).install(crashContext("current"))
+
+        assertThat(
+            otelTesting.logRecords
+                .single()
+                .attributes
+                .get(stringKey(SESSION_ID)),
+        ).isNull()
+        assertThat(store.readContext()).isEqualTo(crashContext("current"))
+    }
+
+    @Test
     fun `maps native signal numbers to names`() {
         val signalNumbers = listOf(4, 5, 6, 7, 8, 11, 15)
 
@@ -96,6 +131,27 @@ class NativeCrashReporterTest {
 
         assertThat(otelTesting.logRecords).isEmpty()
         assertThat(markerFile()).doesNotExist()
+    }
+
+    @Test
+    fun `ignores and removes markers with invalid timestamps`() {
+        val store = FileNativeCrashStore(tempDir)
+        val invalidTimestamps = listOf(null, "not-a-number", "0", "-1")
+
+        invalidTimestamps.forEach { timestamp ->
+            markerFile().apply {
+                parentFile?.mkdirs()
+                writeText(
+                    buildString {
+                        appendLine("signal.number=11")
+                        timestamp?.let { appendLine("timestamp.epoch_nanos=$it") }
+                    },
+                )
+            }
+
+            assertThat(store.readCrashRecord()).isNull()
+            assertThat(markerFile()).doesNotExist()
+        }
     }
 
     @Test
@@ -135,6 +191,8 @@ class NativeCrashReporterTest {
     }
 
     private fun markerFile(): File = File(tempDir, "native-crash.properties")
+
+    private fun contextFile(): File = File(tempDir, "native-crash-context.properties")
 
     private fun session(sessionId: String): Session =
         object : Session {

--- a/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
+++ b/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.io.TempDir
 import java.io.File
+import java.time.Instant
 
 class NativeCrashReporterTest {
     @TempDir
@@ -61,6 +62,16 @@ class NativeCrashReporterTest {
         assertThat(log.attributes.get(stringKey(OS_VERSION))).isEqualTo("crashed-os-version")
         assertThat(store.readCrashRecord()).isNull()
         assertThat(store.readContext()).isEqualTo(crashContext("current"))
+    }
+
+    @Test
+    fun `maps native signal numbers to names`() {
+        val signalNumbers = listOf(4, 5, 6, 7, 8, 11, 15)
+
+        val signalNames = signalNumbers.map { NativeCrashRecord(it, Instant.EPOCH).signalName }
+
+        assertThat(signalNames)
+            .containsExactly("SIGILL", "SIGTRAP", "SIGABRT", "SIGBUS", "SIGFPE", "SIGSEGV", "SIG15")
     }
 
     @Test

--- a/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
+++ b/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
@@ -21,7 +21,6 @@ import io.opentelemetry.android.session.SessionPublisher
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.api.common.Attributes
-import io.opentelemetry.kotlin.semconv.AppAttributes.APP_BUILD_ID
 import io.opentelemetry.kotlin.semconv.ExceptionAttributes.EXCEPTION_MESSAGE
 import io.opentelemetry.kotlin.semconv.ExceptionAttributes.EXCEPTION_TYPE
 import io.opentelemetry.kotlin.semconv.IncubatingApi
@@ -60,8 +59,6 @@ class NativeCrashReporterTest {
         val packageInfo =
             PackageInfo().apply {
                 versionName = "1.2.3"
-                @Suppress("DEPRECATION")
-                versionCode = 42
             }
         val packageManager = mockk<PackageManager>()
         val applicationContext = mockk<Context>()
@@ -87,7 +84,6 @@ class NativeCrashReporterTest {
             .isEqualTo(
                 NativeCrashContext(
                     sessionId = "install-session",
-                    appBuildId = "42",
                     serviceVersion = "1.2.3",
                     osName = "Android",
                     osVersion = Build.VERSION.RELEASE,
@@ -112,7 +108,6 @@ class NativeCrashReporterTest {
         assertThat(log.attributes.get(stringKey(EXCEPTION_MESSAGE)))
             .isEqualTo("Native crash signal SIGSEGV (11)")
         assertThat(log.attributes.get(stringKey(SESSION_ID))).isEqualTo("crashed-session")
-        assertThat(log.attributes.get(stringKey(APP_BUILD_ID))).isEqualTo("crashed-build")
         assertThat(log.attributes.get(stringKey(SERVICE_VERSION))).isEqualTo("crashed-version")
         assertThat(log.attributes.get(stringKey(OS_NAME))).isEqualTo("crashed-os")
         assertThat(log.attributes.get(stringKey(OS_VERSION))).isEqualTo("crashed-os-version")
@@ -129,7 +124,6 @@ class NativeCrashReporterTest {
 
         val attributes = otelTesting.logRecords.single().attributes
         assertThat(attributes.get(stringKey(SESSION_ID))).isNull()
-        assertThat(attributes.get(stringKey(APP_BUILD_ID))).isNull()
         assertThat(attributes.get(stringKey(SERVICE_VERSION))).isNull()
         assertThat(attributes.get(stringKey(OS_NAME))).isNull()
         assertThat(attributes.get(stringKey(OS_VERSION))).isNull()
@@ -276,7 +270,6 @@ class NativeCrashReporterTest {
     private fun crashContext(prefix: String): NativeCrashContext =
         NativeCrashContext(
             sessionId = "$prefix-session",
-            appBuildId = "$prefix-build",
             serviceVersion = "$prefix-version",
             osName = "$prefix-os",
             osVersion = "$prefix-os-version",


### PR DESCRIPTION
## Summary

- add a standalone native-crash instrumentation module
- replay a persisted native crash marker as `app.crash` on the next app startup
- persist the crashed process session, app version/build, and OS context
- ignore missing or malformed markers and replay each valid marker only once

Because the crash is reported by a later app process, the persisted context is attached to the event instead of relying on the new process resource values.

## Scope

This is the first part of #764 and only adds the replay path. A follow-up PR will add the JNI/C signal handler that writes the marker when a native crash occurs.

Native stack unwinding, symbol upload, symbolication, and backend changes are intentionally out of scope.

## Testing

- focused replay tests covering valid, missing, malformed, and consumed markers
- session context update test
- module formatting, checks, API validation, and debug/release assembly