### PR TITLE
Federated semconv phase 5 - use generated event classes

### DIFF
--- a/android-agent/src/test/kotlin/io/opentelemetry/android/OtelAndroidClockTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/OtelAndroidClockTest.kt
@@ -46,11 +46,10 @@ class OtelAndroidClockTest {
     fun `uses GNSS time when available on API 29+`() {
         every { SystemClock.currentGnssTimeClock() } returns gnssClock
 
-        val clock =
-            OtelAndroidClock(
-                isGnssAnchorEnabled = true,
-                isNetworkAnchorEnabled = true,
-            )
+        val clock = OtelAndroidClock(
+            isGnssAnchorEnabled = true,
+            isNetworkAnchorEnabled = true,
+        )
 
         assertThat(clock.now()).isEqualTo(gnssMillis * 1_000_000)
     }
@@ -61,11 +60,10 @@ class OtelAndroidClockTest {
         every { SystemClock.currentGnssTimeClock() } returns gnssClock
         every { SystemClock.currentNetworkTimeClock() } returns networkClock
 
-        val clock =
-            OtelAndroidClock(
-                isGnssAnchorEnabled = true,
-                isNetworkAnchorEnabled = true,
-            )
+        val clock = OtelAndroidClock(
+            isGnssAnchorEnabled = true,
+            isNetworkAnchorEnabled = true,
+        )
 
         assertThat(clock.now()).isEqualTo(gnssMillis * 1_000_000)
     }
@@ -76,11 +74,10 @@ class OtelAndroidClockTest {
         every { SystemClock.currentGnssTimeClock() } throws RuntimeException("no gnss")
         every { SystemClock.currentNetworkTimeClock() } returns networkClock
 
-        val clock =
-            OtelAndroidClock(
-                isGnssAnchorEnabled = true,
-                isNetworkAnchorEnabled = true,
-            )
+        val clock = OtelAndroidClock(
+            isGnssAnchorEnabled = true,
+            isNetworkAnchorEnabled = true,
+        )
 
         assertThat(clock.now()).isEqualTo(networkMillis * 1_000_000)
     }
@@ -90,11 +87,10 @@ class OtelAndroidClockTest {
     fun `falls back to system time when GNSS clock throws and network time is unavailable`() {
         every { SystemClock.currentGnssTimeClock() } throws RuntimeException("no gnss")
 
-        val clock =
-            OtelAndroidClock(
-                isGnssAnchorEnabled = true,
-                isNetworkAnchorEnabled = true,
-            )
+        val clock = OtelAndroidClock(
+            isGnssAnchorEnabled = true,
+            isNetworkAnchorEnabled = true,
+        )
 
         assertThat(clock.now() / 1_000_000).isCloseTo(System.currentTimeMillis(), within(5000L))
     }
@@ -105,11 +101,10 @@ class OtelAndroidClockTest {
         every { SystemClock.currentGnssTimeClock() } throws RuntimeException("no gnss")
         every { SystemClock.currentNetworkTimeClock() } throws RuntimeException("no network")
 
-        val clock =
-            OtelAndroidClock(
-                isGnssAnchorEnabled = true,
-                isNetworkAnchorEnabled = true,
-            )
+        val clock = OtelAndroidClock(
+            isGnssAnchorEnabled = true,
+            isNetworkAnchorEnabled = true,
+        )
 
         assertThat(clock.now() / 1_000_000).isCloseTo(System.currentTimeMillis(), within(5000L))
     }

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/OtelAndroidClockTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/OtelAndroidClockTest.kt
@@ -46,10 +46,11 @@ class OtelAndroidClockTest {
     fun `uses GNSS time when available on API 29+`() {
         every { SystemClock.currentGnssTimeClock() } returns gnssClock
 
-        val clock = OtelAndroidClock(
-            isGnssAnchorEnabled = true,
-            isNetworkAnchorEnabled = true,
-        )
+        val clock =
+            OtelAndroidClock(
+                isGnssAnchorEnabled = true,
+                isNetworkAnchorEnabled = true,
+            )
 
         assertThat(clock.now()).isEqualTo(gnssMillis * 1_000_000)
     }
@@ -60,10 +61,11 @@ class OtelAndroidClockTest {
         every { SystemClock.currentGnssTimeClock() } returns gnssClock
         every { SystemClock.currentNetworkTimeClock() } returns networkClock
 
-        val clock = OtelAndroidClock(
-            isGnssAnchorEnabled = true,
-            isNetworkAnchorEnabled = true,
-        )
+        val clock =
+            OtelAndroidClock(
+                isGnssAnchorEnabled = true,
+                isNetworkAnchorEnabled = true,
+            )
 
         assertThat(clock.now()).isEqualTo(gnssMillis * 1_000_000)
     }
@@ -74,10 +76,11 @@ class OtelAndroidClockTest {
         every { SystemClock.currentGnssTimeClock() } throws RuntimeException("no gnss")
         every { SystemClock.currentNetworkTimeClock() } returns networkClock
 
-        val clock = OtelAndroidClock(
-            isGnssAnchorEnabled = true,
-            isNetworkAnchorEnabled = true,
-        )
+        val clock =
+            OtelAndroidClock(
+                isGnssAnchorEnabled = true,
+                isNetworkAnchorEnabled = true,
+            )
 
         assertThat(clock.now()).isEqualTo(networkMillis * 1_000_000)
     }
@@ -87,10 +90,11 @@ class OtelAndroidClockTest {
     fun `falls back to system time when GNSS clock throws and network time is unavailable`() {
         every { SystemClock.currentGnssTimeClock() } throws RuntimeException("no gnss")
 
-        val clock = OtelAndroidClock(
-            isGnssAnchorEnabled = true,
-            isNetworkAnchorEnabled = true,
-        )
+        val clock =
+            OtelAndroidClock(
+                isGnssAnchorEnabled = true,
+                isNetworkAnchorEnabled = true,
+            )
 
         assertThat(clock.now() / 1_000_000).isCloseTo(System.currentTimeMillis(), within(5000L))
     }
@@ -101,10 +105,11 @@ class OtelAndroidClockTest {
         every { SystemClock.currentGnssTimeClock() } throws RuntimeException("no gnss")
         every { SystemClock.currentNetworkTimeClock() } throws RuntimeException("no network")
 
-        val clock = OtelAndroidClock(
-            isGnssAnchorEnabled = true,
-            isNetworkAnchorEnabled = true,
-        )
+        val clock =
+            OtelAndroidClock(
+                isGnssAnchorEnabled = true,
+                isNetworkAnchorEnabled = true,
+            )
 
         assertThat(clock.now() / 1_000_000).isCloseTo(System.currentTimeMillis(), within(5000L))
     }

--- a/core/src/main/java/io/opentelemetry/android/OtelAndroidClock.kt
+++ b/core/src/main/java/io/opentelemetry/android/OtelAndroidClock.kt
@@ -24,49 +24,47 @@ import io.opentelemetry.sdk.common.Clock
  * the clock doesn't consistently tick when the process is in the background or cached). It also
  * avoids the problem of [SystemClock.elapsedRealtimeNanos] not providing wall-clock time.
  */
-class OtelAndroidClock
-    @JvmOverloads
-    constructor(
-        /**
-         * Whether the [OtelAndroidClock] should attempt to anchor its monotonic time against
-         * [SystemClock.currentGnssTimeClock] on startup (when available). Setting to `true` does
-         * not guarantee a GNSS anchor.
-         */
-        private val isGnssAnchorEnabled: Boolean = false,
-        /**
-         * Whether the [OtelAndroidClock] should attempt to anchor its monotonic time against
-         * [SystemClock.currentNetworkTimeClock] on startup (when available). Setting to `true` does
-         * not guarantee a network time anchor.
-         */
-        private val isNetworkAnchorEnabled: Boolean = false,
-    ) : Clock {
-        private val baselineNanos = currentTimeMillis() * 1_000_000 - nanoTime()
+class OtelAndroidClock @JvmOverloads constructor(
+    /**
+     * Whether the [OtelAndroidClock] should attempt to anchor its monotonic time against
+     * [SystemClock.currentGnssTimeClock] on startup (when available). Setting to `true` does
+     * not guarantee a GNSS anchor.
+     */
+    private val isGnssAnchorEnabled: Boolean = false,
+    /**
+     * Whether the [OtelAndroidClock] should attempt to anchor its monotonic time against
+     * [SystemClock.currentNetworkTimeClock] on startup (when available). Setting to `true` does
+     * not guarantee a network time anchor.
+     */
+    private val isNetworkAnchorEnabled: Boolean = false,
+) : Clock {
+    private val baselineNanos = currentTimeMillis() * 1_000_000 - nanoTime()
 
-        override fun now(): Long = baselineNanos + nanoTime()
+    override fun now(): Long = baselineNanos + nanoTime()
 
-        override fun nanoTime(): Long = SystemClock.elapsedRealtimeNanos()
+    override fun nanoTime(): Long = SystemClock.elapsedRealtimeNanos()
 
-        private fun currentTimeMillis(): Long {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && isGnssAnchorEnabled) {
-                try {
-                    return currentGnssTimeMillis()
-                } catch (_: Exception) {
-                }
+    private fun currentTimeMillis(): Long {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && isGnssAnchorEnabled) {
+            try {
+                return currentGnssTimeMillis()
+            } catch (_: Exception) {
             }
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && isNetworkAnchorEnabled) {
-                try {
-                    return currentNetworkTimeMillis()
-                } catch (_: Exception) {
-                }
-            }
-
-            return System.currentTimeMillis()
         }
 
-        @RequiresApi(api = Build.VERSION_CODES.Q)
-        private fun currentGnssTimeMillis(): Long = SystemClock.currentGnssTimeClock().millis()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && isNetworkAnchorEnabled) {
+            try {
+                return currentNetworkTimeMillis()
+            } catch (_: Exception) {
+            }
+        }
 
-        @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
-        private fun currentNetworkTimeMillis(): Long = SystemClock.currentNetworkTimeClock().millis()
+        return System.currentTimeMillis()
     }
+
+    @RequiresApi(api = Build.VERSION_CODES.Q)
+    private fun currentGnssTimeMillis(): Long = SystemClock.currentGnssTimeClock().millis()
+
+    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
+    private fun currentNetworkTimeMillis(): Long = SystemClock.currentNetworkTimeClock().millis()
+}

--- a/core/src/main/java/io/opentelemetry/android/OtelAndroidClock.kt
+++ b/core/src/main/java/io/opentelemetry/android/OtelAndroidClock.kt
@@ -24,47 +24,51 @@ import io.opentelemetry.sdk.common.Clock
  * the clock doesn't consistently tick when the process is in the background or cached). It also
  * avoids the problem of [SystemClock.elapsedRealtimeNanos] not providing wall-clock time.
  */
-class OtelAndroidClock @JvmOverloads constructor(
-    /**
-     * Whether the [OtelAndroidClock] should attempt to anchor its monotonic time against
-     * [SystemClock.currentGnssTimeClock] on startup (when available). Setting to `true` does
-     * not guarantee a GNSS anchor.
-     */
-    private val isGnssAnchorEnabled: Boolean = false,
-    /**
-     * Whether the [OtelAndroidClock] should attempt to anchor its monotonic time against
-     * [SystemClock.currentNetworkTimeClock] on startup (when available). Setting to `true` does
-     * not guarantee a network time anchor.
-     */
-    private val isNetworkAnchorEnabled: Boolean = false,
-) : Clock {
-    private val baselineNanos = currentTimeMillis() * 1_000_000 - nanoTime()
+class OtelAndroidClock
+    @JvmOverloads
+    constructor(
+        /**
+         * Whether the [OtelAndroidClock] should attempt to anchor its monotonic time against
+         * [SystemClock.currentGnssTimeClock] on startup (when available). Setting to `true` does
+         * not guarantee a GNSS anchor.
+         */
+        private val isGnssAnchorEnabled: Boolean = false,
+        /**
+         * Whether the [OtelAndroidClock] should attempt to anchor its monotonic time against
+         * [SystemClock.currentNetworkTimeClock] on startup (when available). Setting to `true` does
+         * not guarantee a network time anchor.
+         */
+        private val isNetworkAnchorEnabled: Boolean = false,
+    ) : Clock {
+        private val baselineNanos = currentTimeMillis() * 1_000_000 - nanoTime()
 
-    override fun now(): Long = baselineNanos + nanoTime()
+        override fun now(): Long = baselineNanos + nanoTime()
 
-    override fun nanoTime(): Long = SystemClock.elapsedRealtimeNanos()
+        override fun nanoTime(): Long = SystemClock.elapsedRealtimeNanos()
 
-    private fun currentTimeMillis(): Long {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && isGnssAnchorEnabled) {
-            try {
-                return currentGnssTimeMillis()
-            } catch (_: Exception) {
+        private fun currentTimeMillis(): Long {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && isGnssAnchorEnabled) {
+                try {
+                    return currentGnssTimeMillis()
+                } catch (_: Exception) {
+                    // Ignore and fall back to the next available time source.
+                }
             }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && isNetworkAnchorEnabled) {
+                try {
+                    return currentNetworkTimeMillis()
+                } catch (_: Exception) {
+                    // Ignore and fall back to System.currentTimeMillis().
+                }
+            }
+
+            return System.currentTimeMillis()
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && isNetworkAnchorEnabled) {
-            try {
-                return currentNetworkTimeMillis()
-            } catch (_: Exception) {
-            }
-        }
+        @RequiresApi(api = Build.VERSION_CODES.Q)
+        private fun currentGnssTimeMillis(): Long = SystemClock.currentGnssTimeClock().millis()
 
-        return System.currentTimeMillis()
+        @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
+        private fun currentNetworkTimeMillis(): Long = SystemClock.currentNetworkTimeClock().millis()
     }
-
-    @RequiresApi(api = Build.VERSION_CODES.Q)
-    private fun currentGnssTimeMillis(): Long = SystemClock.currentGnssTimeClock().millis()
-
-    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
-    private fun currentNetworkTimeMillis(): Long = SystemClock.currentNetworkTimeClock().millis()
-}

--- a/core/src/main/java/io/opentelemetry/android/OtelAndroidClock.kt
+++ b/core/src/main/java/io/opentelemetry/android/OtelAndroidClock.kt
@@ -24,47 +24,49 @@ import io.opentelemetry.sdk.common.Clock
  * the clock doesn't consistently tick when the process is in the background or cached). It also
  * avoids the problem of [SystemClock.elapsedRealtimeNanos] not providing wall-clock time.
  */
-class OtelAndroidClock @JvmOverloads constructor(
-    /**
-     * Whether the [OtelAndroidClock] should attempt to anchor its monotonic time against
-     * [SystemClock.currentGnssTimeClock] on startup (when available). Setting to `true` does
-     * not guarantee a GNSS anchor.
-     */
-    private val isGnssAnchorEnabled: Boolean = false,
-    /**
-     * Whether the [OtelAndroidClock] should attempt to anchor its monotonic time against
-     * [SystemClock.currentNetworkTimeClock] on startup (when available). Setting to `true` does
-     * not guarantee a network time anchor.
-     */
-    private val isNetworkAnchorEnabled: Boolean = false,
-) : Clock {
-    private val baselineNanos = currentTimeMillis() * 1_000_000 - nanoTime()
+class OtelAndroidClock
+    @JvmOverloads
+    constructor(
+        /**
+         * Whether the [OtelAndroidClock] should attempt to anchor its monotonic time against
+         * [SystemClock.currentGnssTimeClock] on startup (when available). Setting to `true` does
+         * not guarantee a GNSS anchor.
+         */
+        private val isGnssAnchorEnabled: Boolean = false,
+        /**
+         * Whether the [OtelAndroidClock] should attempt to anchor its monotonic time against
+         * [SystemClock.currentNetworkTimeClock] on startup (when available). Setting to `true` does
+         * not guarantee a network time anchor.
+         */
+        private val isNetworkAnchorEnabled: Boolean = false,
+    ) : Clock {
+        private val baselineNanos = currentTimeMillis() * 1_000_000 - nanoTime()
 
-    override fun now(): Long = baselineNanos + nanoTime()
+        override fun now(): Long = baselineNanos + nanoTime()
 
-    override fun nanoTime(): Long = SystemClock.elapsedRealtimeNanos()
+        override fun nanoTime(): Long = SystemClock.elapsedRealtimeNanos()
 
-    private fun currentTimeMillis(): Long {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && isGnssAnchorEnabled) {
-            try {
-                return currentGnssTimeMillis()
-            } catch (_: Exception) {
+        private fun currentTimeMillis(): Long {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && isGnssAnchorEnabled) {
+                try {
+                    return currentGnssTimeMillis()
+                } catch (_: Exception) {
+                }
             }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && isNetworkAnchorEnabled) {
+                try {
+                    return currentNetworkTimeMillis()
+                } catch (_: Exception) {
+                }
+            }
+
+            return System.currentTimeMillis()
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && isNetworkAnchorEnabled) {
-            try {
-                return currentNetworkTimeMillis()
-            } catch (_: Exception) {
-            }
-        }
+        @RequiresApi(api = Build.VERSION_CODES.Q)
+        private fun currentGnssTimeMillis(): Long = SystemClock.currentGnssTimeClock().millis()
 
-        return System.currentTimeMillis()
+        @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
+        private fun currentNetworkTimeMillis(): Long = SystemClock.currentNetworkTimeClock().millis()
     }
-
-    @RequiresApi(api = Build.VERSION_CODES.Q)
-    private fun currentGnssTimeMillis(): Long = SystemClock.currentGnssTimeClock().millis()
-
-    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
-    private fun currentNetworkTimeMillis(): Long = SystemClock.currentNetworkTimeClock().millis()
-}

--- a/instrumentation/anr/build.gradle.kts
+++ b/instrumentation/anr/build.gradle.kts
@@ -23,6 +23,7 @@ dependencies {
     implementation(project(":services"))
     implementation(project(":instrumentation:common-api"))
     implementation(project(":common"))
+    implementation(project(":semconv"))
     implementation(libs.androidx.core)
     implementation(libs.opentelemetry.semconv.kotlin)
     implementation(libs.opentelemetry.sdk)

--- a/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrWatcher.kt
+++ b/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrWatcher.kt
@@ -8,6 +8,7 @@ package io.opentelemetry.android.instrumentation.anr
 import android.os.Handler
 import io.opentelemetry.android.common.internal.utils.threadIdCompat
 import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor
+import io.opentelemetry.android.semconv.events.DeviceAnrEvent
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.context.Context
@@ -90,11 +91,7 @@ internal class AnrWatcher(
             attributesBuilder.putAll(extractedAttributes)
         }
 
-        val eventBuilder = anrLogger.logRecordBuilder()
-        eventBuilder
-            .setEventName("device.anr")
-            .setAllAttributes(attributesBuilder.build())
-            .emit()
+        DeviceAnrEvent().emit(anrLogger, attributesBuilder.build())
     }
 
     private fun stackTraceToString(stackTrace: Array<StackTraceElement>): String {

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkApplicationListener.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkApplicationListener.kt
@@ -9,6 +9,7 @@ import io.opentelemetry.android.common.internal.features.networkattributes.data.
 import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateListener
 import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
 import io.opentelemetry.android.internal.services.network.NetworkChangeListener
+import io.opentelemetry.android.semconv.events.NetworkChangeEvent
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Logger
 import java.util.concurrent.atomic.AtomicBoolean
@@ -64,11 +65,7 @@ internal class NetworkApplicationListener(
                     extractor(attributesBuilder, currentNetwork)
                 },
             )
-            val builder = eventLogger.logRecordBuilder()
-            builder
-                .setEventName("network.change")
-                .setAllAttributes(attributesBuilder.build())
-                .emit()
+            NetworkChangeEvent().emit(eventLogger, attributesBuilder.build())
         }
     }
 }

