### PR TITLE
Generate semantic event name constants

### DIFF
--- a/android-agent/build.gradle.kts
+++ b/android-agent/build.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
     implementation(project(":instrumentation:sessions"))
     implementation(project(":instrumentation:screen-orientation"))
 
-    testImplementation(project(":semconv"))
     testImplementation(libs.opentelemetry.semconv.kotlin)
     testImplementation(libs.robolectric)
     testImplementation(libs.okhttp.mockwebserver)

--- a/android-agent/build.gradle.kts
+++ b/android-agent/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
     implementation(project(":instrumentation:sessions"))
     implementation(project(":instrumentation:screen-orientation"))
 
+    testImplementation(project(":semconv"))
     testImplementation(libs.opentelemetry.semconv.kotlin)
     testImplementation(libs.robolectric)
     testImplementation(libs.okhttp.mockwebserver)

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/OpenTelemetryRumSmokeTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/smoke/OpenTelemetryRumSmokeTest.kt
@@ -12,8 +12,8 @@ import androidx.test.platform.app.InstrumentationRegistry
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.agent.OpenTelemetryRumInitializer
 import io.opentelemetry.android.agent.dsl.OpenTelemetryConfiguration
-import io.opentelemetry.kotlin.semconv.IncubatingApi
-import io.opentelemetry.kotlin.semconv.SessionAttributes.SESSION_ID
+import io.opentelemetry.android.semconv.SessionAttributes.SESSION_ID
+import io.opentelemetry.android.semconv.events.SessionEndEvent.Companion.SESSION_END_EVENT_NAME
 import io.opentelemetry.proto.collector.logs.v1.ExportLogsServiceRequest
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
 import io.opentelemetry.proto.logs.v1.LogRecord
@@ -114,7 +114,6 @@ class OpenTelemetryRumSmokeTest {
     }
 
     @Test
