### PR TITLE
Generate source code for app.jank event appropriate to use in this project

### DIFF
--- a/instrumentation/slowrendering/build.gradle.kts
+++ b/instrumentation/slowrendering/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(project(":session"))
     implementation(project(":common"))
     implementation(project(":agent-api"))
+    implementation(project(":semconv"))
     implementation(libs.androidx.core)
     implementation(libs.opentelemetry.semconv.kotlin)
     implementation(libs.opentelemetry.sdk)

--- a/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/EventJankReporter.kt
+++ b/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/EventJankReporter.kt
@@ -7,11 +7,8 @@ package io.opentelemetry.android.instrumentation.slowrendering
 
 import android.util.Log
 import io.opentelemetry.android.common.RumConstants
-import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.android.semconv.events.AppJankEvent
 import io.opentelemetry.api.logs.Logger
-import io.opentelemetry.kotlin.semconv.AppAttributes.APP_JANK_FRAME_COUNT
-import io.opentelemetry.kotlin.semconv.AppAttributes.APP_JANK_PERIOD
-import io.opentelemetry.kotlin.semconv.AppAttributes.APP_JANK_THRESHOLD
 import io.opentelemetry.kotlin.semconv.IncubatingApi
 
 internal class EventJankReporter(
@@ -41,18 +38,13 @@ internal class EventJankReporter(
         }
 
         if (frameCount > 0) {
-            val eventBuilder = eventLogger.logRecordBuilder()
-            val attributes =
-                Attributes
-                    .builder()
-                    .put(APP_JANK_FRAME_COUNT, frameCount)
-                    .put(APP_JANK_PERIOD, periodSeconds)
-                    .put(APP_JANK_THRESHOLD, threshold)
-                    .build()
-            eventBuilder
-                .setEventName("app.jank")
-                .setAllAttributes(attributes)
-                .emit()
+            AppJankEvent(
+                appJankFrameCount = frameCount,
+                appJankPeriod = periodSeconds,
+                appJankThreshold = threshold,
+            ).emit(
+                logger = eventLogger,
+            )
         }
     }
 }

--- a/semconv/model/android/registry.yaml
+++ b/semconv/model/android/registry.yaml
@@ -1,3 +1,8 @@
+# Imports events defined in dependency registries, by event name, so event classes are
+# generated for them in this module.
+imports:
+  events:
+    - app.jank
 groups:
   - id: registry.android.semconv
     type: attribute_group


### PR DESCRIPTION
Generate the class for the `app.jank` event so that it uses the Java `Logger` interface instead. This demonstrates how we can directly import them to get these specific events into the combined manifest for this registry. We can import these differently if we want, but I feel like we should do that after the federated repo setup has been established.