--- a/instrumentation/okhttp3-websocket/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/websocket/internal/WebsocketListenerWrapper.kt
+++ b/instrumentation/okhttp3-websocket/library/src/main/java/io/opentelemetry/instrumentation/library/okhttp/websocket/internal/WebsocketListenerWrapper.kt
@@ -5,8 +5,10 @@
 
 package io.opentelemetry.instrumentation.library.okhttp.websocket.internal
 
-import io.opentelemetry.android.semconv.WebsocketAttributes.WEBSOCKET_MESSAGE_SIZE_KEY
-import io.opentelemetry.android.semconv.WebsocketAttributes.WEBSOCKET_MESSAGE_TYPE_KEY
+import io.opentelemetry.android.semconv.events.WebsocketCloseEvent
+import io.opentelemetry.android.semconv.events.WebsocketErrorEvent
+import io.opentelemetry.android.semconv.events.WebsocketMessageEvent
+import io.opentelemetry.android.semconv.events.WebsocketOpenEvent
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Logger
@@ -27,7 +29,7 @@ class WebsocketListenerWrapper(
         reason: String,
     ) {
         val attributes = extractAttributes(webSocket)
-        emitEvent("websocket.close", attributes)
+        WebsocketCloseEvent().emit(logger, attributes)
         delegate.onClosed(webSocket, code, reason)
     }
 
