### PR TITLE
chore: Docker image housekeeping

### DIFF
--- a/demo-app/compose.yaml
+++ b/demo-app/compose.yaml
@@ -10,8 +10,5 @@ services:
       - "4318:4318" # OTLP HTTP
   jaeger:
     image: "jaegertracing/jaeger:2.19.0@sha256:ede4864215be4cd85bd8c3129a2fea6c5713c5653c7282c429dba123014bc68b"
-    environment:
-      - COLLECTOR_OTLP_ENABLED=true
-      - COLLECTOR_OTLP_HTTP_HOST_PORT=0.0.0.0:4318
     ports:
       - "16686:16686" # UI

--- a/demo-app/compose.yaml
+++ b/demo-app/compose.yaml
@@ -1,6 +1,6 @@
 services:
   collector:
-    image: "otel/opentelemetry-collector-contrib@sha256:125bdbeb7590cc1952c5b3430ecf14063568980c2c93d5b38676cc0446ed8108"
+    image: "otel/opentelemetry-collector-contrib:0.156.0@sha256:125bdbeb7590cc1952c5b3430ecf14063568980c2c93d5b38676cc0446ed8108"
     volumes:
       - ./collector.yaml:/etc/demo-collector.yaml
     entrypoint: ["/otelcol-contrib"]
@@ -9,7 +9,7 @@ services:
       - "4317:4317" # OTLP gRPC
       - "4318:4318" # OTLP HTTP
   jaeger:
-    image: "jaegertracing/all-in-one@sha256:ab6f1a1f0fb49ea08bcd19f6b84f6081d0d44b364b6de148e1798eb5816bacac"
+    image: "jaegertracing/jaeger:2.19.0@sha256:ede4864215be4cd85bd8c3129a2fea6c5713c5653c7282c429dba123014bc68b"
     environment:
       - COLLECTOR_OTLP_ENABLED=true
       - COLLECTOR_OTLP_HTTP_HOST_PORT=0.0.0.0:4318


### PR DESCRIPTION
Explicitly pin docker version to improve info/context available to renovate.

The jaegar tracing image has been switched as existing image is eol https://github.com/jaegertracing/jaeger/issues/6321