### PR TITLE
okhttp has migrated to a new owner

### DIFF
--- a/instrumentation/okhttp3-websocket/README.md
+++ b/instrumentation/okhttp3-websocket/README.md
@@ -6,7 +6,7 @@ The OpenTelemetry OkHttp WebSocket instrumentation for Android instruments
 client-side OkHttp WebSocket usage. It creates telemetry for websocket lifecycle
 events and can capture metadata about connections and messages.
 
-Provides OpenTelemetry instrumentation for [okhttp3 websockets](https://square.github.io/okhttp/3.x/okhttp/okhttp3/WebSocket.html).
+Provides OpenTelemetry instrumentation for [okhttp3 websockets](https://lysine.dev/okhttp/3.x/okhttp/okhttp3/WebSocket.html).
 
 ## Telemetry
 

--- a/instrumentation/okhttp3/README.md
+++ b/instrumentation/okhttp3/README.md
@@ -3,7 +3,7 @@
 Status: development
 
 The OpenTelemetry OkHttp instrumentation for Android instruments client-side requests
-made via OkHttp (version 3.0 +) [okhttp3](https://square.github.io/okhttp/). It adds distributed tracing context,
+made via OkHttp (version 3.0 +) [okhttp3](https://lysine.dev/okhttp/). It adds distributed tracing context,
 creates client HTTP spans, and records request/response metadata.
 
 ## Telemetry


### PR DESCRIPTION
okhttp is [now part of commonhaus](https://www.commonhaus.org/activity/315.html), and so the github repos and website have merged.

This fixes many ongoing lychee failures in our builds.