### PR TITLE
Import the existing semconv from upstream for the session events.

### DIFF
--- a/instrumentation/sessions/build.gradle.kts
+++ b/instrumentation/sessions/build.gradle.kts
@@ -17,8 +17,8 @@ dependencies {
     api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
     implementation(project(":agent-api"))
     implementation(project(":instrumentation:android-instrumentation"))
+    implementation(project(":semconv"))
     implementation(libs.opentelemetry.sdk)
-    implementation(libs.opentelemetry.semconv.kotlin)
     implementation(project(":core"))
     implementation(project(":common"))
     implementation(project(":session"))

--- a/instrumentation/sessions/src/main/kotlin/io/opentelemetry/android/instrumentation/sessions/SessionIdEventSender.kt
+++ b/instrumentation/sessions/src/main/kotlin/io/opentelemetry/android/instrumentation/sessions/SessionIdEventSender.kt
@@ -5,12 +5,11 @@
 
 package io.opentelemetry.android.instrumentation.sessions
 
+import io.opentelemetry.android.semconv.events.SessionEndEvent
+import io.opentelemetry.android.semconv.events.SessionStartEvent
 import io.opentelemetry.android.session.Session
 import io.opentelemetry.android.session.SessionObserver
 import io.opentelemetry.api.logs.Logger
-import io.opentelemetry.kotlin.semconv.IncubatingApi
-import io.opentelemetry.kotlin.semconv.SessionAttributes.SESSION_ID
-import io.opentelemetry.kotlin.semconv.SessionAttributes.SESSION_PREVIOUS_ID
 
 /**
  * This class is responsible for generating the session related events as
@@ -23,34 +22,17 @@ internal class SessionIdEventSender(
         newSession: Session,
         previousSession: Session,
     ) {
-        @OptIn(IncubatingApi::class)
-        val eventBuilder =
-            eventLogger
-                .logRecordBuilder()
-                .setEventName(EVENT_SESSION_START)
-                .setAttribute(SESSION_ID, newSession.id)
         val previousSessionId = previousSession.id
-        if (previousSessionId.isNotEmpty()) {
-            @OptIn(IncubatingApi::class)
-            eventBuilder.setAttribute(SESSION_PREVIOUS_ID, previousSessionId)
-        }
-        eventBuilder.emit()
+        SessionStartEvent(
+            sessionId = newSession.id,
+            sessionPreviousId = previousSessionId.ifEmpty { null },
+        ).emit(eventLogger)
     }
 
     override fun onSessionEnded(session: Session) {
         if (session.id.isEmpty()) {
             return
         }
-        @OptIn(IncubatingApi::class)
-        eventLogger
-            .logRecordBuilder()
-            .setEventName(EVENT_SESSION_END)
-            .setAttribute(SESSION_ID, session.id)
-            .emit()
-    }
-
-    companion object {
-        const val EVENT_SESSION_START: String = "session.start"
-        const val EVENT_SESSION_END: String = "session.end"
+        SessionEndEvent(sessionId = session.id).emit(eventLogger)
     }
 }

--- a/instrumentation/sessions/src/test/kotlin/io/opentelemetry/android/instrumentation/sessions/SessionIdEventSenderTest.kt
+++ b/instrumentation/sessions/src/test/kotlin/io/opentelemetry/android/instrumentation/sessions/SessionIdEventSenderTest.kt
@@ -5,14 +5,9 @@
 
 package io.opentelemetry.android.instrumentation.sessions
 
-import io.opentelemetry.android.instrumentation.sessions.SessionIdEventSender.Companion.EVENT_SESSION_END
-import io.opentelemetry.android.instrumentation.sessions.SessionIdEventSender.Companion.EVENT_SESSION_START
 import io.opentelemetry.android.session.Session
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.api.logs.Logger
-import io.opentelemetry.kotlin.semconv.IncubatingApi
-import io.opentelemetry.kotlin.semconv.SessionAttributes.SESSION_ID
-import io.opentelemetry.kotlin.semconv.SessionAttributes.SESSION_PREVIOUS_ID
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -20,7 +15,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
-@OptIn(IncubatingApi::class)
 class SessionIdEventSenderTest {
     private lateinit var logger: Logger
 
@@ -47,9 +41,9 @@ class SessionIdEventSenderTest {
         sender.onSessionStarted(newSession, previousSession)
         assertThat(otelTesting.logRecords).hasSize(1)
         val event = otelTesting.logRecords[0]
-        assertThat(event.eventName).isEqualTo(EVENT_SESSION_START)
-        assertThat(event.attributes.get(stringKey(SESSION_ID))).isEqualTo(newSession.id)
-        assertThat(event.attributes.get(stringKey(SESSION_PREVIOUS_ID))).isNull()
+        assertThat(event.eventName).isEqualTo("session.start")
+        assertThat(event.attributes.get(stringKey("session.id"))).isEqualTo(newSession.id)
+        assertThat(event.attributes.get(stringKey("session.previous_id"))).isNull()
     }
 
     @Test
@@ -60,9 +54,9 @@ class SessionIdEventSenderTest {
         sender.onSessionStarted(newSession, previousSession)
         assertThat(otelTesting.logRecords).hasSize(1)
         val event = otelTesting.logRecords[0]
-        assertThat(event.eventName).isEqualTo(EVENT_SESSION_START)
-        assertThat(event.attributes.get(stringKey(SESSION_ID))).isEqualTo(newSession.id)
-        assertThat(event.attributes.get(stringKey(SESSION_PREVIOUS_ID))).isEqualTo(previousSession.id)
+        assertThat(event.eventName).isEqualTo("session.start")
+        assertThat(event.attributes.get(stringKey("session.id"))).isEqualTo(newSession.id)
+        assertThat(event.attributes.get(stringKey("session.previous_id"))).isEqualTo(previousSession.id)
     }
 
     @Test
@@ -72,9 +66,9 @@ class SessionIdEventSenderTest {
         sender.onSessionEnded(session)
         assertThat(otelTesting.logRecords).hasSize(1)
         val event = otelTesting.logRecords[0]
-        assertThat(event.eventName).isEqualTo(EVENT_SESSION_END)
-        assertThat(event.attributes.get(stringKey(SESSION_ID))).isEqualTo(session.id)
-        assertThat(event.attributes.get(stringKey(SESSION_PREVIOUS_ID))).isNull()
+        assertThat(event.eventName).isEqualTo("session.end")
+        assertThat(event.attributes.get(stringKey("session.id"))).isEqualTo(session.id)
+        assertThat(event.attributes.get(stringKey("session.previous_id"))).isNull()
     }
 
     @Test

--- a/semconv/model/android/registry.yaml
+++ b/semconv/model/android/registry.yaml
@@ -3,6 +3,8 @@
 imports:
   events:
     - app.jank
+    - session.end
+    - session.start
 groups:
   - id: registry.android.semconv
     type: attribute_group


### PR DESCRIPTION
Migrates away from the hard-coded semantic conventions here in favor of the existing upstream conventions.