### PR TITLE
Nightly job to check for new semantic conventions 

### DIFF
--- a/.github/scripts/update-semconv-schema-version.sh
+++ b/.github/scripts/update-semconv-schema-version.sh
@@ -1,0 +1,10 @@
+#!/bin/bash -e
+
+# Updates the upstream semantic convention version in both the registry path and schema URL.
+version=$1
+manifest=semconv/model/manifest.yaml
+
+sed -Ei \
+  -e "s|(semantic-conventions@v)[0-9]+\\.[0-9]+\\.[0-9]+|\\1$version|" \
+  -e "s|(schema_url: https://opentelemetry.io/schemas/)[0-9]+\\.[0-9]+\\.[0-9]+$|\\1$version|" \
+  "$manifest"

--- a/.github/workflows/auto-update-semconv-schema.yml
+++ b/.github/workflows/auto-update-semconv-schema.yml
@@ -1,0 +1,70 @@
+name: Auto-update semantic convention schema
+
+on:
+  schedule:
+    # nightly at 09:17 UTC
+    - cron: "17 9 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  update-semconv-schema:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Check for a new schema version
+        id: check-version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          current=$(grep -oE 'semantic-conventions@v[0-9]+\.[0-9]+\.[0-9]+' \
+            semconv/model/manifest.yaml | sed 's/.*@v//')
+          latest=$(gh release view --repo open-telemetry/semantic-conventions \
+            --json tagName --jq .tagName | sed 's/^v//')
+          branch="otelbot/update-semconv-schema-to-${latest}"
+          open_pr=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number')
+
+          echo "version=$latest" >> "$GITHUB_OUTPUT"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          if [[ $current != "$latest" && -z $open_pr ]]; then
+            echo "update-needed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "update-needed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        if: steps.check-version.outputs.update-needed == 'true'
+        id: otelbot-token
+        with:
+          client-id: ${{ vars.OTELBOT_CLIENT_ID }}
+          private-key: ${{ secrets.OTELBOT_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Update schema and create pull request
+        if: steps.check-version.outputs.update-needed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.otelbot-token.outputs.token }}
+          VERSION: ${{ steps.check-version.outputs.version }}
+          BRANCH: ${{ steps.check-version.outputs.branch }}
+        run: |
+          .github/scripts/update-semconv-schema-version.sh "$VERSION"
+          .github/scripts/use-cla-approved-github-bot.sh
+
+          message="Update the upstream semantic convention schema to $VERSION"
+          git checkout -b "$BRANCH"
+          git add semconv/model/manifest.yaml
+          git commit -m "$message"
+          auth_header=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $auth_header" \
+            push --set-upstream origin "$BRANCH"
+          gh pr create \
+            --title "$message" \
+            --body "Update the upstream semantic convention registry and schema URL to \`$VERSION\`." \
+            --base main

--- a/.github/workflows/auto-update-semconv-schema.yml
+++ b/.github/workflows/auto-update-semconv-schema.yml
@@ -28,11 +28,11 @@ jobs:
           latest=$(gh release view --repo open-telemetry/semantic-conventions \
             --json tagName --jq .tagName | sed 's/^v//')
           branch="otelbot/update-semconv-schema-to-${latest}"
-          open_pr=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number')
+          open_pr=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')
 
           echo "version=$latest" >> "$GITHUB_OUTPUT"
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
-          if [[ $current != "$latest" && -z $open_pr ]]; then
+          if [[ "$current" != "$latest" && -z "$open_pr" ]]; then
             echo "update-needed=true" >> "$GITHUB_OUTPUT"
           else
             echo "update-needed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/auto-update-semconv-schema.yml
+++ b/.github/workflows/auto-update-semconv-schema.yml
@@ -28,11 +28,11 @@ jobs:
           latest=$(gh release view --repo open-telemetry/semantic-conventions \
             --json tagName --jq .tagName | sed 's/^v//')
           branch="otelbot/update-semconv-schema-to-${latest}"
-          open_pr=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')
+          existing_pr=$(gh pr list --head "$branch" --state all --json number --jq '.[0].number // empty')
 
           echo "version=$latest" >> "$GITHUB_OUTPUT"
           echo "branch=$branch" >> "$GITHUB_OUTPUT"
-          if [[ "$current" != "$latest" && -z "$open_pr" ]]; then
+          if [[ "$current" != "$latest" && -z "$existing_pr" ]]; then
             echo "update-needed=true" >> "$GITHUB_OUTPUT"
           else
             echo "update-needed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/auto-update-semconv-schema.yml
+++ b/.github/workflows/auto-update-semconv-schema.yml
@@ -61,9 +61,8 @@ jobs:
           git checkout -b "$BRANCH"
           git add semconv/model/manifest.yaml
           git commit -m "$message"
-          auth_header=$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\n')
-          git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $auth_header" \
-            push --set-upstream origin "$BRANCH"
+          gh auth setup-git
+          git push --set-upstream origin "$BRANCH"
           gh pr create \
             --title "$message" \
             --body "Update the upstream semantic convention registry and schema URL to \`$VERSION\`." \


### PR DESCRIPTION
We are already 2 minor versions behind, so it occurred to me that we should have something that updates us, given that renovate can't really handle this level of customized dependency.

This will check for a new version, update our manifest, and create a PR for it.