@@ -36,7 +38,7 @@ class WebsocketListenerWrapper(
         response: Response,
     ) {
         val attributes = extractAttributes(webSocket)
-        emitEvent("websocket.open", attributes)
+        WebsocketOpenEvent().emit(logger, attributes)
         delegate.onOpen(webSocket, response)
     }
 
@@ -45,14 +47,10 @@ class WebsocketListenerWrapper(
         text: String,
     ) {
         val attributes = extractAttributes(webSocket)
-        emitEvent(
-            "websocket.message",
-            attributes
-                .toBuilder()
-                .put(WEBSOCKET_MESSAGE_TYPE_KEY, "text")
-                .put(WEBSOCKET_MESSAGE_SIZE_KEY, text.length.toLong())
-                .build(),
-        )
+        WebsocketMessageEvent(
+            websocketMessageSize = text.length.toLong(),
+            websocketMessageType = "text",
+        ).emit(logger, attributes)
         delegate.onMessage(webSocket, text)
     }
 
@@ -61,14 +59,10 @@ class WebsocketListenerWrapper(
         bytes: ByteString,
     ) {
         val attributes = extractAttributes(webSocket)
-        emitEvent(
-            "websocket.message",
-            attributes
-                .toBuilder()
-                .put(WEBSOCKET_MESSAGE_TYPE_KEY, "bytes")
-                .put(WEBSOCKET_MESSAGE_SIZE_KEY, bytes.size.toLong())
-                .build(),
-        )
+        WebsocketMessageEvent(
+            websocketMessageSize = bytes.size.toLong(),
+            websocketMessageType = "bytes",
+        ).emit(logger, attributes)
         delegate.onMessage(webSocket, bytes)
     }
 
