### PR TITLE
Coroutines context propagation instrumentation

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,6 +75,7 @@ opentelemetry-proto = { module = "io.opentelemetry.proto:opentelemetry-proto", v
 protobuf-kotlin = { module = "com.google.protobuf:protobuf-kotlin", version.ref = "protobufKotlin" }
 kotlinx-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.11.0" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version = "1.11.0" }
+opentelemetry-extension-kotlin = { module = "io.opentelemetry:opentelemetry-extension-kotlin" }
 
 #Compilation tools
 desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.1.5"

--- a/instrumentation/coroutines/README.md
+++ b/instrumentation/coroutines/README.md
@@ -1,0 +1,48 @@
+# coroutines
+
+Status: development
+
+Automatically propagates the current OpenTelemetry `Context` into Kotlin coroutines started with
+`CoroutineScope.launch`. It does **not** create coroutine spans or emit any other telemetry.
+
+## Supported API
+
+- `CoroutineScope.launch` (both the default-parameter form and the explicit form)
+
+## Transformation scope
+
+Only classes local to the module that applies the ByteBuddy plugin are transformed. External
+library and dependency classes are left unchanged.
+
+## Explicit exclusions
+
+The following are out of scope for this instrumentation:
+
+- External dependencies and sibling library modules consumed as dependencies
+- `async`, `withContext`, `runBlocking`, Flow, and all other coroutine builders
+
+## Setup
+
+Add the ByteBuddy Gradle plugin to your application module:
+
+```kotlin
+plugins {
+    id("net.bytebuddy.byte-buddy-gradle-plugin")
+}
+
+dependencies {
+    implementation("io.opentelemetry.android.instrumentation:coroutines-library:<version>")
+    byteBuddy("io.opentelemetry.android.instrumentation:coroutines-agent:<version>")
+}
+```
+
+## Context precedence
+
+If `CoroutineScope.launch` is called with an explicit, non-root OpenTelemetry coroutine context
+element already in the supplied `CoroutineContext`, that user-supplied context takes precedence and
+automatic capture is skipped.
+
+## Suppression
+
+This instrumentation can be suppressed by its stable name `"coroutines"` using the standard
+OpenTelemetry Android suppression mechanism.

--- a/instrumentation/coroutines/README.md
+++ b/instrumentation/coroutines/README.md
@@ -74,6 +74,10 @@ If `CoroutineScope.launch` is called with an explicit, non-root OpenTelemetry co
 element already in the supplied `CoroutineContext`, that user-supplied context takes precedence and
 automatic capture is skipped.
 
+Propagation is one-directional: context flows from the calling thread into the coroutine at launch
+time. Work dispatched from within a coroutine to a plain Java `Executor` or thread starts with a
+fresh context, as it would without this instrumentation.
+
 ## Suppression
 
 This instrumentation can be suppressed by its stable name `"coroutines"` using the standard

--- a/instrumentation/coroutines/README.md
+++ b/instrumentation/coroutines/README.md
@@ -5,6 +5,38 @@ Status: development
 Automatically propagates the current OpenTelemetry `Context` into Kotlin coroutines started with
 `CoroutineScope.launch`. It does **not** create coroutine spans or emit any other telemetry.
 
+## What this does in practice
+
+Given:
+
+```kotlin
+val span = tracer.spanBuilder("work").startSpan()
+span.makeCurrent().use {
+    scope.launch {
+        val inner = tracer.spanBuilder("coroutine-work").startSpan()
+        // ...
+        inner.end()
+    }
+}
+span.end()
+```
+
+**Without** this instrumentation, `coroutine-work` does not inherit the active context and is recorded
+as a separate root span:
+
+```
+work
+coroutine-work
+```
+
+**With** this instrumentation, the active context is carried into the coroutine automatically, and
+`coroutine-work` is recorded as a child of `work`:
+
+```
+work
+└── coroutine-work
+```
+
 ## Supported API
 
 - `CoroutineScope.launch` (both the default-parameter form and the explicit form)

--- a/instrumentation/coroutines/README.md
+++ b/instrumentation/coroutines/README.md
@@ -1,4 +1,4 @@
-# coroutines
+# Kotlin coroutines
 
 Status: development
 
@@ -21,7 +21,7 @@ The following are out of scope for this instrumentation:
 - External dependencies and sibling library modules consumed as dependencies
 - `async`, `withContext`, `runBlocking`, Flow, and all other coroutine builders
 
-## Setup
+## Installation
 
 Add the ByteBuddy Gradle plugin to your application module:
 

--- a/instrumentation/coroutines/agent/build.gradle.kts
+++ b/instrumentation/coroutines/agent/build.gradle.kts
@@ -1,0 +1,20 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+plugins {
+    id("otel.android-library-conventions")
+    id("otel.publish-conventions")
+}
+
+description = "OpenTelemetry Android coroutines context propagation agent"
+
+android {
+    namespace = "io.opentelemetry.android.instrumentation.coroutines"
+}
+
+dependencies {
+    implementation(project(":instrumentation:coroutines:library"))
+    implementation(libs.byteBuddy)
+}

--- a/instrumentation/coroutines/agent/src/main/kotlin/io/opentelemetry/instrumentation/agent/coroutines/CoroutinesPlugin.kt
+++ b/instrumentation/coroutines/agent/src/main/kotlin/io/opentelemetry/instrumentation/agent/coroutines/CoroutinesPlugin.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.agent.coroutines
+
+import io.opentelemetry.instrumentation.library.coroutines.internal.CoroutinesLaunchBridge
+import net.bytebuddy.asm.MemberSubstitution
+import net.bytebuddy.build.AndroidDescriptor
+import net.bytebuddy.build.Plugin
+import net.bytebuddy.description.method.MethodDescription
+import net.bytebuddy.description.type.TypeDescription
+import net.bytebuddy.dynamic.ClassFileLocator
+import net.bytebuddy.dynamic.DynamicType
+import net.bytebuddy.matcher.ElementMatchers
+
+internal class CoroutinesPlugin(
+    private val androidDescriptor: AndroidDescriptor,
+) : Plugin {
+    override fun matches(target: TypeDescription): Boolean = androidDescriptor.getTypeScope(target) == AndroidDescriptor.TypeScope.LOCAL
+
+    override fun apply(
+        builder: DynamicType.Builder<*>,
+        typeDescription: TypeDescription,
+        classFileLocator: ClassFileLocator,
+    ): DynamicType.Builder<*> =
+        builder.visit(
+            MemberSubstitution
+                .relaxed()
+                .method(
+                    ElementMatchers
+                        .named<MethodDescription>("launch")
+                        .and(ElementMatchers.isDeclaredBy(ElementMatchers.named("kotlinx.coroutines.BuildersKt"))),
+                ).replaceWith(BRIDGE_LAUNCH)
+                .method(
+                    ElementMatchers
+                        .named<MethodDescription>("launch\$default")
+                        .and(ElementMatchers.isDeclaredBy(ElementMatchers.named("kotlinx.coroutines.BuildersKt"))),
+                ).replaceWith(BRIDGE_LAUNCH_DEFAULT)
+                .on(ElementMatchers.any()),
+        )
+
+    override fun close() {}
+
+    private companion object {
+        private val BRIDGE_TYPE = TypeDescription.ForLoadedType.of(CoroutinesLaunchBridge::class.java)
+        private val BRIDGE_LAUNCH: MethodDescription =
+            BRIDGE_TYPE.declaredMethods
+                .filter(
+                    ElementMatchers
+                        .named<MethodDescription>("launch")
+                        .and(ElementMatchers.isStatic())
+                        .and(ElementMatchers.takesArguments(4)),
+                ).getOnly()
+        private val BRIDGE_LAUNCH_DEFAULT: MethodDescription =
+            BRIDGE_TYPE.declaredMethods
+                .filter(
+                    ElementMatchers
+                        .named<MethodDescription>("launch\$default")
+                        .and(ElementMatchers.isStatic()),
+                ).getOnly()
+    }
+}

--- a/instrumentation/coroutines/agent/src/main/resources/META-INF/net.bytebuddy/build.plugins
+++ b/instrumentation/coroutines/agent/src/main/resources/META-INF/net.bytebuddy/build.plugins
@@ -1,0 +1,1 @@
+io.opentelemetry.instrumentation.agent.coroutines.CoroutinesPlugin

--- a/instrumentation/coroutines/agent/src/test/kotlin/io/opentelemetry/instrumentation/agent/coroutines/CoroutinesPluginTest.kt
+++ b/instrumentation/coroutines/agent/src/test/kotlin/io/opentelemetry/instrumentation/agent/coroutines/CoroutinesPluginTest.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.agent.coroutines
+
+import net.bytebuddy.build.AndroidDescriptor
+import net.bytebuddy.description.type.TypeDescription
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class CoroutinesPluginTest {
+    private val sampleType: TypeDescription = TypeDescription.ForLoadedType.of(Any::class.java)
+
+    @Test
+    fun `LOCAL scope matches`() {
+        val plugin = CoroutinesPlugin(AndroidDescriptor.Trivial.LOCAL)
+        assertThat(plugin.matches(sampleType)).isTrue()
+    }
+
+    @Test
+    fun `EXTERNAL scope does not match`() {
+        val plugin = CoroutinesPlugin(AndroidDescriptor.Trivial.EXTERNAL)
+        assertThat(plugin.matches(sampleType)).isFalse()
+    }
+}

--- a/instrumentation/coroutines/library/api/library.api
+++ b/instrumentation/coroutines/library/api/library.api
@@ -1,0 +1,19 @@
+public final class io/opentelemetry/instrumentation/library/coroutines/CoroutinesInstrumentation : io/opentelemetry/android/instrumentation/AndroidInstrumentation {
+	public fun <init> ()V
+	public fun getName ()Ljava/lang/String;
+	public fun install (Landroid/content/Context;Lio/opentelemetry/android/OpenTelemetryRum;)V
+	public fun uninstall (Landroid/content/Context;Lio/opentelemetry/android/OpenTelemetryRum;)V
+}
+
+public final class io/opentelemetry/instrumentation/library/coroutines/internal/CoroutinesContextHelper {
+	public static final field INSTANCE Lio/opentelemetry/instrumentation/library/coroutines/internal/CoroutinesContextHelper;
+	public static final fun addCurrentContextIfNeeded (Lkotlin/coroutines/CoroutineContext;)Lkotlin/coroutines/CoroutineContext;
+	public static final fun setEnabled (Z)V
+}
+
+public final class io/opentelemetry/instrumentation/library/coroutines/internal/CoroutinesLaunchBridge {
+	public static final field INSTANCE Lio/opentelemetry/instrumentation/library/coroutines/internal/CoroutinesLaunchBridge;
+	public static final fun launch (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Lkotlinx/coroutines/CoroutineStart;Lkotlin/jvm/functions/Function2;)Lkotlinx/coroutines/Job;
+	public static final fun launch$default (Lkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/CoroutineContext;Lkotlinx/coroutines/CoroutineStart;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lkotlinx/coroutines/Job;
+}
+

--- a/instrumentation/coroutines/library/build.gradle.kts
+++ b/instrumentation/coroutines/library/build.gradle.kts
@@ -1,0 +1,23 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+plugins {
+    id("otel.android-library-conventions")
+    id("otel.publish-conventions")
+}
+
+description = "OpenTelemetry Android coroutines context propagation library"
+
+android {
+    namespace = "io.opentelemetry.android.coroutines.library"
+}
+
+dependencies {
+    api(platform(libs.opentelemetry.platform.alpha))
+    implementation(project(":instrumentation:android-instrumentation"))
+    implementation(libs.opentelemetry.extension.kotlin)
+    compileOnly(libs.kotlinx.coroutines)
+    testImplementation(libs.kotlinx.coroutines)
+}

--- a/instrumentation/coroutines/library/src/main/kotlin/io/opentelemetry/instrumentation/library/coroutines/CoroutinesInstrumentation.kt
+++ b/instrumentation/coroutines/library/src/main/kotlin/io/opentelemetry/instrumentation/library/coroutines/CoroutinesInstrumentation.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.library.coroutines
+
+import android.content.Context
+import com.google.auto.service.AutoService
+import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.instrumentation.AndroidInstrumentation
+import io.opentelemetry.instrumentation.library.coroutines.internal.CoroutinesContextHelper
+
+@AutoService(AndroidInstrumentation::class)
+class CoroutinesInstrumentation : AndroidInstrumentation {
+    override val name: String = "coroutines"
+
+    override fun install(
+        context: Context,
+        openTelemetryRum: OpenTelemetryRum,
+    ) {
+        CoroutinesContextHelper.setEnabled(true)
+    }
+
+    override fun uninstall(
+        context: Context,
+        openTelemetryRum: OpenTelemetryRum,
+    ) {
+        CoroutinesContextHelper.setEnabled(false)
+    }
+}

--- a/instrumentation/coroutines/library/src/main/kotlin/io/opentelemetry/instrumentation/library/coroutines/internal/CoroutinesContextHelper.kt
+++ b/instrumentation/coroutines/library/src/main/kotlin/io/opentelemetry/instrumentation/library/coroutines/internal/CoroutinesContextHelper.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.library.coroutines.internal
+
+import io.opentelemetry.context.Context
+import io.opentelemetry.extension.kotlin.asContextElement
+import io.opentelemetry.extension.kotlin.getOpenTelemetryContext
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Decides whether the current OpenTelemetry [Context] should be added to an about-to-launch
+ * coroutine. Not intended as public API; public JVM visibility is required so that the runtime
+ * instrumentation in the parent package can configure it.
+ */
+object CoroutinesContextHelper {
+    @Volatile
+    private var enabled = false
+
+    @JvmStatic
+    fun setEnabled(value: Boolean) {
+        enabled = value
+    }
+
+    /**
+     * Returns the supplied [coroutineContext] enriched with the current OpenTelemetry context
+     * when all of the following are true:
+     *
+     * - Runtime instrumentation is enabled.
+     * - The current OpenTelemetry context is not root.
+     * - The coroutine context does not already carry a non-root OpenTelemetry context (user
+     *   supplied context takes precedence).
+     */
+    @JvmStatic
+    fun addCurrentContextIfNeeded(coroutineContext: CoroutineContext): CoroutineContext {
+        if (!enabled) {
+            return coroutineContext
+        }
+
+        val current = Context.current()
+        if (current === Context.root()) {
+            return coroutineContext
+        }
+
+        val existing = coroutineContext.getOpenTelemetryContext()
+        if (existing !== Context.root()) {
+            return coroutineContext
+        }
+
+        return coroutineContext + current.asContextElement()
+    }
+}

--- a/instrumentation/coroutines/library/src/main/kotlin/io/opentelemetry/instrumentation/library/coroutines/internal/CoroutinesLaunchBridge.kt
+++ b/instrumentation/coroutines/library/src/main/kotlin/io/opentelemetry/instrumentation/library/coroutines/internal/CoroutinesLaunchBridge.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.library.coroutines.internal
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.jvm.functions.Function2
+
+/**
+ * Intercepts `kotlinx.coroutines.BuildersKt.launch` and `BuildersKt.launch$default` calls that
+ * the ByteBuddy agent plugin rewrites in application classes.
+ *
+ * These methods must be public JVM methods with descriptors identical to the originals because the
+ * plugin changes only the call owner in the rewritten bytecode.
+ */
+object CoroutinesLaunchBridge {
+    @JvmStatic
+    @Suppress("UNCHECKED_CAST")
+    fun launch(
+        scope: CoroutineScope,
+        context: CoroutineContext,
+        start: CoroutineStart,
+        block: Function2<*, *, *>,
+    ): Job {
+        val enriched = CoroutinesContextHelper.addCurrentContextIfNeeded(context)
+        return scope.launch(enriched, start, block as (suspend CoroutineScope.() -> Unit))
+    }
+
+    @JvmStatic
+    @JvmName("launch\$default")
+    @Suppress("UNCHECKED_CAST", "UNUSED_PARAMETER")
+    fun launchWithDefaults(
+        scope: CoroutineScope,
+        context: CoroutineContext?,
+        start: CoroutineStart?,
+        block: Function2<*, *, *>,
+        mask: Int,
+        handler: Any?,
+    ): Job {
+        val actualContext =
+            if (mask and 0x1 != 0) {
+                // The context param has been omitted
+                EmptyCoroutineContext
+            } else {
+                context ?: EmptyCoroutineContext
+            }
+
+        val actualStart =
+            if (mask and 0x2 != 0) {
+                // The start param has been omitted
+                CoroutineStart.DEFAULT
+            } else {
+                start ?: CoroutineStart.DEFAULT
+            }
+
+        val enriched = CoroutinesContextHelper.addCurrentContextIfNeeded(actualContext)
+        return scope.launch(enriched, actualStart, block as (suspend CoroutineScope.() -> Unit))
+    }
+}

--- a/instrumentation/coroutines/library/src/test/kotlin/io/opentelemetry/instrumentation/library/coroutines/CoroutinesContextHelperTest.kt
+++ b/instrumentation/coroutines/library/src/test/kotlin/io/opentelemetry/instrumentation/library/coroutines/CoroutinesContextHelperTest.kt
@@ -1,0 +1,170 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.library.coroutines
+
+import io.mockk.mockk
+import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.context.Context
+import io.opentelemetry.extension.kotlin.asContextElement
+import io.opentelemetry.extension.kotlin.getOpenTelemetryContext
+import io.opentelemetry.instrumentation.library.coroutines.internal.CoroutinesContextHelper
+import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import kotlin.coroutines.EmptyCoroutineContext
+import android.content.Context as AndroidContext
+
+class CoroutinesContextHelperTest {
+    companion object {
+        @RegisterExtension
+        @JvmField
+        val otelExtension: OpenTelemetryExtension = OpenTelemetryExtension.create()
+    }
+
+    @BeforeEach
+    fun enable() {
+        CoroutinesContextHelper.setEnabled(true)
+    }
+
+    @AfterEach
+    fun disable() {
+        CoroutinesContextHelper.setEnabled(false)
+    }
+
+    @Test
+    fun `disabled instrumentation returns original coroutine context`() {
+        CoroutinesContextHelper.setEnabled(false)
+        val span =
+            otelExtension.openTelemetry
+                .getTracer("test")
+                .spanBuilder("s")
+                .startSpan()
+        span.makeCurrent().use {
+            val result = CoroutinesContextHelper.addCurrentContextIfNeeded(EmptyCoroutineContext)
+            assertThat(result).isSameAs(EmptyCoroutineContext)
+        }
+        span.end()
+    }
+
+    @Test
+    fun `root current context does not add element`() {
+        val result = CoroutinesContextHelper.addCurrentContextIfNeeded(EmptyCoroutineContext)
+        assertThat(result).isSameAs(EmptyCoroutineContext)
+    }
+
+    @Test
+    fun `non-root current context is added`() {
+        val span =
+            otelExtension.openTelemetry
+                .getTracer("test")
+                .spanBuilder("s")
+                .startSpan()
+        span.makeCurrent().use {
+            val result = CoroutinesContextHelper.addCurrentContextIfNeeded(EmptyCoroutineContext)
+            assertThat(result).isNotSameAs(EmptyCoroutineContext)
+            val otelCtx = result.getOpenTelemetryContext()
+            assertThat(otelCtx).isNotEqualTo(Context.root())
+        }
+        span.end()
+    }
+
+    @Test
+    fun `existing non-root OTel coroutine context is preserved`() {
+        val span1 =
+            otelExtension.openTelemetry
+                .getTracer("test")
+                .spanBuilder("s1")
+                .startSpan()
+        val existingElement = span1.makeCurrent().use { Context.current().asContextElement() }
+
+        val span2 =
+            otelExtension.openTelemetry
+                .getTracer("test")
+                .spanBuilder("s2")
+                .startSpan()
+        span2.makeCurrent().use {
+            val result = CoroutinesContextHelper.addCurrentContextIfNeeded(existingElement)
+            assertThat(result).isSameAs(existingElement)
+        }
+        span1.end()
+        span2.end()
+    }
+
+    @Test
+    fun `already-present current context is not duplicated`() {
+        val span =
+            otelExtension.openTelemetry
+                .getTracer("test")
+                .spanBuilder("s")
+                .startSpan()
+        span.makeCurrent().use {
+            val element = Context.current().asContextElement()
+            val result = CoroutinesContextHelper.addCurrentContextIfNeeded(element)
+            assertThat(result).isSameAs(element)
+        }
+        span.end()
+    }
+
+    @Test
+    fun `install enables and uninstall disables context injection`() {
+        val instrumentation = CoroutinesInstrumentation()
+        val androidContext = mockk<AndroidContext>()
+        val openTelemetryRum = mockk<OpenTelemetryRum>()
+        val span =
+            otelExtension.openTelemetry
+                .getTracer("test")
+                .spanBuilder("s")
+                .startSpan()
+        span.makeCurrent().use {
+            instrumentation.uninstall(androidContext, openTelemetryRum)
+            val resultDisabled = CoroutinesContextHelper.addCurrentContextIfNeeded(EmptyCoroutineContext)
+            assertThat(resultDisabled).isSameAs(EmptyCoroutineContext)
+
+            instrumentation.install(androidContext, openTelemetryRum)
+            val resultEnabled = CoroutinesContextHelper.addCurrentContextIfNeeded(EmptyCoroutineContext)
+            assertThat(resultEnabled).isNotSameAs(EmptyCoroutineContext)
+
+            instrumentation.uninstall(androidContext, openTelemetryRum)
+            val resultUninstalled = CoroutinesContextHelper.addCurrentContextIfNeeded(EmptyCoroutineContext)
+            assertThat(resultUninstalled).isSameAs(EmptyCoroutineContext)
+        }
+        span.end()
+    }
+
+    @Test
+    fun `context does not leak to caller thread after coroutine completes`() {
+        val span =
+            otelExtension.openTelemetry
+                .getTracer("test")
+                .spanBuilder("s")
+                .startSpan()
+        var contextInsideCoroutine: Context? = null
+
+        runBlocking {
+            span.makeCurrent().use {
+                val enriched = CoroutinesContextHelper.addCurrentContextIfNeeded(EmptyCoroutineContext)
+                val job =
+                    launch(enriched + Dispatchers.Default) {
+                        delay(10)
+                        contextInsideCoroutine = Context.current()
+                    }
+                job.join()
+            }
+            assertThat(Context.current()).isEqualTo(Context.root())
+        }
+
+        assertThat(contextInsideCoroutine).isNotNull()
+        assertThat(contextInsideCoroutine).isNotEqualTo(Context.root())
+        span.end()
+    }
+}

--- a/instrumentation/coroutines/testing/build.gradle.kts
+++ b/instrumentation/coroutines/testing/build.gradle.kts
@@ -1,0 +1,22 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+plugins {
+    id("otel.android-app-conventions")
+    id("net.bytebuddy.byte-buddy-gradle-plugin")
+}
+
+android {
+    namespace = "io.opentelemetry.android.coroutines.test"
+}
+
+dependencies {
+    byteBuddy(project(":instrumentation:coroutines:agent"))
+    implementation(project(":instrumentation:coroutines:library"))
+    implementation(project(":test-common"))
+    implementation(libs.kotlinx.coroutines)
+
+    androidTestImplementation(libs.assertj.core)
+}

--- a/instrumentation/coroutines/testing/src/androidTest/kotlin/io/opentelemetry/instrumentation/library/coroutines/testing/InstrumentationTest.kt
+++ b/instrumentation/coroutines/testing/src/androidTest/kotlin/io/opentelemetry/instrumentation/library/coroutines/testing/InstrumentationTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.library.coroutines.testing
+
+import io.opentelemetry.android.test.common.OpenTelemetryRumRule
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.context.Context
+import io.opentelemetry.instrumentation.library.coroutines.CoroutinesTestUtil
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class InstrumentationTest {
+    @Rule
+    @JvmField
+    var otelRule: OpenTelemetryRumRule = OpenTelemetryRumRule()
+
+    private val scope = CoroutineScope(Dispatchers.IO)
+
+    @Test
+    fun test_launch_default_propagates_context_after_suspension() {
+        val tracer = otelRule.openTelemetryRum.openTelemetry.getTracer("test")
+        val parentSpan = tracer.spanBuilder("parent").startSpan()
+        val latch = CountDownLatch(1)
+        var spanIdInCoroutine: String? = null
+
+        parentSpan.makeCurrent().use {
+            CoroutinesTestUtil.launchDefault(scope) {
+                delay(10)
+                spanIdInCoroutine = Span.current().spanContext.spanId
+                latch.countDown()
+            }
+        }
+
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue()
+        assertThat(spanIdInCoroutine).isEqualTo(parentSpan.spanContext.spanId)
+        assertThat(Context.current()).isEqualTo(Context.root())
+        parentSpan.end()
+    }
+
+    @Test
+    fun test_launch_direct_propagates_context_after_suspension() {
+        val tracer = otelRule.openTelemetryRum.openTelemetry.getTracer("test")
+        val parentSpan = tracer.spanBuilder("parent").startSpan()
+        val latch = CountDownLatch(1)
+        var spanIdInCoroutine: String? = null
+
+        parentSpan.makeCurrent().use {
+            CoroutinesTestUtil.launchDirect(scope) {
+                delay(10)
+                spanIdInCoroutine = Span.current().spanContext.spanId
+                latch.countDown()
+            }
+        }
+
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue()
+        assertThat(spanIdInCoroutine).isEqualTo(parentSpan.spanContext.spanId)
+        assertThat(Context.current()).isEqualTo(Context.root())
+        parentSpan.end()
+    }
+
+    @Test
+    fun test_no_context_when_no_span_active() {
+        val latch = CountDownLatch(1)
+        var spanInsideCoroutine: Span? = null
+
+        CoroutinesTestUtil.launchDefault(scope) {
+            delay(10)
+            spanInsideCoroutine = Span.current()
+            latch.countDown()
+        }
+
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue()
+        assertThat(spanInsideCoroutine!!.spanContext.isValid).isFalse()
+    }
+
+    @Test
+    fun test_no_context_leakage_to_caller_thread() {
+        val tracer = otelRule.openTelemetryRum.openTelemetry.getTracer("test")
+        val parentSpan = tracer.spanBuilder("parent").startSpan()
+        val latch = CountDownLatch(1)
+
+        parentSpan.makeCurrent().use {
+            CoroutinesTestUtil.launchDefault(scope) {
+                delay(10)
+                latch.countDown()
+            }
+        }
+
+        assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue()
+        assertThat(Span.current().spanContext.isValid).isFalse()
+        parentSpan.end()
+    }
+}

--- a/instrumentation/coroutines/testing/src/main/AndroidManifest.xml
+++ b/instrumentation/coroutines/testing/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest>
+</manifest>

--- a/instrumentation/coroutines/testing/src/main/kotlin/io/opentelemetry/instrumentation/library/coroutines/CoroutinesTestUtil.kt
+++ b/instrumentation/coroutines/testing/src/main/kotlin/io/opentelemetry/instrumentation/library/coroutines/CoroutinesTestUtil.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.library.coroutines
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Exercises both launch overloads from application bytecode so that ByteBuddy transforms them.
+ * These functions must live in src/main so that they are included in the transformed application
+ * classes.
+ */
+object CoroutinesTestUtil {
+    fun launchDefault(
+        scope: CoroutineScope,
+        block: suspend CoroutineScope.() -> Unit,
+    ): Job = scope.launch { block() }
+
+    fun launchDirect(
+        scope: CoroutineScope,
+        block: suspend CoroutineScope.() -> Unit,
+    ): Job = scope.launch(EmptyCoroutineContext, CoroutineStart.DEFAULT) { block() }
+}


### PR DESCRIPTION
Closes #239 

Example of what this instrumentation helps with, as stated in its README.md file:

Given:

```kotlin
val span = tracer.spanBuilder("work").startSpan()
span.makeCurrent().use {
    scope.launch {
        val inner = tracer.spanBuilder("coroutine-work").startSpan()
        // ...
        inner.end()
    }
}
span.end()
```

**Without** this instrumentation, `coroutine-work` does not inherit the active context and is recorded
as a separate root span:

```
work
coroutine-work
```

**With** this instrumentation, the active context is carried into the coroutine automatically, and
`coroutine-work` is recorded as a child of `work`:

```
work
└── coroutine-work
```
