### PR TITLE
fix(session): preserve explicit session IDs on logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### 🛠️ Bug fixes
+
+- Preserve explicit session IDs on logs so recovered native crashes and session-end events remain
+  associated with the session they describe.
+  ([#1939](https://github.com/open-telemetry/opentelemetry-android/pull/1939))
+
 ## Version 1.6.0 (2026-07-28)
 
 OpenTelemetry Android now has a [project roadmap](docs/ROADMAP.md) describing the project's

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/OpenTelemetryRumSmokeTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/OpenTelemetryRumSmokeTest.kt
@@ -140,9 +140,9 @@ class OpenTelemetryRumSmokeTest {
         assertThat(currentSessionId).isNotEqualTo(endedSessionId)
         val request =
             server.awaitLogRequest {
-                findEvent(it, "session.end") != null
+                findSessionEvent(it, "session.end") != null
             }
-        val sessionEnd = checkNotNull(findEvent(request, "session.end"))
+        val sessionEnd = checkNotNull(findSessionEvent(request, "session.end"))
         val exportedSessionId =
             sessionEnd.attributesList
                 .first { it.key == SESSION_ID }
@@ -179,7 +179,7 @@ class OpenTelemetryRumSmokeTest {
                 logRecord.body.stringValue
             }.contains(logMessage)
 
-    private fun findEvent(
+    private fun findSessionEvent(
         request: ExportLogsServiceRequest,
         eventName: String,
     ): LogRecord? =

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/OpenTelemetryRumSmokeTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/OpenTelemetryRumSmokeTest.kt
@@ -12,12 +12,17 @@ import androidx.test.platform.app.InstrumentationRegistry
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.agent.OpenTelemetryRumInitializer
 import io.opentelemetry.android.agent.dsl.OpenTelemetryConfiguration
+import io.opentelemetry.kotlin.semconv.IncubatingApi
+import io.opentelemetry.kotlin.semconv.SessionAttributes.SESSION_ID
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
+import io.opentelemetry.proto.logs.v1.LogRecord
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import io.opentelemetry.sdk.testing.time.TestClock
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import java.util.concurrent.TimeUnit
 
 @RunWith(AndroidJUnit4::class)
 class OpenTelemetryRumSmokeTest {
@@ -25,6 +30,7 @@ class OpenTelemetryRumSmokeTest {
     private val spanName = "span-span"
     private val logScopeName = "logger"
     private val logMessage = "Hello world"
+    private val sessionLogScopeName = "otel.session"
 
     private lateinit var server: FakeOpenTelemetryServer
 
@@ -107,6 +113,44 @@ class OpenTelemetryRumSmokeTest {
         assertThat(server.logRequestCount()).isZero
     }
 
+    @Test
+    @OptIn(IncubatingApi::class)
+    fun testSessionEndUsesEndedSessionId() {
+        val clock = TestClock.create()
+        lateinit var endedSessionId: String
+        lateinit var currentSessionId: String
+
+        performOpenTelemetryRumAction(
+            config = {
+                httpExport {
+                    baseUrl = server.url
+                }
+                diskBufferingConfig.enabled(false)
+                disableTracing()
+                disableMetrics()
+                this.clock = clock
+            },
+            action = {
+                endedSessionId = sessionProvider.getSessionId()
+                clock.advance(4, TimeUnit.HOURS)
+                currentSessionId = sessionProvider.getSessionId()
+            },
+        )
+
+        assertThat(currentSessionId).isNotEqualTo(endedSessionId)
+        val request =
+            server.awaitLogRequest {
+                findEvent(it, "session.end") != null
+            }
+        val sessionEnd = checkNotNull(findEvent(request, "session.end"))
+        val exportedSessionId =
+            sessionEnd.attributesList
+                .first { it.key == SESSION_ID }
+                .value
+                .stringValue
+        assertThat(exportedSessionId).isEqualTo(endedSessionId)
+    }
+
     private fun OpenTelemetryRum.recordLog() {
         openTelemetry.logsBridge
             .get(logScopeName)
@@ -134,6 +178,16 @@ class OpenTelemetryRumSmokeTest {
             .map { logRecord ->
                 logRecord.body.stringValue
             }.contains(logMessage)
+
+    private fun findEvent(
+        request: ExportLogsServiceRequest,
+        eventName: String,
+    ): LogRecord? =
+        request.resourceLogsList
+            .flatMap { it.scopeLogsList }
+            .filter { it.scope.name == sessionLogScopeName }
+            .flatMap { it.logRecordsList }
+            .find { it.eventName == eventName }
 
     private fun findSpan(request: ExportTraceServiceRequest): Boolean =
         request

--- a/core/src/main/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppender.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppender.kt
@@ -24,6 +24,8 @@ internal class SessionIdLogRecordAppender(
         context: Context,
         logRecord: ReadWriteLogRecord,
     ) {
-        logRecord.setAttribute(sessionIdKey, sessionProvider.getSessionId())
+        if (logRecord.getAttribute(sessionIdKey) == null) {
+            logRecord.setAttribute(sessionIdKey, sessionProvider.getSessionId())
+        }
     }
 }

--- a/core/src/main/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppender.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppender.kt
@@ -24,6 +24,7 @@ internal class SessionIdLogRecordAppender(
         context: Context,
         logRecord: ReadWriteLogRecord,
     ) {
+        // Recovered crashes and session-end events can describe a session that is no longer current.
         if (logRecord.getAttribute(sessionIdKey) == null) {
             logRecord.setAttribute(sessionIdKey, sessionProvider.getSessionId())
         }

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.kt
@@ -213,7 +213,7 @@ class OpenTelemetryRumBuilderTest {
     }
 
     @Test
-    fun preservesExplicitSessionIdOnLogs() {
+    fun preservesEndedSessionIdOnSessionEndLogs() {
         createAndSetServiceManager()
         val openTelemetryRum =
             makeBuilder()
@@ -228,15 +228,13 @@ class OpenTelemetryRumBuilderTest {
             .loggerBuilder("test")
             .build()
             .logRecordBuilder()
-            .setAttribute(stringKey(SESSION_ID), "persisted-session")
+            .setEventName("session.end")
+            .setAttribute(stringKey(SESSION_ID), "ended-session")
             .emit()
 
-        assertThat(
-            logsExporter.finishedLogRecordItems
-                .single()
-                .attributes
-                .get(stringKey(SESSION_ID)),
-        ).isEqualTo("persisted-session")
+        val sessionEnd = logsExporter.finishedLogRecordItems.single()
+        assertThat(sessionEnd.eventName).isEqualTo("session.end")
+        assertThat(sessionEnd.attributes.get(stringKey(SESSION_ID))).isEqualTo("ended-session")
     }
 
     @Test

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.kt
@@ -213,7 +213,7 @@ class OpenTelemetryRumBuilderTest {
     }
 
     @Test
-    fun preservesEndedSessionIdOnSessionEndLogs() {
+    fun preservesExplicitSessionIdOnLogs() {
         createAndSetServiceManager()
         val openTelemetryRum =
             makeBuilder()
@@ -228,13 +228,15 @@ class OpenTelemetryRumBuilderTest {
             .loggerBuilder("test")
             .build()
             .logRecordBuilder()
-            .setEventName("session.end")
-            .setAttribute(stringKey(SESSION_ID), "ended-session")
+            .setAttribute(stringKey(SESSION_ID), "persisted-session")
             .emit()
 
-        val sessionEnd = logsExporter.finishedLogRecordItems.single()
-        assertThat(sessionEnd.eventName).isEqualTo("session.end")
-        assertThat(sessionEnd.attributes.get(stringKey(SESSION_ID))).isEqualTo("ended-session")
+        assertThat(
+            logsExporter.finishedLogRecordItems
+                .single()
+                .attributes
+                .get(stringKey(SESSION_ID)),
+        ).isEqualTo("persisted-session")
     }
 
     @Test

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumBuilderTest.kt
@@ -213,6 +213,33 @@ class OpenTelemetryRumBuilderTest {
     }
 
     @Test
+    fun preservesExplicitSessionIdOnLogs() {
+        createAndSetServiceManager()
+        val openTelemetryRum =
+            makeBuilder()
+                .setSessionProvider(SessionProvider { "current-session" })
+                .addLoggerProviderCustomizer { logRecordProviderBuilder: SdkLoggerProviderBuilder, _: Context ->
+                    logRecordProviderBuilder.addLogRecordProcessor(
+                        SimpleLogRecordProcessor.create(logsExporter),
+                    )
+                }.build()
+
+        openTelemetryRum.openTelemetry.logsBridge
+            .loggerBuilder("test")
+            .build()
+            .logRecordBuilder()
+            .setAttribute(stringKey(SESSION_ID), "persisted-session")
+            .emit()
+
+        assertThat(
+            logsExporter.finishedLogRecordItems
+                .single()
+                .attributes
+                .get(stringKey(SESSION_ID)),
+        ).isEqualTo("persisted-session")
+    }
+
+    @Test
     fun canCustomizeMetrics() {
         val metricReader = InMemoryMetricReader.create()
         val openTelemetryRum =

--- a/core/src/test/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppenderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppenderTest.kt
@@ -33,6 +33,7 @@ class SessionIdLogRecordAppenderTest {
     fun setUp() {
         MockKAnnotations.init(this)
         every { sessionProvider.getSessionId() }.returns(SESSION_ID_VALUE)
+        every { log.getAttribute(any<AttributeKey<String>>()) } returns null
         every { log.setAttribute(any<AttributeKey<String>>(), any<String>()) } returns log
     }
 
@@ -43,5 +44,15 @@ class SessionIdLogRecordAppenderTest {
         underTest.onEmit(Context.root(), log)
 
         verify { log.setAttribute(stringKey(SESSION_ID), SESSION_ID_VALUE) }
+    }
+
+    @Test
+    fun `should preserve an existing sessionId attribute`() {
+        every { log.getAttribute(stringKey(SESSION_ID)) } returns "persisted-session"
+        val underTest = SessionIdLogRecordAppender(sessionProvider)
+
+        underTest.onEmit(Context.root(), log)
+
+        verify(exactly = 0) { log.setAttribute(any<AttributeKey<String>>(), any<String>()) }
     }
 }


### PR DESCRIPTION
- preserve an explicitly supplied `session.id` instead of replacing it with the current session
- keep adding the current session to logs that do not already have one
- cover the behavior through the normal logger pipeline

This keeps a recovered native crash attached to the session that actually crashed after the app restarts.

Fixes #1937.

#### Validation

- core and native-crash unit tests
- Android-agent smoke test covering session rotation and exported session attribution
- formatting, API compatibility, and Android lint checks
- Android 15 ARM64 emulator: Session A crashed, Session B started, and the replayed `app.crash` retained Session A and the original crash timestamp; another relaunch did not replay it again