### PR TITLE
Use upstream semconv attributes instead of hard coded literals

### DIFF
--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGeneratorTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGeneratorTest.kt
@@ -29,8 +29,10 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.mockkClass
-import io.opentelemetry.api.common.AttributeKey.longKey
-import io.opentelemetry.api.common.AttributeKey.stringKey
+import io.opentelemetry.android.semconv.AppAttributes.APP_SCREEN_COORDINATE_X_KEY
+import io.opentelemetry.android.semconv.AppAttributes.APP_SCREEN_COORDINATE_Y_KEY
+import io.opentelemetry.android.semconv.AppAttributes.APP_WIDGET_ID_KEY
+import io.opentelemetry.android.semconv.AppAttributes.APP_WIDGET_NAME_KEY
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
@@ -109,16 +111,16 @@ internal class ComposeClickEventGeneratorTest {
             .assertThat(event)
             .hasEventName("app.screen.click")
             .hasAttributesSatisfyingExactly(
-                equalTo(longKey("app.screen.coordinate.x"), motionEvent.x.toLong()),
-                equalTo(longKey("app.screen.coordinate.y"), motionEvent.y.toLong()),
+                equalTo(APP_SCREEN_COORDINATE_X_KEY, motionEvent.x.toLong()),
+                equalTo(APP_SCREEN_COORDINATE_Y_KEY, motionEvent.y.toLong()),
             )
 
         event = events[1]
         assertThat(event)
             .hasEventName("app.widget.click")
             .hasAttributesSatisfying(
-                equalTo(stringKey("app.widget.id"), "2"),
-                equalTo(stringKey("app.widget.name"), "click"),
+                equalTo(APP_WIDGET_ID_KEY, "2"),
+                equalTo(APP_WIDGET_NAME_KEY, "click"),
             )
     }
 
@@ -146,16 +148,16 @@ internal class ComposeClickEventGeneratorTest {
             .assertThat(event)
             .hasEventName("app.screen.click")
             .hasAttributesSatisfyingExactly(
-                equalTo(longKey("app.screen.coordinate.x"), motionEvent.x.toLong()),
-                equalTo(longKey("app.screen.coordinate.y"), motionEvent.y.toLong()),
+                equalTo(APP_SCREEN_COORDINATE_X_KEY, motionEvent.x.toLong()),
+                equalTo(APP_SCREEN_COORDINATE_Y_KEY, motionEvent.y.toLong()),
             )
 
         event = events[1]
         assertThat(event)
             .hasEventName("app.widget.click")
             .hasAttributesSatisfying(
-                equalTo(stringKey("app.widget.id"), "3"),
-                equalTo(stringKey("app.widget.name"), "click"),
+                equalTo(APP_WIDGET_ID_KEY, "3"),
+                equalTo(APP_WIDGET_NAME_KEY, "click"),
             )
     }
 
@@ -184,16 +186,16 @@ internal class ComposeClickEventGeneratorTest {
             .assertThat(event)
             .hasEventName("app.screen.click")
             .hasAttributesSatisfyingExactly(
-                equalTo(longKey("app.screen.coordinate.x"), motionEvent.x.toLong()),
-                equalTo(longKey("app.screen.coordinate.y"), motionEvent.y.toLong()),
+                equalTo(APP_SCREEN_COORDINATE_X_KEY, motionEvent.x.toLong()),
+                equalTo(APP_SCREEN_COORDINATE_Y_KEY, motionEvent.y.toLong()),
             )
 
         event = events[1]
         assertThat(event)
             .hasEventName("app.widget.click")
             .hasAttributesSatisfying(
-                equalTo(stringKey("app.widget.id"), "3"),
-                equalTo(stringKey("app.widget.name"), "clickMe"),
+                equalTo(APP_WIDGET_ID_KEY, "3"),
+                equalTo(APP_WIDGET_NAME_KEY, "clickMe"),
             )
     }
 

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
@@ -40,9 +40,11 @@ import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.verify
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.semconv.AppAttributes.APP_SCREEN_COORDINATE_X_KEY
+import io.opentelemetry.android.semconv.AppAttributes.APP_SCREEN_COORDINATE_Y_KEY
+import io.opentelemetry.android.semconv.AppAttributes.APP_WIDGET_ID_KEY
+import io.opentelemetry.android.semconv.AppAttributes.APP_WIDGET_NAME_KEY
 import io.opentelemetry.android.session.SessionProvider
