### PR TITLE
test(native-crash): verify marker format compatibility

### DIFF
--- a/instrumentation/native-crash/build.gradle.kts
+++ b/instrumentation/native-crash/build.gradle.kts
@@ -10,6 +10,17 @@ android {
 
     defaultConfig {
         consumerProguardFiles("consumer-rules.pro")
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        getByName("debug") {
+            externalNativeBuild {
+                cmake {
+                    arguments += "-DOTEL_NATIVE_CRASH_TESTING=ON"
+                }
+            }
+        }
     }
 
     externalNativeBuild {
@@ -30,4 +41,8 @@ dependencies {
     implementation(libs.opentelemetry.semconv.kotlin)
 
     testImplementation(project(":test-common"))
+    androidTestImplementation(libs.androidx.test.core)
+    androidTestImplementation(libs.androidx.test.runner)
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.assertj.core)
 }

--- a/instrumentation/native-crash/src/androidTest/kotlin/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashMarkerCompatibilityTest.kt
+++ b/instrumentation/native-crash/src/androidTest/kotlin/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashMarkerCompatibilityTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.nativecrash
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.time.Instant
+
+@RunWith(AndroidJUnit4::class)
+class NativeCrashMarkerCompatibilityTest {
+    @Test
+    fun nativeWriterAndKotlinReaderUseCompatibleMarkerFormat() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val directory =
+            File(context.cacheDir, "native-crash-marker-compatibility").apply {
+                deleteRecursively()
+                assertThat(mkdirs()).isTrue()
+            }
+        val store = FileNativeCrashStore(directory)
+        val timestampNanos = 1_783_598_400_123_456_789L
+
+        System.loadLibrary("otel_android_native_crash")
+        assertThat(
+            NativeCrashTestJni.writeCrashMarker(
+                markerPath = store.crashRecordPath.absolutePath,
+                signalNumber = 11,
+                timestampEpochNanos = timestampNanos,
+            ),
+        ).isTrue()
+
+        assertThat(store.readCrashRecord())
+            .isEqualTo(
+                NativeCrashRecord(
+                    signalNumber = 11,
+                    timestamp = Instant.ofEpochSecond(1_783_598_400, 123_456_789),
+                ),
+            )
+    }
+}
+
+internal object NativeCrashTestJni {
+    @JvmStatic
+    external fun writeCrashMarker(
+        markerPath: String,
+        signalNumber: Int,
+        timestampEpochNanos: Long,
+    ): Boolean
+}

--- a/instrumentation/native-crash/src/main/cpp/CMakeLists.txt
+++ b/instrumentation/native-crash/src/main/cpp/CMakeLists.txt
@@ -4,6 +4,8 @@
 cmake_minimum_required(VERSION 3.22.1)
 project(otel_android_native_crash LANGUAGES C)
 
