### PR TITLE
Turn gradle tooling parallel on

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,3 +26,6 @@ android.minCompileSdk=34
 android.compileSdk=37
 version=1.6.0
 group=io.opentelemetry.android
+
+# Enabled parallel sync for Gradle 9.4+
+org.gradle.tooling.parallel=true


### PR DESCRIPTION
I don't see any downside to turning this on for developers. The "tooling" parallelism is used to improve gradle sync performance without turning on full build parallelism, which I guess can break some builds.

https://docs.gradle.org/current/userguide/performance.html#sec:configure_tooling_api_actions_parallelism