-import io.opentelemetry.api.common.AttributeKey.longKey
-import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
@@ -151,16 +153,16 @@ internal class ComposeInstrumentationTest {
         assertThat(event)
             .hasEventName("app.screen.click")
             .hasAttributesSatisfyingExactly(
-                equalTo(longKey("app.screen.coordinate.x"), motionEvent.x.toLong()),
-                equalTo(longKey("app.screen.coordinate.y"), motionEvent.y.toLong()),
+                equalTo(APP_SCREEN_COORDINATE_X_KEY, motionEvent.x.toLong()),
+                equalTo(APP_SCREEN_COORDINATE_Y_KEY, motionEvent.y.toLong()),
             )
 
         event = events[1]
         assertThat(event)
             .hasEventName("app.widget.click")
             .hasAttributesSatisfying(
-                equalTo(stringKey("app.widget.id"), mockLayoutNode.semanticsId.toString()),
-                equalTo(stringKey("app.widget.name"), "clickMe"),
+                equalTo(APP_WIDGET_ID_KEY, mockLayoutNode.semanticsId.toString()),
+                equalTo(APP_WIDGET_NAME_KEY, "clickMe"),
             )
     }
 

--- a/instrumentation/sessions/src/test/kotlin/io/opentelemetry/android/instrumentation/sessions/SessionIdEventSenderTest.kt
+++ b/instrumentation/sessions/src/test/kotlin/io/opentelemetry/android/instrumentation/sessions/SessionIdEventSenderTest.kt
@@ -5,8 +5,9 @@
 
 package io.opentelemetry.android.instrumentation.sessions
 
+import io.opentelemetry.android.semconv.SessionAttributes.SESSION_ID_KEY
+import io.opentelemetry.android.semconv.SessionAttributes.SESSION_PREVIOUS_ID_KEY
 import io.opentelemetry.android.session.Session
-import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -42,8 +43,8 @@ class SessionIdEventSenderTest {
         assertThat(otelTesting.logRecords).hasSize(1)
         val event = otelTesting.logRecords[0]
         assertThat(event.eventName).isEqualTo("session.start")
-        assertThat(event.attributes.get(stringKey("session.id"))).isEqualTo(newSession.id)
-        assertThat(event.attributes.get(stringKey("session.previous_id"))).isNull()
+        assertThat(event.attributes.get(SESSION_ID_KEY)).isEqualTo(newSession.id)
+        assertThat(event.attributes.get(SESSION_PREVIOUS_ID_KEY)).isNull()
     }
 
     @Test
@@ -55,8 +56,8 @@ class SessionIdEventSenderTest {
         assertThat(otelTesting.logRecords).hasSize(1)
         val event = otelTesting.logRecords[0]
         assertThat(event.eventName).isEqualTo("session.start")
-        assertThat(event.attributes.get(stringKey("session.id"))).isEqualTo(newSession.id)
-        assertThat(event.attributes.get(stringKey("session.previous_id"))).isEqualTo(previousSession.id)
+        assertThat(event.attributes.get(SESSION_ID_KEY)).isEqualTo(newSession.id)
+        assertThat(event.attributes.get(SESSION_PREVIOUS_ID_KEY)).isEqualTo(previousSession.id)
     }
 
     @Test
@@ -67,8 +68,8 @@ class SessionIdEventSenderTest {
         assertThat(otelTesting.logRecords).hasSize(1)
         val event = otelTesting.logRecords[0]
         assertThat(event.eventName).isEqualTo("session.end")
-        assertThat(event.attributes.get(stringKey("session.id"))).isEqualTo(session.id)
-        assertThat(event.attributes.get(stringKey("session.previous_id"))).isNull()
+        assertThat(event.attributes.get(SESSION_ID_KEY)).isEqualTo(session.id)
+        assertThat(event.attributes.get(SESSION_PREVIOUS_ID_KEY)).isNull()
     }
 
     @Test

--- a/instrumentation/slowrendering/build.gradle.kts
+++ b/instrumentation/slowrendering/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     implementation(project(":agent-api"))
     implementation(project(":semconv"))
     implementation(libs.androidx.core)
-    implementation(libs.opentelemetry.semconv.kotlin)
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.instrumentation.api)
     testImplementation(libs.robolectric)

--- a/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/EventJankReporter.kt
+++ b/instrumentation/slowrendering/src/main/java/io/opentelemetry/android/instrumentation/slowrendering/EventJankReporter.kt
@@ -9,14 +9,12 @@ import android.util.Log
 import io.opentelemetry.android.common.RumConstants
 import io.opentelemetry.android.semconv.events.AppJankEvent
 import io.opentelemetry.api.logs.Logger