+option(OTEL_NATIVE_CRASH_TESTING "Build native crash instrumentation test hooks" OFF)
+
 add_library(otel_android_native_crash SHARED native_crash_handler.c)
 
 set_target_properties(
@@ -21,3 +23,11 @@ target_compile_options(
         -Wextra
         -Werror
 )
+
+if(OTEL_NATIVE_CRASH_TESTING)
+    target_compile_definitions(
+        otel_android_native_crash
+        PRIVATE
+            OTEL_NATIVE_CRASH_TESTING=1
+    )
+endif()

--- a/instrumentation/native-crash/src/main/cpp/native_crash_handler.c
+++ b/instrumentation/native-crash/src/main/cpp/native_crash_handler.c
@@ -108,20 +108,7 @@ static bool write_all(int file_descriptor, const char *buffer, size_t length) {
     return true;
 }
 
-static void write_crash_marker(int signal_number) {
-    struct timespec crash_time;
-    if (clock_gettime(CLOCK_REALTIME, &crash_time) != 0 || crash_time.tv_sec < 0 ||
-        crash_time.tv_nsec < 0) {
-        return;
-    }
-
-    uint64_t seconds = (uint64_t) crash_time.tv_sec;
-    uint64_t nanoseconds = (uint64_t) crash_time.tv_nsec;
-    if (seconds > (UINT64_MAX - nanoseconds) / NANOS_PER_SECOND) {
-        return;
-    }
-    uint64_t timestamp_epoch_nanos = seconds * NANOS_PER_SECOND + nanoseconds;
-
+static bool write_crash_marker_at(int signal_number, uint64_t timestamp_epoch_nanos) {
     char marker[MARKER_BUFFER_SIZE];
     size_t marker_length = 0;
     static const char signal_key[] = "signal.number=";
@@ -137,26 +124,41 @@ static void write_crash_marker(int signal_number) {
             sizeof(timestamp_key) - 1) ||
         !append_uint64(marker, sizeof(marker), &marker_length, timestamp_epoch_nanos) ||
         !append_bytes(marker, sizeof(marker), &marker_length, newline, sizeof(newline) - 1)) {
-        return;
+        return false;
     }
 
     int file_descriptor =
         open(temporary_crash_record_path, O_CREAT | O_WRONLY | O_TRUNC | O_CLOEXEC, 0600);
     if (file_descriptor < 0) {
-        return;
+        return false;
     }
 
     bool complete = write_all(file_descriptor, marker, marker_length) && fsync(file_descriptor) == 0;
     if (close(file_descriptor) != 0) {
         complete = false;
     }
-    if (complete) {
-        if (rename(temporary_crash_record_path, crash_record_path) != 0) {
-            unlink(temporary_crash_record_path);
-        }
-    } else {
+    if (!complete || rename(temporary_crash_record_path, crash_record_path) != 0) {
         unlink(temporary_crash_record_path);
+        return false;
     }
+    return true;
+}
+
+static void write_crash_marker(int signal_number) {
+    struct timespec crash_time;
+    if (clock_gettime(CLOCK_REALTIME, &crash_time) != 0 || crash_time.tv_sec < 0 ||
+        crash_time.tv_nsec < 0) {
+        return;
+    }
+
+    uint64_t seconds = (uint64_t) crash_time.tv_sec;
+    uint64_t nanoseconds = (uint64_t) crash_time.tv_nsec;
+    if (seconds > (UINT64_MAX - nanoseconds) / NANOS_PER_SECOND) {
+        return;
+    }
+    (void) write_crash_marker_at(
+        signal_number,
+        seconds * NANOS_PER_SECOND + nanoseconds);
 }
 
 static void rollback_installed_handlers(void) {
@@ -324,23 +326,26 @@ static bool install_handlers(void) {
     return true;
 }
 
-static bool install_for_path(const char *path, size_t path_length) {
+static bool set_crash_record_paths(const char *path, size_t path_length) {
     size_t suffix_length = sizeof(TEMPORARY_SUFFIX) - 1;
     if (path == NULL || path_length == 0 || path_length >= sizeof(crash_record_path) ||
         path_length + suffix_length >= sizeof(temporary_crash_record_path)) {
         return false;
     }
+    memcpy(crash_record_path, path, path_length);
+    crash_record_path[path_length] = '\0';
+    memcpy(temporary_crash_record_path, path, path_length);
+    memcpy(temporary_crash_record_path + path_length, TEMPORARY_SUFFIX, suffix_length + 1);
+    return true;
+}
 
+static bool install_for_path(const char *path, size_t path_length) {
     pthread_mutex_lock(&install_mutex);
     bool installed;
     if (handlers_installed) {
         installed = strcmp(crash_record_path, path) == 0;
     } else {
-        memcpy(crash_record_path, path, path_length);
-        crash_record_path[path_length] = '\0';
-        memcpy(temporary_crash_record_path, path, path_length);
-        memcpy(temporary_crash_record_path + path_length, TEMPORARY_SUFFIX, suffix_length + 1);
-        installed = install_handlers();
+        installed = set_crash_record_paths(path, path_length) && install_handlers();
         handlers_installed = installed;
     }
     pthread_mutex_unlock(&install_mutex);
@@ -372,3 +377,38 @@ Java_io_opentelemetry_android_instrumentation_nativecrash_NativeCrashJni_install
     (*environment)->ReleaseStringUTFChars(environment, marker_path, path);
     return installed ? JNI_TRUE : JNI_FALSE;
 }
+
+#ifdef OTEL_NATIVE_CRASH_TESTING
+JNIEXPORT jboolean JNICALL
+Java_io_opentelemetry_android_instrumentation_nativecrash_NativeCrashTestJni_writeCrashMarker(
+    JNIEnv *environment,
+    jclass native_crash_test_jni,
+    jstring marker_path,
+    jint signal_number,
+    jlong timestamp_epoch_nanos) {
+    (void) native_crash_test_jni;
+    if (marker_path == NULL || signal_number <= 0 || timestamp_epoch_nanos <= 0) {
+        return JNI_FALSE;
+    }
+
+    jsize path_length = (*environment)->GetStringUTFLength(environment, marker_path);
+    if (path_length <= 0) {
+        return JNI_FALSE;
+    }
+
+    const char *path = (*environment)->GetStringUTFChars(environment, marker_path, NULL);
+    if (path == NULL) {
+        return JNI_FALSE;
+    }
+
+    pthread_mutex_lock(&install_mutex);
+    bool written =
+        !handlers_installed &&
+        set_crash_record_paths(path, (size_t) path_length) &&
+        write_crash_marker_at((int) signal_number, (uint64_t) timestamp_epoch_nanos);
+    pthread_mutex_unlock(&install_mutex);
+
+    (*environment)->ReleaseStringUTFChars(environment, marker_path, path);
+    return written ? JNI_TRUE : JNI_FALSE;
+}
+#endif

--- a/instrumentation/native-crash/src/main/cpp/native_crash_handler.c
+++ b/instrumentation/native-crash/src/main/cpp/native_crash_handler.c
@@ -108,7 +108,11 @@ static bool write_all(int file_descriptor, const char *buffer, size_t length) {
     return true;
 }
 
-static bool write_crash_marker_at(int signal_number, uint64_t timestamp_epoch_nanos) {
+static bool write_crash_marker_at(
+    const char *record_path,
+    const char *temporary_record_path,
+    int signal_number,
+    uint64_t timestamp_epoch_nanos) {
     char marker[MARKER_BUFFER_SIZE];
     size_t marker_length = 0;
     static const char signal_key[] = "signal.number=";
@@ -128,7 +132,7 @@ static bool write_crash_marker_at(int signal_number, uint64_t timestamp_epoch_na
     }
 
     int file_descriptor =
-        open(temporary_crash_record_path, O_CREAT | O_WRONLY | O_TRUNC | O_CLOEXEC, 0600);
+        open(temporary_record_path, O_CREAT | O_WRONLY | O_TRUNC | O_CLOEXEC, 0600);
     if (file_descriptor < 0) {
         return false;
     }
@@ -137,8 +141,8 @@ static bool write_crash_marker_at(int signal_number, uint64_t timestamp_epoch_na
     if (close(file_descriptor) != 0) {
         complete = false;
     }
-    if (!complete || rename(temporary_crash_record_path, crash_record_path) != 0) {
-        unlink(temporary_crash_record_path);
+    if (!complete || rename(temporary_record_path, record_path) != 0) {
+        unlink(temporary_record_path);
         return false;
     }
     return true;
@@ -157,6 +161,8 @@ static void write_crash_marker(int signal_number) {
         return;
     }
     (void) write_crash_marker_at(
+        crash_record_path,
+        temporary_crash_record_path,
         signal_number,
         seconds * NANOS_PER_SECOND + nanoseconds);
 }
@@ -326,16 +332,23 @@ static bool install_handlers(void) {
     return true;
 }
 
-static bool set_crash_record_paths(const char *path, size_t path_length) {
+static bool build_crash_record_paths(
+    const char *path,
+    size_t path_length,
+    char *record_path,
+    size_t record_path_capacity,
+    char *temporary_record_path,
+    size_t temporary_record_path_capacity) {
     size_t suffix_length = sizeof(TEMPORARY_SUFFIX) - 1;
-    if (path == NULL || path_length == 0 || path_length >= sizeof(crash_record_path) ||
-        path_length + suffix_length >= sizeof(temporary_crash_record_path)) {
+    if (path == NULL || path_length == 0 || path_length >= record_path_capacity ||
+        suffix_length >= temporary_record_path_capacity ||
+        path_length >= temporary_record_path_capacity - suffix_length) {
         return false;
     }
-    memcpy(crash_record_path, path, path_length);
-    crash_record_path[path_length] = '\0';
-    memcpy(temporary_crash_record_path, path, path_length);
-    memcpy(temporary_crash_record_path + path_length, TEMPORARY_SUFFIX, suffix_length + 1);
+    memcpy(record_path, path, path_length);
+    record_path[path_length] = '\0';
+    memcpy(temporary_record_path, path, path_length);
+    memcpy(temporary_record_path + path_length, TEMPORARY_SUFFIX, suffix_length + 1);
     return true;
 }
 
@@ -345,7 +358,15 @@ static bool install_for_path(const char *path, size_t path_length) {
     if (handlers_installed) {
         installed = strcmp(crash_record_path, path) == 0;
     } else {
-        installed = set_crash_record_paths(path, path_length) && install_handlers();
+        installed =
+            build_crash_record_paths(
+                path,
+                path_length,
+                crash_record_path,
+                sizeof(crash_record_path),
+                temporary_crash_record_path,
+                sizeof(temporary_crash_record_path)) &&
+            install_handlers();
         handlers_installed = installed;
     }
     pthread_mutex_unlock(&install_mutex);
@@ -401,12 +422,21 @@ Java_io_opentelemetry_android_instrumentation_nativecrash_NativeCrashTestJni_wri
         return JNI_FALSE;
     }
 
-    pthread_mutex_lock(&install_mutex);
+    char test_crash_record_path[PATH_MAX];
+    char test_temporary_crash_record_path[PATH_MAX];
     bool written =
-        !handlers_installed &&
-        set_crash_record_paths(path, (size_t) path_length) &&
-        write_crash_marker_at((int) signal_number, (uint64_t) timestamp_epoch_nanos);
-    pthread_mutex_unlock(&install_mutex);
+        build_crash_record_paths(
+            path,
+            (size_t) path_length,
+            test_crash_record_path,
+            sizeof(test_crash_record_path),
+            test_temporary_crash_record_path,
+            sizeof(test_temporary_crash_record_path)) &&
+        write_crash_marker_at(
+            test_crash_record_path,
+            test_temporary_crash_record_path,
+            (int) signal_number,
+            (uint64_t) timestamp_epoch_nanos);
 
     (*environment)->ReleaseStringUTFChars(environment, marker_path, path);
     return written ? JNI_TRUE : JNI_FALSE;


### PR DESCRIPTION

Adds a device test that writes a crash marker through the native C serializer and reads it through `FileNativeCrashStore`. The test verifies the signal number and nanosecond timestamp.

The JNI test hook is only included in debug builds.

Resolves #1915

Validation: `connectedDebugAndroidTest` passed on a Pixel 8 API 37 ARM64 emulator. The repository's current CI does not run connected Android tests, so this remains a manually validated device test.