@@ -78,7 +72,7 @@ class WebsocketListenerWrapper(
         response: Response?,
     ) {
         val attributes = extractAttributes(webSocket)
-        emitEvent("websocket.error", attributes)
+        WebsocketErrorEvent().emit(logger, attributes)
         delegate.onFailure(webSocket, t, response)
     }
 
@@ -92,17 +86,6 @@ class WebsocketListenerWrapper(
                 put(UrlAttributes.URL_FULL, request.url.toString())
                 put(NetworkAttributes.NETWORK_PEER_PORT, request.url.port.toLong())
             }.build()
-
-    private fun emitEvent(
-        eventName: String,
-        attributes: Attributes,
-    ) {
-        logger
-            .logRecordBuilder()
-            .setEventName(eventName)
-            .setAllAttributes(attributes)
-            .emit()
-    }
 
     companion object {
         private const val SCOPE = "io.opentelemetry.websocket.events"

--- a/instrumentation/power-save-mode/src/main/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeDetector.kt
+++ b/instrumentation/power-save-mode/src/main/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeDetector.kt
@@ -9,7 +9,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.os.PowerManager
-import io.opentelemetry.android.semconv.AndroidAttributes.ANDROID_POWER_SAVE_MODE_ENABLED_KEY
+import io.opentelemetry.android.semconv.events.DevicePowerSaveModeChangeEvent
 import io.opentelemetry.api.logs.Logger
 
 /**
@@ -25,18 +25,12 @@ internal class PowerSaveModeDetector(
     private val powerManager: PowerManager,
     private val logger: Logger,
 ) : BroadcastReceiver() {
-    internal companion object {
-        const val EVENT_NAME = "device.power_save_mode.change"
-    }
-
     override fun onReceive(
         context: Context,
         intent: Intent,
     ) {
-        logger
-            .logRecordBuilder()
-            .setEventName(EVENT_NAME)
-            .setAttribute(ANDROID_POWER_SAVE_MODE_ENABLED_KEY, powerManager.isPowerSaveMode)
-            .emit()
+        DevicePowerSaveModeChangeEvent(
+            androidPowerSaveModeEnabled = powerManager.isPowerSaveMode,
+        ).emit(logger)
     }
 }

--- a/instrumentation/power-save-mode/src/test/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeDetectorTest.kt
+++ b/instrumentation/power-save-mode/src/test/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeDetectorTest.kt
@@ -19,6 +19,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
 
+private const val EVENT_NAME = "device.power_save_mode.change"
+
 @RunWith(AndroidJUnit4::class)
 class PowerSaveModeDetectorTest {
     @get:Rule
@@ -52,7 +54,7 @@ class PowerSaveModeDetectorTest {
         // then
         assertThat(openTelemetryRule.logRecords).hasSize(1)
         val record = openTelemetryRule.logRecords.single()
-        assertThat(record.eventName).isEqualTo(PowerSaveModeDetector.EVENT_NAME)
+        assertThat(record.eventName).isEqualTo(EVENT_NAME)
         assertThat(record.attributes.get(ANDROID_POWER_SAVE_MODE_ENABLED_KEY))
             .isEqualTo(true)
     }
@@ -68,7 +70,7 @@ class PowerSaveModeDetectorTest {
         // then
         assertThat(openTelemetryRule.logRecords).hasSize(1)
         val record = openTelemetryRule.logRecords.single()
-        assertThat(record.eventName).isEqualTo(PowerSaveModeDetector.EVENT_NAME)
+        assertThat(record.eventName).isEqualTo(EVENT_NAME)
         assertThat(record.attributes.get(ANDROID_POWER_SAVE_MODE_ENABLED_KEY))
             .isEqualTo(false)
     }

--- a/instrumentation/power-save-mode/src/test/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeInstrumentationTest.kt
+++ b/instrumentation/power-save-mode/src/test/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeInstrumentationTest.kt
@@ -25,6 +25,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
 
+private const val EVENT_NAME = "device.power_save_mode.change"
+
 @RunWith(AndroidJUnit4::class)
 class PowerSaveModeInstrumentationTest {
     @get:Rule
@@ -59,7 +61,7 @@ class PowerSaveModeInstrumentationTest {
 
         assertThat(openTelemetryRule.logRecords).hasSize(1)
         val record = openTelemetryRule.logRecords.single()
-        assertThat(record.eventName).isEqualTo(PowerSaveModeDetector.EVENT_NAME)
+        assertThat(record.eventName).isEqualTo(EVENT_NAME)
         assertThat(record.attributes.get(ANDROID_POWER_SAVE_MODE_ENABLED_KEY))
             .isEqualTo(true)
     }

--- a/instrumentation/screen-orientation/src/main/java/io/opentelemetry/android/instrumentation/screenorientation/ScreenOrientationDetector.kt
+++ b/instrumentation/screen-orientation/src/main/java/io/opentelemetry/android/instrumentation/screenorientation/ScreenOrientationDetector.kt
@@ -10,7 +10,7 @@ import android.content.Context
 import android.content.res.Configuration
 import android.content.res.Configuration.ORIENTATION_LANDSCAPE
 import android.content.res.Configuration.ORIENTATION_PORTRAIT
-import io.opentelemetry.android.semconv.ScreenAttributes.SCREEN_ORIENTATION_KEY
+import io.opentelemetry.android.semconv.events.DeviceScreenOrientationEvent
 import io.opentelemetry.api.logs.Logger
 
 /**
@@ -29,16 +29,8 @@ internal class ScreenOrientationDetector(
 ) : ComponentCallbacks {
     private var currentOrientation: Int = applicationContext.resources.configuration.orientation
 
-    internal companion object {
-        const val EVENT_NAME = "device.screen_orientation"
-    }
-
     private fun emitLog(orientation: String) {
-        logger
-            .logRecordBuilder()
-            .setEventName(EVENT_NAME)
-            .setAttribute(SCREEN_ORIENTATION_KEY, orientation)
-            .emit()
+        DeviceScreenOrientationEvent(screenOrientation = orientation).emit(logger)
     }
 
     private val Int.name: String

--- a/instrumentation/screen-orientation/src/test/java/io/opentelemetry/android/instrumentation/screenorientation/ScreenOrientationDetectorTest.kt
+++ b/instrumentation/screen-orientation/src/test/java/io/opentelemetry/android/instrumentation/screenorientation/ScreenOrientationDetectorTest.kt
@@ -11,6 +11,7 @@ import android.content.res.Configuration.ORIENTATION_PORTRAIT
 import io.mockk.every
 import io.mockk.mockk
 import io.opentelemetry.android.semconv.ScreenAttributes.SCREEN_ORIENTATION_KEY
+import io.opentelemetry.android.semconv.events.DeviceScreenOrientationEvent
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull

--- a/instrumentation/screen-orientation/src/test/java/io/opentelemetry/android/instrumentation/screenorientation/ScreenOrientationDetectorTest.kt
+++ b/instrumentation/screen-orientation/src/test/java/io/opentelemetry/android/instrumentation/screenorientation/ScreenOrientationDetectorTest.kt
@@ -11,7 +11,6 @@ import android.content.res.Configuration.ORIENTATION_PORTRAIT
 import io.mockk.every
 import io.mockk.mockk
 import io.opentelemetry.android.semconv.ScreenAttributes.SCREEN_ORIENTATION_KEY
-import io.opentelemetry.android.semconv.events.DeviceScreenOrientationEvent
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull

--- a/instrumentation/screen-orientation/src/test/java/io/opentelemetry/android/instrumentation/screenorientation/ScreenOrientationDetectorTest.kt
+++ b/instrumentation/screen-orientation/src/test/java/io/opentelemetry/android/instrumentation/screenorientation/ScreenOrientationDetectorTest.kt
@@ -10,8 +10,8 @@ import android.content.res.Configuration
 import android.content.res.Configuration.ORIENTATION_PORTRAIT
 import io.mockk.every
 import io.mockk.mockk
-import io.opentelemetry.android.instrumentation.screenorientation.ScreenOrientationDetector.Companion.EVENT_NAME
 import io.opentelemetry.android.semconv.ScreenAttributes.SCREEN_ORIENTATION_KEY
+import io.opentelemetry.android.semconv.events.DeviceScreenOrientationEvent
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -19,6 +19,8 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.jupiter.api.assertNotNull
+
+private const val EVENT_NAME = "device.screen_orientation"
 
 class ScreenOrientationDetectorTest {
     private lateinit var sut: ScreenOrientationDetector

--- a/instrumentation/thermal/src/main/java/io/opentelemetry/android/instrumentation/thermal/ThermalDetector.kt
+++ b/instrumentation/thermal/src/main/java/io/opentelemetry/android/instrumentation/thermal/ThermalDetector.kt
@@ -7,7 +7,7 @@ package io.opentelemetry.android.instrumentation.thermal
 
 import android.os.PowerManager
 import androidx.annotation.RequiresApi
-import io.opentelemetry.android.semconv.AndroidAttributes.ANDROID_THERMAL_THROTTLING_STATUS_KEY
+import io.opentelemetry.android.semconv.events.DeviceThermalStatusChangeEvent
 import io.opentelemetry.api.logs.Logger
 
 /**
@@ -25,16 +25,8 @@ import io.opentelemetry.api.logs.Logger
 internal class ThermalDetector(
     private val logger: Logger,
 ) : PowerManager.OnThermalStatusChangedListener {
-    internal companion object {
-        const val EVENT_NAME = "device.thermal_status.change"
-    }
-
     override fun onThermalStatusChanged(status: Int) {
-        logger
-            .logRecordBuilder()
-            .setEventName(EVENT_NAME)
-            .setAttribute(ANDROID_THERMAL_THROTTLING_STATUS_KEY, status.name)
-            .emit()
+        DeviceThermalStatusChangeEvent(androidThermalThrottlingStatus = status.name).emit(logger)
     }
 
     private val Int.name: String

--- a/instrumentation/thermal/src/test/java/io/opentelemetry/android/instrumentation/thermal/ThermalDetectorTest.kt
+++ b/instrumentation/thermal/src/test/java/io/opentelemetry/android/instrumentation/thermal/ThermalDetectorTest.kt
@@ -6,13 +6,14 @@
 package io.opentelemetry.android.instrumentation.thermal
 
 import android.os.PowerManager
-import io.opentelemetry.android.instrumentation.thermal.ThermalDetector.Companion.EVENT_NAME
 import io.opentelemetry.android.semconv.AndroidAttributes.ANDROID_THERMAL_THROTTLING_STATUS_KEY
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+
+private const val EVENT_NAME = "device.thermal_status.change"
 
 class ThermalDetectorTest {
     private lateinit var detector: ThermalDetector

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
@@ -11,14 +11,14 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.Window
 import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_CLICK_EVENT_NAME
-import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_FLING_EVENT_NAME
-import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_LONG_PRESS_EVENT_NAME
-import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_SCROLL_EVENT_NAME
 import io.opentelemetry.android.instrumentation.view.click.internal.Gesture
 import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_CLICK_EVENT_NAME
-import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_FLING_EVENT_NAME
-import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_LONG_PRESS_EVENT_NAME
-import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_SCROLL_EVENT_NAME
+import io.opentelemetry.android.semconv.events.AppScreenFlingEvent
+import io.opentelemetry.android.semconv.events.AppScreenLongpressEvent
+import io.opentelemetry.android.semconv.events.AppScreenScrollEvent
+import io.opentelemetry.android.semconv.events.AppWidgetFlingEvent
+import io.opentelemetry.android.semconv.events.AppWidgetLongpressEvent
+import io.opentelemetry.android.semconv.events.AppWidgetScrollEvent
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.LogRecordBuilder
 import io.opentelemetry.api.logs.Logger
@@ -86,15 +86,10 @@ internal class ViewClickEventGenerator(
 
                     val safeEvent = MotionEvent.obtain(e)
                     val gesture = Gesture.LongPress(safeEvent)
-                    createEvent(APP_SCREEN_LONG_PRESS_EVENT_NAME, gesture)
-                        .setAttribute(APP_SCREEN_COORDINATE_Y, safeEvent.y.toLong())
-                        .setAttribute(APP_SCREEN_COORDINATE_X, safeEvent.x.toLong())
-                        .emit()
+                    emitAppScreenLongPress(safeEvent, gesture)
 
                     findTargetForTap(window.decorView, safeEvent.x, safeEvent.y)?.let { view ->
-                        createEvent(VIEW_LONG_PRESS_EVENT_NAME, gesture)
-                            .setAllAttributes(createViewAttributes(view))
-                            .emit()
+                        emitAppWidgetLongPress(view, gesture)
                     }
                     safeEvent.recycle()
                 }
@@ -110,15 +105,10 @@ internal class ViewClickEventGenerator(
 
                     val safeEvent = MotionEvent.obtain(e2)
                     val gesture = Gesture.Scroll(safeEvent, distanceX.toDouble(), distanceY.toDouble())
-                    createEvent(APP_SCREEN_SCROLL_EVENT_NAME, gesture)
-                        .setAttribute(APP_SCREEN_COORDINATE_Y, safeEvent.y.toLong())
-                        .setAttribute(APP_SCREEN_COORDINATE_X, safeEvent.x.toLong())
-                        .emit()
+                    emitAppScreenScroll(safeEvent, gesture)
 
                     findTargetForTap(window.decorView, safeEvent.x, safeEvent.y)?.let { view ->
-                        createEvent(VIEW_SCROLL_EVENT_NAME, gesture)
-                            .setAllAttributes(createViewAttributes(view))
-                            .emit()
+                        emitAppWidgetScroll(view, gesture)
                     }
                     safeEvent.recycle()
                 }
@@ -135,15 +125,10 @@ internal class ViewClickEventGenerator(
 
                     val safeEvent = MotionEvent.obtain(e2)
                     val gesture = Gesture.Fling(safeEvent, velocityX.toDouble(), velocityY.toDouble())
-                    createEvent(APP_SCREEN_FLING_EVENT_NAME, gesture)
-                        .setAttribute(APP_SCREEN_COORDINATE_Y, safeEvent.y.toLong())
-                        .setAttribute(APP_SCREEN_COORDINATE_X, safeEvent.x.toLong())
-                        .emit()
+                    emitAppScreenFling(safeEvent, gesture)
 
                     findTargetForTap(window.decorView, safeEvent.x, safeEvent.y)?.let { view ->
-                        createEvent(VIEW_FLING_EVENT_NAME, gesture)
-                            .setAllAttributes(createViewAttributes(view))
-                            .emit()
+                        emitAppWidgetFling(view, gesture)
                     }
                     safeEvent.recycle()
                 }
@@ -187,6 +172,92 @@ internal class ViewClickEventGenerator(
                 .setAllAttributes(gesture.attributes)
 
         return logger
+    }
+
+    private fun emitAppScreenLongPress(
+        motionEvent: MotionEvent,
+        gesture: Gesture.LongPress,
+    ) {
+        AppScreenLongpressEvent(
+            appScreenCoordinateX = motionEvent.x.toLong(),
+            appScreenCoordinateY = motionEvent.y.toLong(),
+            hwPointerButton = gesture.buttonStateDescription,
+            hwPointerType = gesture.toolTypeDescription,
+        ).emit(eventLogger)
+    }
+
+    private fun emitAppWidgetLongPress(
+        view: View,
+        gesture: Gesture.LongPress,
+    ) {
+        AppWidgetLongpressEvent(
+            appScreenCoordinateX = view.x.toLong(),
+            appScreenCoordinateY = view.y.toLong(),
+            appWidgetId = view.id.toString(),
+            appWidgetName = viewToName(view),
+            hwPointerButton = gesture.buttonStateDescription,
+            hwPointerType = gesture.toolTypeDescription,
+        ).emit(eventLogger)
+    }
+
+    private fun emitAppScreenScroll(
+        motionEvent: MotionEvent,
+        gesture: Gesture.Scroll,
+    ) {
+        AppScreenScrollEvent(
+            appScreenCoordinateX = motionEvent.x.toLong(),
+            appScreenCoordinateY = motionEvent.y.toLong(),
+            hwPointerButton = gesture.buttonStateDescription,
+            hwPointerDistanceX = gesture.distanceX,
+            hwPointerDistanceY = gesture.distanceY,
+            hwPointerType = gesture.toolTypeDescription,
+        ).emit(eventLogger)
+    }
+
+    private fun emitAppWidgetScroll(
+        view: View,
+        gesture: Gesture.Scroll,
+    ) {
+        AppWidgetScrollEvent(
+            appScreenCoordinateX = view.x.toLong(),
+            appScreenCoordinateY = view.y.toLong(),
+            appWidgetId = view.id.toString(),
+            appWidgetName = viewToName(view),
+            hwPointerButton = gesture.buttonStateDescription,
+            hwPointerDistanceX = gesture.distanceX,
+            hwPointerDistanceY = gesture.distanceY,
+            hwPointerType = gesture.toolTypeDescription,
+        ).emit(eventLogger)
+    }
+
+    private fun emitAppScreenFling(
+        motionEvent: MotionEvent,
+        gesture: Gesture.Fling,
+    ) {
+        AppScreenFlingEvent(
+            appScreenCoordinateX = motionEvent.x.toLong(),
+            appScreenCoordinateY = motionEvent.y.toLong(),
+            hwPointerButton = gesture.buttonStateDescription,
+            hwPointerType = gesture.toolTypeDescription,
+            hwPointerVelocityX = gesture.velocityX,
+            hwPointerVelocityY = gesture.velocityY,
+        ).emit(eventLogger)
+    }
+
+    private fun emitAppWidgetFling(
+        view: View,
+        gesture: Gesture.Fling,
+    ) {
+        AppWidgetFlingEvent(
+            appScreenCoordinateX = view.x.toLong(),
+            appScreenCoordinateY = view.y.toLong(),
+            appWidgetId = view.id.toString(),
+            appWidgetName = viewToName(view),
+            hwPointerButton = gesture.buttonStateDescription,
+            hwPointerType = gesture.toolTypeDescription,
+            hwPointerVelocityX = gesture.velocityX,
+            hwPointerVelocityY = gesture.velocityY,
+        ).emit(eventLogger)
     }
 
     @OptIn(IncubatingApi::class)

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/internal/ViewUtils.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/internal/ViewUtils.kt
@@ -17,16 +17,6 @@ import io.opentelemetry.api.common.Attributes
 
 internal const val APP_SCREEN_CLICK_EVENT_NAME = "app.screen.click"
 internal const val VIEW_CLICK_EVENT_NAME = "app.widget.click"
-internal const val APP_SCREEN_LONG_PRESS_EVENT_NAME = "app.screen.longpress"
-internal const val VIEW_LONG_PRESS_EVENT_NAME = "app.widget.longpress"
-
-internal const val APP_SCREEN_SCROLL_EVENT_NAME = "app.screen.scroll"
-
-internal const val VIEW_SCROLL_EVENT_NAME = "app.widget.scroll"
-
-internal const val APP_SCREEN_FLING_EVENT_NAME = "app.screen.fling"
-
-internal const val VIEW_FLING_EVENT_NAME = "app.widget.fling"
 
 internal fun buttonStateToString(buttonStateInt: Int): String? =
     when (buttonStateInt) {
@@ -71,12 +61,14 @@ internal sealed class Gesture(
     val m: MotionEvent,
 ) {
     private val t = TapEventMetadata(m)
+    val buttonStateDescription: String? = t.buttonStateDescription
+    val toolTypeDescription: String = t.toolTypeDescription
     var attributes = Attributes.empty()
 
     init {
-        attributes = attributes.toBuilder().put(HW_POINTER_TYPE_KEY, t.toolTypeDescription).build()
-        if (t.buttonStateDescription != null) {
-            attributes = attributes.toBuilder().put(HW_POINTER_BUTTON_KEY, t.buttonStateDescription).build()
+        attributes = attributes.toBuilder().put(HW_POINTER_TYPE_KEY, toolTypeDescription).build()
+        if (buttonStateDescription != null) {
+            attributes = attributes.toBuilder().put(HW_POINTER_BUTTON_KEY, buttonStateDescription).build()
         }
     }
 

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewLongPressInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewLongPressInstrumentationTest.kt
@@ -22,8 +22,6 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import io.opentelemetry.android.OpenTelemetryRum
-import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_LONG_PRESS_EVENT_NAME
-import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_LONG_PRESS_EVENT_NAME
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_TYPE_KEY
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.common.AttributeKey.longKey
@@ -43,6 +41,9 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.runner.RunWith
+
+private const val APP_SCREEN_LONG_PRESS_EVENT_NAME = "app.screen.longpress"
+private const val VIEW_LONG_PRESS_EVENT_NAME = "app.widget.longpress"
 
 @OptIn(IncubatingApi::class)
 @RunWith(AndroidJUnit4::class)

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewScrollInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewScrollInstrumentationTest.kt
@@ -24,10 +24,6 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import io.opentelemetry.android.OpenTelemetryRum
-import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_FLING_EVENT_NAME
-import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_SCROLL_EVENT_NAME
-import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_FLING_EVENT_NAME
-import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_SCROLL_EVENT_NAME
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_DISTANCE_X_KEY
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_DISTANCE_Y_KEY
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_TYPE_KEY
@@ -50,6 +46,11 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.runner.RunWith
+
+private const val APP_SCREEN_FLING_EVENT_NAME = "app.screen.fling"
+private const val APP_SCREEN_SCROLL_EVENT_NAME = "app.screen.scroll"
+private const val VIEW_FLING_EVENT_NAME = "app.widget.fling"
+private const val VIEW_SCROLL_EVENT_NAME = "app.widget.scroll"
 
 @RunWith(AndroidJUnit4::class)
 @ExtendWith(MockKExtension::class)


### PR DESCRIPTION
Part of #1814.

The previous phase created event classes based on the semantic convention definitions, but those event classes were not yet used by production code. This now wires up the events to production code.

A couple caveats:

* the view click instrumentation still generates its own events (the old way), because those event definitions exist in upstream (not our local federation) and do not have event classes generated for them.
* the startup progress events still do their own event generation, because they need to override the timestamps, which is not something that the generated event classes allow/provide.