-import io.opentelemetry.kotlin.semconv.IncubatingApi
 
 internal class EventJankReporter(
     private val eventLogger: Logger,
     private val threshold: Double,
     private val debugVerbose: Boolean = false,
 ) : JankReporter {
-    @OptIn(IncubatingApi::class)
     override fun reportSlow(
         durationToCountHistogram: Map<Int, Int>,
         periodSeconds: Double,

--- a/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/EventJankReporterTest.kt
+++ b/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/EventJankReporterTest.kt
@@ -8,12 +8,9 @@ package io.opentelemetry.android.instrumentation.slowrendering
 import android.util.Log
 import io.mockk.every
 import io.mockk.mockkStatic
-import io.opentelemetry.api.common.AttributeKey.doubleKey
-import io.opentelemetry.api.common.AttributeKey.longKey
-import io.opentelemetry.kotlin.semconv.AppAttributes.APP_JANK_FRAME_COUNT
-import io.opentelemetry.kotlin.semconv.AppAttributes.APP_JANK_PERIOD
-import io.opentelemetry.kotlin.semconv.AppAttributes.APP_JANK_THRESHOLD
-import io.opentelemetry.kotlin.semconv.IncubatingApi
+import io.opentelemetry.android.semconv.AppAttributes.APP_JANK_FRAME_COUNT_KEY
+import io.opentelemetry.android.semconv.AppAttributes.APP_JANK_PERIOD_KEY
+import io.opentelemetry.android.semconv.AppAttributes.APP_JANK_THRESHOLD_KEY
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
@@ -23,7 +20,6 @@ class EventJankReporterTest {
     @Rule
     var otelTesting: OpenTelemetryRule = OpenTelemetryRule.create()
 
-    @OptIn(IncubatingApi::class)
     @Test
     fun `event is generated`() {
         val eventLogger = otelTesting.openTelemetry.logsBridge.get("JANK!")
@@ -40,8 +36,8 @@ class EventJankReporterTest {
         assertThat(otelTesting.logRecords.size).isEqualTo(1)
         val log = otelTesting.logRecords.get(0)
         assertThat(log.eventName).isEqualTo("app.jank")
-        assertThat(log.attributes.get(longKey(APP_JANK_FRAME_COUNT))).isEqualTo(1)
-        assertThat(log.attributes.get(doubleKey(APP_JANK_PERIOD))).isEqualTo(10.5)
-        assertThat(log.attributes.get(doubleKey(APP_JANK_THRESHOLD))).isEqualTo(0.6)
+        assertThat(log.attributes.get(APP_JANK_FRAME_COUNT_KEY)).isEqualTo(1)
+        assertThat(log.attributes.get(APP_JANK_PERIOD_KEY)).isEqualTo(10.5)
+        assertThat(log.attributes.get(APP_JANK_THRESHOLD_KEY)).isEqualTo(0.6)
     }
 }

--- a/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderListenerTest.kt
+++ b/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderListenerTest.kt
@@ -20,13 +20,10 @@ import io.mockk.junit4.MockKRule
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
-import io.opentelemetry.api.common.AttributeKey.doubleKey
-import io.opentelemetry.api.common.AttributeKey.longKey
+import io.opentelemetry.android.semconv.AppAttributes.APP_JANK_FRAME_COUNT_KEY
+import io.opentelemetry.android.semconv.AppAttributes.APP_JANK_PERIOD_KEY
+import io.opentelemetry.android.semconv.AppAttributes.APP_JANK_THRESHOLD_KEY
 import io.opentelemetry.api.logs.Logger
-import io.opentelemetry.kotlin.semconv.AppAttributes.APP_JANK_FRAME_COUNT
-import io.opentelemetry.kotlin.semconv.AppAttributes.APP_JANK_PERIOD
-import io.opentelemetry.kotlin.semconv.AppAttributes.APP_JANK_THRESHOLD
-import io.opentelemetry.kotlin.semconv.IncubatingApi
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
 import kotlinx.coroutines.Runnable
 import org.assertj.core.api.Assertions.assertThat
@@ -240,20 +237,19 @@ class SlowRenderListenerTest {
             .combine(EventJankReporter(eventLogger, FROZEN_THRESHOLD_MS / 1000.0))
     }
 
-    @OptIn(IncubatingApi::class)
     private fun assertLogContent(periodSeconds: Double) {
         assertThat(otelTesting.logRecords).hasSize(2)
 
         val slowLog = otelTesting.logRecords[0]
         assertThat(slowLog.eventName).isEqualTo("app.jank")
-        assertThat(slowLog.attributes.get(longKey(APP_JANK_FRAME_COUNT))).isEqualTo(4)
-        assertThat(slowLog.attributes.get(doubleKey(APP_JANK_PERIOD))).isEqualTo(periodSeconds)
-        assertThat(slowLog.attributes.get(doubleKey(APP_JANK_THRESHOLD))).isEqualTo(0.016)
+        assertThat(slowLog.attributes.get(APP_JANK_FRAME_COUNT_KEY)).isEqualTo(4)
+        assertThat(slowLog.attributes.get(APP_JANK_PERIOD_KEY)).isEqualTo(periodSeconds)
+        assertThat(slowLog.attributes.get(APP_JANK_THRESHOLD_KEY)).isEqualTo(0.016)
 
         val frozenLog = otelTesting.logRecords[1]
         assertThat(frozenLog.eventName).isEqualTo("app.jank")
-        assertThat(frozenLog.attributes.get(longKey(APP_JANK_FRAME_COUNT))).isEqualTo(1)
-        assertThat(frozenLog.attributes.get(doubleKey(APP_JANK_PERIOD))).isEqualTo(periodSeconds)
-        assertThat(frozenLog.attributes.get(doubleKey(APP_JANK_THRESHOLD))).isEqualTo(0.7)
+        assertThat(frozenLog.attributes.get(APP_JANK_FRAME_COUNT_KEY)).isEqualTo(1)
+        assertThat(frozenLog.attributes.get(APP_JANK_PERIOD_KEY)).isEqualTo(periodSeconds)
+        assertThat(frozenLog.attributes.get(APP_JANK_THRESHOLD_KEY)).isEqualTo(0.7)
     }
 }

--- a/semconv/templates/registry/kotlin/kotlin_event_template.kt.j2
+++ b/semconv/templates/registry/kotlin/kotlin_event_template.kt.j2
@@ -6,10 +6,9 @@
 
 package io.opentelemetry.android.semconv.events
 
-{%- set has_array_attributes = (ctx.attributes | selectattr("type", "in", ["string[]", "boolean[]", "int[]", "double[]"]) | list | length) > 0 -%}
-{%- if has_array_attributes %}
-import io.opentelemetry.api.common.AttributeKey
-{%- endif %}
+{%- for attribute in ctx.attributes %}
+import io.opentelemetry.android.semconv.{{ attribute.root_namespace | pascal_case }}Attributes.{{ attribute.name | screaming_snake_case }}_KEY
+{%- endfor %}
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Logger
 
@@ -34,17 +33,10 @@ class {{ my_class_name }}(
         val attributes = Attributes.builder()
 {%- for attribute in ctx.attributes %}
         {%- set required = attribute.requirement_level == "required" %}
-        {%- if attribute.type in ["string[]", "boolean[]", "int[]", "double[]"] %}
-        {%- set key = 'AttributeKey.' ~ (attribute.type | map_text("kotlin_key_factory")) ~ '("' ~ attribute.name ~ '")' %}
         {%- if required %}
-        attributes.put({{ key }}, {{ attribute.name | camel_case }})
+        attributes.put({{ attribute.name | screaming_snake_case }}_KEY, {{ attribute.name | camel_case }})
         {%- else %}
-        {{ attribute.name | camel_case }}?.let { attributes.put({{ key }}, it) }
-        {%- endif %}
-        {%- elif required %}
-        attributes.put("{{ attribute.name }}", {{ attribute.name | camel_case }})
-        {%- else %}
-        {{ attribute.name | camel_case }}?.let { attributes.put("{{ attribute.name }}", it) }
+        {{ attribute.name | camel_case }}?.let { attributes.put({{ attribute.name | screaming_snake_case }}_KEY, it) }
         {%- endif %}
 {%- endfor %}
         attributes.putAll(additionalAttributes)

--- a/semconv/templates/registry/kotlin/weaver.yaml
+++ b/semconv/templates/registry/kotlin/weaver.yaml
@@ -54,7 +54,8 @@ templates:
           deprecated: .deprecated,
           attributes: ((.attributes // [])
             | map(select(.type != "any"))
-            | unique_by(.name))
+            | unique_by(.name)
+            | map(. + { root_namespace: (.name | split(".")[0]) }))
         })
     application_mode: each
     file_name: "io/opentelemetry/android/semconv/events/{{ctx.name | pascal_case}}Event.kt"


### PR DESCRIPTION
This builds on #1949 and will also need a rebase.

Now that we are able to generate attribute constants from upstream event definitions, we can plug those attribute definitions into the places that used literals before.
