### PR TITLE
Fix weaver semconv schema url and allow dependency bump

### DIFF
--- a/demo-app/gradle/libs.versions.toml
+++ b/demo-app/gradle/libs.versions.toml
@@ -35,7 +35,7 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version = "2.2.1" }
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version = "2.2.2" }
 material = { group = "com.google.android.material", name = "material", version = "1.14.0" }
 material-icons-core = { group = "androidx.compose.material", name = "material-icons-core", version = "1.7.8" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,7 +21,7 @@ fragment = "1.8.9"
 koverGradlePlugin = "0.9.9"
 openTelemetryProto = "1.11.0-alpha"
 protobufKotlin = "4.35.1"
-weaver = "0.25.0"
+weaver = "0.25.1"
 
 [libraries]
 opentelemetry-platform-alpha = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version.ref = "opentelemetry-instrumentation-alpha" }

--- a/semconv/model/manifest.yaml
+++ b/semconv/model/manifest.yaml
@@ -4,3 +4,4 @@ schema_url: https://opentelemetry.io/schemas/opentelemetry-android/0.1.0
 dependencies:
   - name: otel
     registry_path: https://github.com/open-telemetry/semantic-conventions@v1.41.1[model]
+    schema_url: https://opentelemetry.io/schemas/1.41.1


### PR DESCRIPTION
Based on top of this PR that bumps dependencies with an extra fix of specifying the schema_url which was required to fix weaver's semconv generation: https://github.com/open-telemetry/opentelemetry-android/pull/1934