### PR TITLE
restore codeql now that kotlin 2.4.0 is supported

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
         run: touch demo-app/local.properties
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/init@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
         with:
           languages: java, actions
           # using "linked" helps to keep up with the latest Kotlin support
@@ -53,7 +53,7 @@ jobs:
         run: ./gradlew assemble --no-build-cache --no-daemon --stacktrace
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        uses: github/codeql-action/analyze@e0647621c2984b5ed2f768cb892365bf2a616ad1 # v4.37.2
 
       - name: Enable KVM for Android tests
         run: |


### PR DESCRIPTION
Kotlin 2.4.0 is supported again, so we can start using CodeQL.
