### PR TITLE
Fix linting on recent clock changes

### DIFF
--- a/android-agent/src/test/kotlin/io/opentelemetry/android/OtelAndroidClockTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/OtelAndroidClockTest.kt
@@ -46,10 +46,11 @@ class OtelAndroidClockTest {
     fun `uses GNSS time when available on API 29+`() {
         every { SystemClock.currentGnssTimeClock() } returns gnssClock
 
-        val clock = OtelAndroidClock(
-            isGnssAnchorEnabled = true,
-            isNetworkAnchorEnabled = true,
-        )
+        val clock =
+            OtelAndroidClock(
+                isGnssAnchorEnabled = true,
+                isNetworkAnchorEnabled = true,
+            )
 
         assertThat(clock.now()).isEqualTo(gnssMillis * 1_000_000)
     }
@@ -60,10 +61,11 @@ class OtelAndroidClockTest {
         every { SystemClock.currentGnssTimeClock() } returns gnssClock
         every { SystemClock.currentNetworkTimeClock() } returns networkClock
 
-        val clock = OtelAndroidClock(
-            isGnssAnchorEnabled = true,
-            isNetworkAnchorEnabled = true,
-        )
+        val clock =
+            OtelAndroidClock(
+                isGnssAnchorEnabled = true,
+                isNetworkAnchorEnabled = true,
+            )
 
         assertThat(clock.now()).isEqualTo(gnssMillis * 1_000_000)
     }
@@ -74,10 +76,11 @@ class OtelAndroidClockTest {
         every { SystemClock.currentGnssTimeClock() } throws RuntimeException("no gnss")
         every { SystemClock.currentNetworkTimeClock() } returns networkClock
 
-        val clock = OtelAndroidClock(
-            isGnssAnchorEnabled = true,
-            isNetworkAnchorEnabled = true,
-        )
+        val clock =
+            OtelAndroidClock(
+                isGnssAnchorEnabled = true,
+                isNetworkAnchorEnabled = true,
+            )
 
         assertThat(clock.now()).isEqualTo(networkMillis * 1_000_000)
     }
@@ -87,10 +90,11 @@ class OtelAndroidClockTest {
     fun `falls back to system time when GNSS clock throws and network time is unavailable`() {
         every { SystemClock.currentGnssTimeClock() } throws RuntimeException("no gnss")
 
-        val clock = OtelAndroidClock(
-            isGnssAnchorEnabled = true,
-            isNetworkAnchorEnabled = true,
-        )
+        val clock =
+            OtelAndroidClock(
+                isGnssAnchorEnabled = true,
+                isNetworkAnchorEnabled = true,
+            )
 
         assertThat(clock.now() / 1_000_000).isCloseTo(System.currentTimeMillis(), within(5000L))
     }
@@ -101,10 +105,11 @@ class OtelAndroidClockTest {
         every { SystemClock.currentGnssTimeClock() } throws RuntimeException("no gnss")
         every { SystemClock.currentNetworkTimeClock() } throws RuntimeException("no network")
 
-        val clock = OtelAndroidClock(
-            isGnssAnchorEnabled = true,
-            isNetworkAnchorEnabled = true,
-        )
+        val clock =
+            OtelAndroidClock(
+                isGnssAnchorEnabled = true,
+                isNetworkAnchorEnabled = true,
+            )
 
         assertThat(clock.now() / 1_000_000).isCloseTo(System.currentTimeMillis(), within(5000L))
     }

--- a/core/src/main/java/io/opentelemetry/android/OtelAndroidClock.kt
+++ b/core/src/main/java/io/opentelemetry/android/OtelAndroidClock.kt
@@ -51,8 +51,8 @@ class OtelAndroidClock
                 try {
                     return currentGnssTimeMillis()
                 } catch (_: Exception) {
+                    // Ignore and fall back to the next available time source.
                 }
-            }
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && isNetworkAnchorEnabled) {
                 try {

--- a/core/src/main/java/io/opentelemetry/android/OtelAndroidClock.kt
+++ b/core/src/main/java/io/opentelemetry/android/OtelAndroidClock.kt
@@ -24,47 +24,49 @@ import io.opentelemetry.sdk.common.Clock
  * the clock doesn't consistently tick when the process is in the background or cached). It also
  * avoids the problem of [SystemClock.elapsedRealtimeNanos] not providing wall-clock time.
  */
-class OtelAndroidClock @JvmOverloads constructor(
-    /**
-     * Whether the [OtelAndroidClock] should attempt to anchor its monotonic time against
-     * [SystemClock.currentGnssTimeClock] on startup (when available). Setting to `true` does
-     * not guarantee a GNSS anchor.
-     */
-    private val isGnssAnchorEnabled: Boolean = false,
-    /**
-     * Whether the [OtelAndroidClock] should attempt to anchor its monotonic time against
-     * [SystemClock.currentNetworkTimeClock] on startup (when available). Setting to `true` does
-     * not guarantee a network time anchor.
-     */
-    private val isNetworkAnchorEnabled: Boolean = false,
-) : Clock {
-    private val baselineNanos = currentTimeMillis() * 1_000_000 - nanoTime()
+class OtelAndroidClock
+    @JvmOverloads
+    constructor(
+        /**
+         * Whether the [OtelAndroidClock] should attempt to anchor its monotonic time against
+         * [SystemClock.currentGnssTimeClock] on startup (when available). Setting to `true` does
+         * not guarantee a GNSS anchor.
+         */
+        private val isGnssAnchorEnabled: Boolean = false,
+        /**
+         * Whether the [OtelAndroidClock] should attempt to anchor its monotonic time against
+         * [SystemClock.currentNetworkTimeClock] on startup (when available). Setting to `true` does
+         * not guarantee a network time anchor.
+         */
+        private val isNetworkAnchorEnabled: Boolean = false,
+    ) : Clock {
+        private val baselineNanos = currentTimeMillis() * 1_000_000 - nanoTime()
 
-    override fun now(): Long = baselineNanos + nanoTime()
+        override fun now(): Long = baselineNanos + nanoTime()
 
-    override fun nanoTime(): Long = SystemClock.elapsedRealtimeNanos()
+        override fun nanoTime(): Long = SystemClock.elapsedRealtimeNanos()
 
-    private fun currentTimeMillis(): Long {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && isGnssAnchorEnabled) {
-            try {
-                return currentGnssTimeMillis()
-            } catch (_: Exception) {
+        private fun currentTimeMillis(): Long {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && isGnssAnchorEnabled) {
+                try {
+                    return currentGnssTimeMillis()
+                } catch (_: Exception) {
+                }
             }
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && isNetworkAnchorEnabled) {
+                try {
+                    return currentNetworkTimeMillis()
+                } catch (_: Exception) {
+                }
+            }
+
+            return System.currentTimeMillis()
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && isNetworkAnchorEnabled) {
-            try {
-                return currentNetworkTimeMillis()
-            } catch (_: Exception) {
-            }
-        }
+        @RequiresApi(api = Build.VERSION_CODES.Q)
+        private fun currentGnssTimeMillis(): Long = SystemClock.currentGnssTimeClock().millis()
 
-        return System.currentTimeMillis()
+        @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
+        private fun currentNetworkTimeMillis(): Long = SystemClock.currentNetworkTimeClock().millis()
     }
-
-    @RequiresApi(api = Build.VERSION_CODES.Q)
-    private fun currentGnssTimeMillis(): Long = SystemClock.currentGnssTimeClock().millis()
-
-    @RequiresApi(api = Build.VERSION_CODES.TIRAMISU)
-    private fun currentNetworkTimeMillis(): Long = SystemClock.currentNetworkTimeClock().millis()
-}

--- a/core/src/main/java/io/opentelemetry/android/OtelAndroidClock.kt
+++ b/core/src/main/java/io/opentelemetry/android/OtelAndroidClock.kt
@@ -53,11 +53,13 @@ class OtelAndroidClock
                 } catch (_: Exception) {
                     // Ignore and fall back to the next available time source.
                 }
+            }
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && isNetworkAnchorEnabled) {
                 try {
                     return currentNetworkTimeMillis()
                 } catch (_: Exception) {
+                    // Ignore and fall back to System.currentTimeMillis().
                 }
             }
 


### PR DESCRIPTION
The [main build is currently broken](https://github.com/open-telemetry/opentelemetry-android/actions/runs/29107152552). 

<img width="186" height="126" alt="image" src="https://github.com/user-attachments/assets/5a19f7c5-1c00-46e5-9538-cf72d710a844" />

This fixes that.

#1880 contained a couple of linting problems that apparently didn't fail the PR build. I believe that this is due to this setting https://github.com/open-telemetry/opentelemetry-android/blob/main/.github/repository-settings.md#main, which doesn't require the branch to be "up to date" before merging. We might want to reconsider that setting.