-    @OptIn(IncubatingApi::class)
     fun testSessionEndUsesEndedSessionId() {
         val clock = TestClock.create()
         lateinit var endedSessionId: String
@@ -140,9 +139,9 @@ class OpenTelemetryRumSmokeTest {
         assertThat(currentSessionId).isNotEqualTo(endedSessionId)
         val request =
             server.awaitLogRequest {
-                findSessionEvent(it, "session.end") != null
+                findSessionEvent(it, SESSION_END_EVENT_NAME) != null
             }
-        val sessionEnd = checkNotNull(findSessionEvent(request, "session.end"))
+        val sessionEnd = checkNotNull(findSessionEvent(request, SESSION_END_EVENT_NAME))
         val exportedSessionId =
             sessionEnd.attributesList
                 .first { it.key == SESSION_ID }

--- a/instrumentation/anr/src/test/java/io/opentelemetry/android/instrumentation/anr/AnrWatcherTest.kt
+++ b/instrumentation/anr/src/test/java/io/opentelemetry/android/instrumentation/anr/AnrWatcherTest.kt
@@ -10,6 +10,7 @@ import io.mockk.Called
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import io.opentelemetry.android.semconv.events.DeviceAnrEvent.Companion.DEVICE_ANR_EVENT_NAME
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.LogRecordBuilder
 import io.opentelemetry.api.logs.Logger
@@ -95,7 +96,7 @@ class AnrWatcherTest {
             anrWatcher.run()
         }
         verify(exactly = 1) { logger.logRecordBuilder() }
-        verify(exactly = 1) { logRecordBuilder.setEventName("device.anr") }
+        verify(exactly = 1) { logRecordBuilder.setEventName(DEVICE_ANR_EVENT_NAME) }
         verify(exactly = 1) { logRecordBuilder.setAllAttributes(any<Attributes>()) }
         verify(exactly = 1) { logRecordBuilder.emit() }
 
@@ -109,7 +110,7 @@ class AnrWatcherTest {
         anrWatcher.run()
 
         verify(exactly = 2) { logger.logRecordBuilder() }
-        verify(exactly = 2) { logRecordBuilder.setEventName("device.anr") }
+        verify(exactly = 2) { logRecordBuilder.setEventName(DEVICE_ANR_EVENT_NAME) }
         verify(exactly = 2) { logRecordBuilder.setAllAttributes(any<Attributes>()) }
         verify(exactly = 2) { logRecordBuilder.emit() }
     }

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGeneratorTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGeneratorTest.kt
@@ -33,6 +33,8 @@ import io.opentelemetry.android.semconv.AppAttributes.APP_SCREEN_COORDINATE_X_KE
 import io.opentelemetry.android.semconv.AppAttributes.APP_SCREEN_COORDINATE_Y_KEY
 import io.opentelemetry.android.semconv.AppAttributes.APP_WIDGET_ID_KEY
 import io.opentelemetry.android.semconv.AppAttributes.APP_WIDGET_NAME_KEY
+import io.opentelemetry.android.semconv.events.AppScreenClickEvent.Companion.APP_SCREEN_CLICK_EVENT_NAME
+import io.opentelemetry.android.semconv.events.AppWidgetClickEvent.Companion.APP_WIDGET_CLICK_EVENT_NAME
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
@@ -109,7 +111,7 @@ internal class ComposeClickEventGeneratorTest {
         var event = events[0]
         OpenTelemetryAssertions
             .assertThat(event)
-            .hasEventName("app.screen.click")
+            .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(APP_SCREEN_COORDINATE_X_KEY, motionEvent.x.toLong()),
                 equalTo(APP_SCREEN_COORDINATE_Y_KEY, motionEvent.y.toLong()),
@@ -117,7 +119,7 @@ internal class ComposeClickEventGeneratorTest {
 
         event = events[1]
         assertThat(event)
-            .hasEventName("app.widget.click")
+            .hasEventName(APP_WIDGET_CLICK_EVENT_NAME)
             .hasAttributesSatisfying(
                 equalTo(APP_WIDGET_ID_KEY, "2"),
                 equalTo(APP_WIDGET_NAME_KEY, "click"),
@@ -146,7 +148,7 @@ internal class ComposeClickEventGeneratorTest {
         var event = events[0]
         OpenTelemetryAssertions
             .assertThat(event)
-            .hasEventName("app.screen.click")
+            .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(APP_SCREEN_COORDINATE_X_KEY, motionEvent.x.toLong()),
                 equalTo(APP_SCREEN_COORDINATE_Y_KEY, motionEvent.y.toLong()),
@@ -154,7 +156,7 @@ internal class ComposeClickEventGeneratorTest {
 
         event = events[1]
         assertThat(event)
-            .hasEventName("app.widget.click")
+            .hasEventName(APP_WIDGET_CLICK_EVENT_NAME)
             .hasAttributesSatisfying(
                 equalTo(APP_WIDGET_ID_KEY, "3"),
                 equalTo(APP_WIDGET_NAME_KEY, "click"),
@@ -184,7 +186,7 @@ internal class ComposeClickEventGeneratorTest {
         var event = events[0]
         OpenTelemetryAssertions
             .assertThat(event)
-            .hasEventName("app.screen.click")
+            .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(APP_SCREEN_COORDINATE_X_KEY, motionEvent.x.toLong()),
                 equalTo(APP_SCREEN_COORDINATE_Y_KEY, motionEvent.y.toLong()),
@@ -192,7 +194,7 @@ internal class ComposeClickEventGeneratorTest {
 
         event = events[1]
         assertThat(event)
-            .hasEventName("app.widget.click")
+            .hasEventName(APP_WIDGET_CLICK_EVENT_NAME)
             .hasAttributesSatisfying(
                 equalTo(APP_WIDGET_ID_KEY, "3"),
                 equalTo(APP_WIDGET_NAME_KEY, "clickMe"),

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
@@ -44,6 +44,8 @@ import io.opentelemetry.android.semconv.AppAttributes.APP_SCREEN_COORDINATE_X_KE
 import io.opentelemetry.android.semconv.AppAttributes.APP_SCREEN_COORDINATE_Y_KEY
 import io.opentelemetry.android.semconv.AppAttributes.APP_WIDGET_ID_KEY
 import io.opentelemetry.android.semconv.AppAttributes.APP_WIDGET_NAME_KEY
+import io.opentelemetry.android.semconv.events.AppScreenClickEvent.Companion.APP_SCREEN_CLICK_EVENT_NAME
+import io.opentelemetry.android.semconv.events.AppWidgetClickEvent.Companion.APP_WIDGET_CLICK_EVENT_NAME
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.sdk.common.Clock
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
@@ -151,7 +153,7 @@ internal class ComposeInstrumentationTest {
 
         var event = events[0]
         assertThat(event)
-            .hasEventName("app.screen.click")
+            .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(APP_SCREEN_COORDINATE_X_KEY, motionEvent.x.toLong()),
                 equalTo(APP_SCREEN_COORDINATE_Y_KEY, motionEvent.y.toLong()),
@@ -159,7 +161,7 @@ internal class ComposeInstrumentationTest {
 
         event = events[1]
         assertThat(event)
-            .hasEventName("app.widget.click")
+            .hasEventName(APP_WIDGET_CLICK_EVENT_NAME)
             .hasAttributesSatisfying(
                 equalTo(APP_WIDGET_ID_KEY, mockLayoutNode.semanticsId.toString()),
                 equalTo(APP_WIDGET_NAME_KEY, "clickMe"),

--- a/instrumentation/compose/navigation/build.gradle.kts
+++ b/instrumentation/compose/navigation/build.gradle.kts
@@ -51,7 +51,6 @@ dependencies {
     }
     compileOnly(libs.androidx.navigation.compose)
     implementation(libs.opentelemetry.instrumentation.apiSemconv)
-    implementation(libs.opentelemetry.semconv.kotlin)
 
     testImplementation(project(":test-common"))
 

--- a/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentationTest.kt
+++ b/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentationTest.kt
@@ -28,6 +28,7 @@ import io.opentelemetry.android.internal.services.network.CurrentNetworkProvider
 import io.opentelemetry.android.internal.services.network.NetworkChangeListener
 import io.opentelemetry.android.internal.services.network.NetworkProviderHolder
 import io.opentelemetry.android.semconv.NetworkAttributes.NETWORK_STATUS_KEY
+import io.opentelemetry.android.semconv.events.NetworkChangeEvent.Companion.NETWORK_CHANGE_EVENT_NAME
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.kotlin.semconv.IncubatingApi
@@ -89,7 +90,7 @@ class NetworkChangeInstrumentationTest {
         assertThat(events).hasSize(1)
         val event = events[0]
         assertThat(event)
-            .hasEventName("network.change")
+            .hasEventName(NETWORK_CHANGE_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(NETWORK_STATUS_KEY, "available"),
                 equalTo(stringKey(NETWORK_CONNECTION_TYPE), "wifi"),
@@ -120,7 +121,7 @@ class NetworkChangeInstrumentationTest {
         assertThat(events).hasSize(1)
         val event = events[0]
         assertThat(event)
-            .hasEventName("network.change")
+            .hasEventName(NETWORK_CHANGE_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(NETWORK_STATUS_KEY, "available"),
                 equalTo(stringKey(NETWORK_CONNECTION_TYPE), "cell"),
@@ -149,7 +150,7 @@ class NetworkChangeInstrumentationTest {
         assertThat(events).hasSize(1)
         val event = events[0]
         assertThat(event)
-            .hasEventName("network.change")
+            .hasEventName(NETWORK_CHANGE_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(NETWORK_STATUS_KEY, "lost"),
                 equalTo(stringKey(NETWORK_CONNECTION_TYPE), "unavailable"),
@@ -189,7 +190,7 @@ class NetworkChangeInstrumentationTest {
         assertThat(otelTesting.logRecords).hasSize(1)
         val event = otelTesting.logRecords[0]
         assertThat(event)
-            .hasEventName("network.change")
+            .hasEventName(NETWORK_CHANGE_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(NETWORK_STATUS_KEY, "lost"),
                 equalTo(stringKey(NETWORK_CONNECTION_TYPE), "unavailable"),

--- a/instrumentation/okhttp3-websocket/library/src/test/kotlin/io/opentelemetry/instrumentation/library/okhttp/websocket/internal/WebsocketListenerWrapperTest.kt
+++ b/instrumentation/okhttp3-websocket/library/src/test/kotlin/io/opentelemetry/instrumentation/library/okhttp/websocket/internal/WebsocketListenerWrapperTest.kt
@@ -11,6 +11,10 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.verify
 import io.opentelemetry.android.semconv.WebsocketAttributes.WEBSOCKET_MESSAGE_SIZE_KEY
 import io.opentelemetry.android.semconv.WebsocketAttributes.WEBSOCKET_MESSAGE_TYPE_KEY
+import io.opentelemetry.android.semconv.events.WebsocketCloseEvent.Companion.WEBSOCKET_CLOSE_EVENT_NAME
+import io.opentelemetry.android.semconv.events.WebsocketErrorEvent.Companion.WEBSOCKET_ERROR_EVENT_NAME
+import io.opentelemetry.android.semconv.events.WebsocketMessageEvent.Companion.WEBSOCKET_MESSAGE_EVENT_NAME
+import io.opentelemetry.android.semconv.events.WebsocketOpenEvent.Companion.WEBSOCKET_OPEN_EVENT_NAME
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
@@ -69,7 +73,7 @@ internal class WebsocketListenerWrapperTest {
 
         val event = logRecords[0]
         assertThat(event)
-            .hasEventName("websocket.open")
+            .hasEventName(WEBSOCKET_OPEN_EVENT_NAME)
             .hasAttributesSatisfying(
                 equalTo(NetworkAttributes.NETWORK_PROTOCOL_NAME, "websocket"),
                 equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
@@ -91,7 +95,7 @@ internal class WebsocketListenerWrapperTest {
 
         val event = logRecords[0]
         assertThat(event)
-            .hasEventName("websocket.message")
+            .hasEventName(WEBSOCKET_MESSAGE_EVENT_NAME)
             .hasAttributesSatisfying(
                 equalTo(NetworkAttributes.NETWORK_PROTOCOL_NAME, "websocket"),
                 equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
@@ -115,7 +119,7 @@ internal class WebsocketListenerWrapperTest {
 
         val event = logRecords[0]
         assertThat(event)
-            .hasEventName("websocket.message")
+            .hasEventName(WEBSOCKET_MESSAGE_EVENT_NAME)
             .hasAttributesSatisfying(
                 equalTo(NetworkAttributes.NETWORK_PROTOCOL_NAME, "websocket"),
                 equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
@@ -140,7 +144,7 @@ internal class WebsocketListenerWrapperTest {
 
         val event = logRecords[0]
         assertThat(event)
-            .hasEventName("websocket.close")
+            .hasEventName(WEBSOCKET_CLOSE_EVENT_NAME)
             .hasAttributesSatisfying(
                 equalTo(NetworkAttributes.NETWORK_PROTOCOL_NAME, "websocket"),
                 equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),
@@ -162,7 +166,7 @@ internal class WebsocketListenerWrapperTest {
 
         val event = logRecords[0]
         assertThat(event)
-            .hasEventName("websocket.error")
+            .hasEventName(WEBSOCKET_ERROR_EVENT_NAME)
             .hasAttributesSatisfying(
                 equalTo(NetworkAttributes.NETWORK_PROTOCOL_NAME, "websocket"),
                 equalTo(HttpAttributes.HTTP_REQUEST_METHOD, "GET"),

--- a/instrumentation/power-save-mode/src/test/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeDetectorTest.kt
+++ b/instrumentation/power-save-mode/src/test/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeDetectorTest.kt
@@ -11,6 +11,7 @@ import android.os.PowerManager
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.opentelemetry.android.semconv.AndroidAttributes.ANDROID_POWER_SAVE_MODE_ENABLED_KEY
+import io.opentelemetry.android.semconv.events.DevicePowerSaveModeChangeEvent.Companion.DEVICE_POWER_SAVE_MODE_CHANGE_EVENT_NAME
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -18,8 +19,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
-
-private const val EVENT_NAME = "device.power_save_mode.change"
 
 @RunWith(AndroidJUnit4::class)
 class PowerSaveModeDetectorTest {
@@ -54,7 +53,7 @@ class PowerSaveModeDetectorTest {
         // then
         assertThat(openTelemetryRule.logRecords).hasSize(1)
         val record = openTelemetryRule.logRecords.single()
-        assertThat(record.eventName).isEqualTo(EVENT_NAME)
+        assertThat(record.eventName).isEqualTo(DEVICE_POWER_SAVE_MODE_CHANGE_EVENT_NAME)
         assertThat(record.attributes.get(ANDROID_POWER_SAVE_MODE_ENABLED_KEY))
             .isEqualTo(true)
     }
@@ -70,7 +69,7 @@ class PowerSaveModeDetectorTest {
         // then
         assertThat(openTelemetryRule.logRecords).hasSize(1)
         val record = openTelemetryRule.logRecords.single()
-        assertThat(record.eventName).isEqualTo(EVENT_NAME)
+        assertThat(record.eventName).isEqualTo(DEVICE_POWER_SAVE_MODE_CHANGE_EVENT_NAME)
         assertThat(record.attributes.get(ANDROID_POWER_SAVE_MODE_ENABLED_KEY))
             .isEqualTo(false)
     }

--- a/instrumentation/power-save-mode/src/test/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeInstrumentationTest.kt
+++ b/instrumentation/power-save-mode/src/test/java/io/opentelemetry/android/instrumentation/powersavemode/PowerSaveModeInstrumentationTest.kt
@@ -16,6 +16,7 @@ import io.mockk.mockk
 import io.mockk.unmockkAll
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.semconv.AndroidAttributes.ANDROID_POWER_SAVE_MODE_ENABLED_KEY
+import io.opentelemetry.android.semconv.events.DevicePowerSaveModeChangeEvent.Companion.DEVICE_POWER_SAVE_MODE_CHANGE_EVENT_NAME
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
@@ -24,8 +25,6 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Shadows.shadowOf
-
-private const val EVENT_NAME = "device.power_save_mode.change"
 
 @RunWith(AndroidJUnit4::class)
 class PowerSaveModeInstrumentationTest {
@@ -61,7 +60,7 @@ class PowerSaveModeInstrumentationTest {
 
         assertThat(openTelemetryRule.logRecords).hasSize(1)
         val record = openTelemetryRule.logRecords.single()
-        assertThat(record.eventName).isEqualTo(EVENT_NAME)
+        assertThat(record.eventName).isEqualTo(DEVICE_POWER_SAVE_MODE_CHANGE_EVENT_NAME)
         assertThat(record.attributes.get(ANDROID_POWER_SAVE_MODE_ENABLED_KEY))
             .isEqualTo(true)
     }

--- a/instrumentation/screen-orientation/src/test/java/io/opentelemetry/android/instrumentation/screenorientation/ScreenOrientationDetectorTest.kt
+++ b/instrumentation/screen-orientation/src/test/java/io/opentelemetry/android/instrumentation/screenorientation/ScreenOrientationDetectorTest.kt
@@ -11,6 +11,7 @@ import android.content.res.Configuration.ORIENTATION_PORTRAIT
 import io.mockk.every
 import io.mockk.mockk
 import io.opentelemetry.android.semconv.ScreenAttributes.SCREEN_ORIENTATION_KEY
+import io.opentelemetry.android.semconv.events.DeviceScreenOrientationEvent.Companion.DEVICE_SCREEN_ORIENTATION_EVENT_NAME
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNull
@@ -18,8 +19,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.jupiter.api.assertNotNull
-
-private const val EVENT_NAME = "device.screen_orientation"
 
 class ScreenOrientationDetectorTest {
     private lateinit var sut: ScreenOrientationDetector
@@ -61,7 +60,7 @@ class ScreenOrientationDetectorTest {
         )
 
         // then
-        val record = openTelemetryRule.logRecords.find { it.eventName == EVENT_NAME }
+        val record = openTelemetryRule.logRecords.find { it.eventName == DEVICE_SCREEN_ORIENTATION_EVENT_NAME }
         assertEquals(1, openTelemetryRule.logRecords.size)
         assertNotNull(record)
         assertEquals("landscape", record.attributes.get(SCREEN_ORIENTATION_KEY))
@@ -78,6 +77,8 @@ class ScreenOrientationDetectorTest {
 
         // then
         assertEquals(0, openTelemetryRule.logRecords.size)
-        assertNull(openTelemetryRule.logRecords.find { it.eventName == EVENT_NAME })
+        assertNull(
+            openTelemetryRule.logRecords.find { it.eventName == DEVICE_SCREEN_ORIENTATION_EVENT_NAME },
+        )
     }
 }

--- a/instrumentation/sessions/src/test/kotlin/io/opentelemetry/android/instrumentation/sessions/SessionIdEventSenderTest.kt
+++ b/instrumentation/sessions/src/test/kotlin/io/opentelemetry/android/instrumentation/sessions/SessionIdEventSenderTest.kt
@@ -7,6 +7,8 @@ package io.opentelemetry.android.instrumentation.sessions
 
 import io.opentelemetry.android.semconv.SessionAttributes.SESSION_ID_KEY
 import io.opentelemetry.android.semconv.SessionAttributes.SESSION_PREVIOUS_ID_KEY
+import io.opentelemetry.android.semconv.events.SessionEndEvent.Companion.SESSION_END_EVENT_NAME
+import io.opentelemetry.android.semconv.events.SessionStartEvent.Companion.SESSION_START_EVENT_NAME
 import io.opentelemetry.android.session.Session
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
@@ -42,7 +44,7 @@ class SessionIdEventSenderTest {
         sender.onSessionStarted(newSession, previousSession)
         assertThat(otelTesting.logRecords).hasSize(1)
         val event = otelTesting.logRecords[0]
-        assertThat(event.eventName).isEqualTo("session.start")
+        assertThat(event.eventName).isEqualTo(SESSION_START_EVENT_NAME)
         assertThat(event.attributes.get(SESSION_ID_KEY)).isEqualTo(newSession.id)
         assertThat(event.attributes.get(SESSION_PREVIOUS_ID_KEY)).isNull()
     }
@@ -55,7 +57,7 @@ class SessionIdEventSenderTest {
         sender.onSessionStarted(newSession, previousSession)
         assertThat(otelTesting.logRecords).hasSize(1)
         val event = otelTesting.logRecords[0]
-        assertThat(event.eventName).isEqualTo("session.start")
+        assertThat(event.eventName).isEqualTo(SESSION_START_EVENT_NAME)
         assertThat(event.attributes.get(SESSION_ID_KEY)).isEqualTo(newSession.id)
         assertThat(event.attributes.get(SESSION_PREVIOUS_ID_KEY)).isEqualTo(previousSession.id)
     }
@@ -67,7 +69,7 @@ class SessionIdEventSenderTest {
         sender.onSessionEnded(session)
         assertThat(otelTesting.logRecords).hasSize(1)
         val event = otelTesting.logRecords[0]
-        assertThat(event.eventName).isEqualTo("session.end")
+        assertThat(event.eventName).isEqualTo(SESSION_END_EVENT_NAME)
         assertThat(event.attributes.get(SESSION_ID_KEY)).isEqualTo(session.id)
         assertThat(event.attributes.get(SESSION_PREVIOUS_ID_KEY)).isNull()
     }

--- a/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/EventJankReporterTest.kt
+++ b/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/EventJankReporterTest.kt
@@ -11,6 +11,7 @@ import io.mockk.mockkStatic
 import io.opentelemetry.android.semconv.AppAttributes.APP_JANK_FRAME_COUNT_KEY
 import io.opentelemetry.android.semconv.AppAttributes.APP_JANK_PERIOD_KEY
 import io.opentelemetry.android.semconv.AppAttributes.APP_JANK_THRESHOLD_KEY
+import io.opentelemetry.android.semconv.events.AppJankEvent.Companion.APP_JANK_EVENT_NAME
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
@@ -35,7 +36,7 @@ class EventJankReporterTest {
 
         assertThat(otelTesting.logRecords.size).isEqualTo(1)
         val log = otelTesting.logRecords.get(0)
-        assertThat(log.eventName).isEqualTo("app.jank")
+        assertThat(log.eventName).isEqualTo(APP_JANK_EVENT_NAME)
         assertThat(log.attributes.get(APP_JANK_FRAME_COUNT_KEY)).isEqualTo(1)
         assertThat(log.attributes.get(APP_JANK_PERIOD_KEY)).isEqualTo(10.5)
         assertThat(log.attributes.get(APP_JANK_THRESHOLD_KEY)).isEqualTo(0.6)

--- a/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderListenerTest.kt
+++ b/instrumentation/slowrendering/src/test/java/io/opentelemetry/android/instrumentation/slowrendering/SlowRenderListenerTest.kt
@@ -23,6 +23,7 @@ import io.mockk.verify
 import io.opentelemetry.android.semconv.AppAttributes.APP_JANK_FRAME_COUNT_KEY
 import io.opentelemetry.android.semconv.AppAttributes.APP_JANK_PERIOD_KEY
 import io.opentelemetry.android.semconv.AppAttributes.APP_JANK_THRESHOLD_KEY
+import io.opentelemetry.android.semconv.events.AppJankEvent.Companion.APP_JANK_EVENT_NAME
 import io.opentelemetry.api.logs.Logger
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
 import kotlinx.coroutines.Runnable
@@ -241,13 +242,13 @@ class SlowRenderListenerTest {
         assertThat(otelTesting.logRecords).hasSize(2)
 
         val slowLog = otelTesting.logRecords[0]
-        assertThat(slowLog.eventName).isEqualTo("app.jank")
+        assertThat(slowLog.eventName).isEqualTo(APP_JANK_EVENT_NAME)
         assertThat(slowLog.attributes.get(APP_JANK_FRAME_COUNT_KEY)).isEqualTo(4)
         assertThat(slowLog.attributes.get(APP_JANK_PERIOD_KEY)).isEqualTo(periodSeconds)
         assertThat(slowLog.attributes.get(APP_JANK_THRESHOLD_KEY)).isEqualTo(0.016)
 
         val frozenLog = otelTesting.logRecords[1]
-        assertThat(frozenLog.eventName).isEqualTo("app.jank")
+        assertThat(frozenLog.eventName).isEqualTo(APP_JANK_EVENT_NAME)
         assertThat(frozenLog.attributes.get(APP_JANK_FRAME_COUNT_KEY)).isEqualTo(1)
         assertThat(frozenLog.attributes.get(APP_JANK_PERIOD_KEY)).isEqualTo(periodSeconds)
         assertThat(frozenLog.attributes.get(APP_JANK_THRESHOLD_KEY)).isEqualTo(0.7)

--- a/instrumentation/startup/build.gradle.kts
+++ b/instrumentation/startup/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
     implementation(project(":session"))
     implementation(project(":semconv"))
     implementation(libs.androidx.core)
-    implementation(libs.opentelemetry.semconv.kotlin)
     implementation(libs.opentelemetry.sdk)
     implementation(libs.opentelemetry.instrumentation.api)
     testImplementation(project(":test-common"))

--- a/instrumentation/thermal/src/test/java/io/opentelemetry/android/instrumentation/thermal/ThermalDetectorTest.kt
+++ b/instrumentation/thermal/src/test/java/io/opentelemetry/android/instrumentation/thermal/ThermalDetectorTest.kt
@@ -7,13 +7,12 @@ package io.opentelemetry.android.instrumentation.thermal
 
 import android.os.PowerManager
 import io.opentelemetry.android.semconv.AndroidAttributes.ANDROID_THERMAL_THROTTLING_STATUS_KEY
+import io.opentelemetry.android.semconv.events.DeviceThermalStatusChangeEvent.Companion.DEVICE_THERMAL_STATUS_CHANGE_EVENT_NAME
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
-
-private const val EVENT_NAME = "device.thermal_status.change"
 
 class ThermalDetectorTest {
     private lateinit var detector: ThermalDetector
@@ -40,7 +39,7 @@ class ThermalDetectorTest {
         // then
         assertThat(openTelemetryRule.logRecords).hasSize(1)
         val record = openTelemetryRule.logRecords.single()
-        assertThat(record.eventName).isEqualTo(EVENT_NAME)
+        assertThat(record.eventName).isEqualTo(DEVICE_THERMAL_STATUS_CHANGE_EVENT_NAME)
         assertThat(record.attributes.get(ANDROID_THERMAL_THROTTLING_STATUS_KEY))
             .isEqualTo("severe")
     }

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
@@ -10,12 +10,12 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
-import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_CLICK_EVENT_NAME
 import io.opentelemetry.android.instrumentation.view.click.internal.Gesture
-import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_CLICK_EVENT_NAME
+import io.opentelemetry.android.semconv.events.AppScreenClickEvent.Companion.APP_SCREEN_CLICK_EVENT_NAME
 import io.opentelemetry.android.semconv.events.AppScreenFlingEvent
 import io.opentelemetry.android.semconv.events.AppScreenLongpressEvent
 import io.opentelemetry.android.semconv.events.AppScreenScrollEvent
+import io.opentelemetry.android.semconv.events.AppWidgetClickEvent.Companion.APP_WIDGET_CLICK_EVENT_NAME
 import io.opentelemetry.android.semconv.events.AppWidgetFlingEvent
 import io.opentelemetry.android.semconv.events.AppWidgetLongpressEvent
 import io.opentelemetry.android.semconv.events.AppWidgetScrollEvent
@@ -50,7 +50,7 @@ internal class ViewClickEventGenerator(
                         .emit()
 
                     findTargetForTap(window.decorView, safeEvent.x, safeEvent.y)?.let { view ->
-                        createEvent(VIEW_CLICK_EVENT_NAME, gesture)
+                        createEvent(APP_WIDGET_CLICK_EVENT_NAME, gesture)
                             .setAllAttributes(createViewAttributes(view))
                             .emit()
                     }
@@ -72,7 +72,7 @@ internal class ViewClickEventGenerator(
                         .emit()
 
                     findTargetForTap(window.decorView, safeEvent.x, safeEvent.y)?.let { view ->
-                        createEvent(VIEW_CLICK_EVENT_NAME, gesture)
+                        createEvent(APP_WIDGET_CLICK_EVENT_NAME, gesture)
                             .setAllAttributes(createViewAttributes(view))
                             .emit()
                     }

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/internal/ViewUtils.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/internal/ViewUtils.kt
@@ -15,9 +15,6 @@ import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_VELOCITY_X_KEY
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_VELOCITY_Y_KEY
 import io.opentelemetry.api.common.Attributes
 
-internal const val APP_SCREEN_CLICK_EVENT_NAME = "app.screen.click"
-internal const val VIEW_CLICK_EVENT_NAME = "app.widget.click"
-
 internal fun buttonStateToString(buttonStateInt: Int): String? =
     when (buttonStateInt) {
         MotionEvent.BUTTON_PRIMARY, MotionEvent.BUTTON_STYLUS_PRIMARY -> "primary"

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
@@ -27,11 +27,11 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import io.opentelemetry.android.OpenTelemetryRum
-import io.opentelemetry.android.instrumentation.view.click.internal.APP_SCREEN_CLICK_EVENT_NAME
-import io.opentelemetry.android.instrumentation.view.click.internal.VIEW_CLICK_EVENT_NAME
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_BUTTON_KEY
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_CLICKS_KEY
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_TYPE_KEY
+import io.opentelemetry.android.semconv.events.AppScreenClickEvent.Companion.APP_SCREEN_CLICK_EVENT_NAME
+import io.opentelemetry.android.semconv.events.AppWidgetClickEvent.Companion.APP_WIDGET_CLICK_EVENT_NAME
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.common.AttributeKey.longKey
 import io.opentelemetry.api.common.AttributeKey.stringKey
@@ -138,7 +138,7 @@ class ViewClickInstrumentationTest {
 
         event = events[1]
         assertThat(event)
-            .hasEventName(VIEW_CLICK_EVENT_NAME)
+            .hasEventName(APP_WIDGET_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
                 equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
@@ -210,7 +210,7 @@ class ViewClickInstrumentationTest {
 
         event = events[1]
         assertThat(event)
-            .hasEventName(VIEW_CLICK_EVENT_NAME)
+            .hasEventName(APP_WIDGET_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
                 equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
@@ -383,7 +383,7 @@ class ViewClickInstrumentationTest {
         event = events[1]
         OpenTelemetryAssertions
             .assertThat(event)
-            .hasEventName(VIEW_CLICK_EVENT_NAME)
+            .hasEventName(APP_WIDGET_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
                 equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
@@ -453,7 +453,7 @@ class ViewClickInstrumentationTest {
         event = events[1]
         OpenTelemetryAssertions
             .assertThat(event)
-            .hasEventName(VIEW_CLICK_EVENT_NAME)
+            .hasEventName(APP_WIDGET_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
                 equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
@@ -522,7 +522,7 @@ class ViewClickInstrumentationTest {
 
         event = events[1]
         assertThat(event)
-            .hasEventName(VIEW_CLICK_EVENT_NAME)
+            .hasEventName(APP_WIDGET_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
                 equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
@@ -593,7 +593,7 @@ class ViewClickInstrumentationTest {
 
         event = events[1]
         assertThat(event)
-            .hasEventName(VIEW_CLICK_EVENT_NAME)
+            .hasEventName(APP_WIDGET_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
                 equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
@@ -729,7 +729,7 @@ class ViewClickInstrumentationTest {
         event = events[1]
         OpenTelemetryAssertions
             .assertThat(event)
-            .hasEventName(VIEW_CLICK_EVENT_NAME)
+            .hasEventName(APP_WIDGET_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
                 equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewLongPressInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewLongPressInstrumentationTest.kt
@@ -23,6 +23,8 @@ import io.mockk.slot
 import io.mockk.verify
 import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_TYPE_KEY
+import io.opentelemetry.android.semconv.events.AppScreenLongpressEvent.Companion.APP_SCREEN_LONGPRESS_EVENT_NAME
+import io.opentelemetry.android.semconv.events.AppWidgetLongpressEvent.Companion.APP_WIDGET_LONGPRESS_EVENT_NAME
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.common.AttributeKey.longKey
 import io.opentelemetry.api.common.AttributeKey.stringKey
@@ -41,9 +43,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.runner.RunWith
-
-private const val APP_SCREEN_LONG_PRESS_EVENT_NAME = "app.screen.longpress"
-private const val VIEW_LONG_PRESS_EVENT_NAME = "app.widget.longpress"
 
 @OptIn(IncubatingApi::class)
 @RunWith(AndroidJUnit4::class)
@@ -121,7 +120,7 @@ class ViewLongPressInstrumentationTest {
 
         var event = events[0]
         assertThat(event)
-            .hasEventName(APP_SCREEN_LONG_PRESS_EVENT_NAME)
+            .hasEventName(APP_SCREEN_LONGPRESS_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(longKey(APP_SCREEN_COORDINATE_X), motionEvent.x.toLong()),
                 equalTo(longKey(APP_SCREEN_COORDINATE_Y), motionEvent.y.toLong()),
@@ -130,7 +129,7 @@ class ViewLongPressInstrumentationTest {
 
         event = events[1]
         assertThat(event)
-            .hasEventName(VIEW_LONG_PRESS_EVENT_NAME)
+            .hasEventName(APP_WIDGET_LONGPRESS_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
                 equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
@@ -187,7 +186,7 @@ class ViewLongPressInstrumentationTest {
 
         var event = events[0]
         assertThat(event)
-            .hasEventName(APP_SCREEN_LONG_PRESS_EVENT_NAME)
+            .hasEventName(APP_SCREEN_LONGPRESS_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(longKey(APP_SCREEN_COORDINATE_X), initialDownEvent.x.toLong()),
                 equalTo(longKey(APP_SCREEN_COORDINATE_Y), initialDownEvent.y.toLong()),
@@ -196,7 +195,7 @@ class ViewLongPressInstrumentationTest {
 
         event = events[1]
         assertThat(event)
-            .hasEventName(VIEW_LONG_PRESS_EVENT_NAME)
+            .hasEventName(APP_WIDGET_LONGPRESS_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
                 equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
@@ -258,7 +257,7 @@ class ViewLongPressInstrumentationTest {
         var event = events[0]
         OpenTelemetryAssertions
             .assertThat(event)
-            .hasEventName(APP_SCREEN_LONG_PRESS_EVENT_NAME)
+            .hasEventName(APP_SCREEN_LONGPRESS_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(longKey(APP_SCREEN_COORDINATE_X), initialDownEvent.x.toLong()),
                 equalTo(longKey(APP_SCREEN_COORDINATE_Y), initialDownEvent.y.toLong()),
@@ -268,7 +267,7 @@ class ViewLongPressInstrumentationTest {
         event = events[1]
         OpenTelemetryAssertions
             .assertThat(event)
-            .hasEventName(VIEW_LONG_PRESS_EVENT_NAME)
+            .hasEventName(APP_WIDGET_LONGPRESS_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
                 equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewScrollInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewScrollInstrumentationTest.kt
@@ -29,6 +29,10 @@ import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_DISTANCE_Y_KEY
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_TYPE_KEY
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_VELOCITY_X_KEY
 import io.opentelemetry.android.semconv.HwAttributes.HW_POINTER_VELOCITY_Y_KEY
+import io.opentelemetry.android.semconv.events.AppScreenFlingEvent.Companion.APP_SCREEN_FLING_EVENT_NAME
+import io.opentelemetry.android.semconv.events.AppScreenScrollEvent.Companion.APP_SCREEN_SCROLL_EVENT_NAME
+import io.opentelemetry.android.semconv.events.AppWidgetFlingEvent.Companion.APP_WIDGET_FLING_EVENT_NAME
+import io.opentelemetry.android.semconv.events.AppWidgetScrollEvent.Companion.APP_WIDGET_SCROLL_EVENT_NAME
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.common.AttributeKey.longKey
 import io.opentelemetry.api.common.AttributeKey.stringKey
@@ -46,11 +50,6 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.runner.RunWith
-
-private const val APP_SCREEN_FLING_EVENT_NAME = "app.screen.fling"
-private const val APP_SCREEN_SCROLL_EVENT_NAME = "app.screen.scroll"
-private const val VIEW_FLING_EVENT_NAME = "app.widget.fling"
-private const val VIEW_SCROLL_EVENT_NAME = "app.widget.scroll"
 
 @RunWith(AndroidJUnit4::class)
 @ExtendWith(MockKExtension::class)
@@ -138,7 +137,7 @@ class ViewScrollInstrumentationTest {
 
         event = events[1]
         assertThat(event)
-            .hasEventName(VIEW_SCROLL_EVENT_NAME)
+            .hasEventName(APP_WIDGET_SCROLL_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
                 equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),
@@ -266,7 +265,7 @@ class ViewScrollInstrumentationTest {
 
         event = events[3]
         assertThat(event)
-            .hasEventName(VIEW_FLING_EVENT_NAME)
+            .hasEventName(APP_WIDGET_FLING_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(longKey(APP_SCREEN_COORDINATE_X), mockView.x.toLong()),
                 equalTo(longKey(APP_SCREEN_COORDINATE_Y), mockView.y.toLong()),

--- a/semconv/templates/registry/kotlin/kotlin_event_template.kt.j2
+++ b/semconv/templates/registry/kotlin/kotlin_event_template.kt.j2
@@ -26,6 +26,10 @@ class {{ my_class_name }}(
     val {{ attribute.name | camel_case }}: {{ attribute.type | instantiated_type | map_text("kotlin_event_type") }}{{ '?' if not required else '' }}{{ ' = null' if not required else '' }},
 {%- endfor %}
 ) : OpenTelemetryEvent {
+    companion object {
+        const val {{ ctx.name | screaming_snake_case }}_EVENT_NAME: String = "{{ ctx.name }}"
+    }
+
     override fun emit(
         logger: Logger,
         additionalAttributes: Attributes,
@@ -43,7 +47,7 @@ class {{ my_class_name }}(
 
         logger
             .logRecordBuilder()
-            .setEventName("{{ ctx.name }}")
+            .setEventName({{ ctx.name | screaming_snake_case }}_EVENT_NAME)
             .setAllAttributes(attributes.build())
             .emit()
     }


### PR DESCRIPTION
Builds upon #1950 and will get a rebase after that one merges.

This generates a constant for the event names, and plugs them into both the event class usages and also the tests.