### PR TITLE
Optimize service loader initialization

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/instrumentation/AndroidInstrumentationLoaderImpl.kt
+++ b/core/src/main/java/io/opentelemetry/android/instrumentation/AndroidInstrumentationLoaderImpl.kt
@@ -11,10 +11,26 @@ import java.util.ServiceLoader
 
 internal class AndroidInstrumentationLoaderImpl : AndroidInstrumentationLoader {
     private val instrumentations: MutableMap<Class<out AndroidInstrumentation>, AndroidInstrumentation> by lazy {
-        ServiceLoader
-            .load(AndroidInstrumentation::class.java)
+        loadInstrumentations()
             .associateBy { it.javaClass }
             .toMutableMap()
+    }
+
+    /**
+     * Loads the [AndroidInstrumentation] implementations declared via SPI. Before making changes to
+     * this function please study R8's ServiceLoaderRewriter as it replaces
+     * reflective lookup with direct instantiation, keeping reflection off the startup path. The
+     * two-argument `load` overload, the literal class reference and the local for-each are all
+     * required for this optimization to occur.
+     *
+     * https://r8.googlesource.com/r8/+/refs/heads/main/src/main/java/com/android/tools/r8/ir/optimize/ServiceLoaderRewriter.java
+     */
+    private fun loadInstrumentations(): List<AndroidInstrumentation> {
+        val instrumentations = mutableListOf<AndroidInstrumentation>()
+        for (instrumentation in ServiceLoader.load(AndroidInstrumentation::class.java, AndroidInstrumentation::class.java.classLoader)) {
+            instrumentations.add(instrumentation)
+        }
+        return instrumentations
     }
 
     @Suppress("UNCHECKED_CAST")

--- a/core/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurators.kt
+++ b/core/src/main/java/io/opentelemetry/android/instrumentation/InstrumentationConfigurators.kt
@@ -15,12 +15,25 @@ internal class InstrumentationConfigurators
         private val configurators: Map<Class<out AndroidInstrumentation>, List<Konfigurator>>,
     ) {
         companion object {
-            fun create(): InstrumentationConfigurators = create { ServiceLoader.load(Konfigurator::class.java) }
+            fun create(): InstrumentationConfigurators = create { loadConfigurators() }
 
             // Exists for testing
             inline fun create(loader: () -> Iterable<Konfigurator>): InstrumentationConfigurators {
                 val configurators = loader().groupBy { it.instrumentationType }
                 return InstrumentationConfigurators(configurators)
+            }
+
+            /**
+             * Loads the [InstrumentationConfigurator] implementations declared via SPI. See the R8
+             * note on [AndroidInstrumentationLoaderImpl.loadInstrumentations] before changing the
+             * shape of this function.
+             */
+            private fun loadConfigurators(): List<Konfigurator> {
+                val configurators = mutableListOf<Konfigurator>()
+                for (configurator in ServiceLoader.load(Konfigurator::class.java, Konfigurator::class.java.classLoader)) {
+                    configurators.add(configurator)
+                }
+                return configurators
             }
         }
 

--- a/core/src/main/java/io/opentelemetry/android/internal/initialization/InitializationEvents.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/initialization/InitializationEvents.kt
@@ -7,7 +7,7 @@ package io.opentelemetry.android.internal.initialization
 
 import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.sdk.trace.export.SpanExporter
-import java.util.ServiceLoader.load
+import java.util.ServiceLoader
 
 /**
  * This class is internal and not for public use. Its APIs are unstable and can change at any time.
@@ -35,7 +35,7 @@ interface InitializationEvents {
         @JvmStatic
         fun get(): InitializationEvents {
             if (instance == null) {
-                val initializationEvents = load(InitializationEvents::class.java).firstOrNull()
+                val initializationEvents = loadInitializationEvents().firstOrNull()
                 if (initializationEvents != null) {
                     set(initializationEvents)
                 } else {
@@ -77,4 +77,17 @@ interface InitializationEvents {
                 override fun spanExporterInitialized(spanExporter: SpanExporter) {}
             }
     }
+}
+
+/**
+ * Loads the [InitializationEvents] implementations declared via SPI. See the R8 note on
+ * `AndroidInstrumentationLoaderImpl.loadInstrumentations` before changing the shape of this
+ * function.
+ */
+private fun loadInitializationEvents(): List<InitializationEvents> {
+    val events = mutableListOf<InitializationEvents>()
+    for (event in ServiceLoader.load(InitializationEvents::class.java, InitializationEvents::class.java.classLoader)) {
+        events.add(event)
+    }
+    return events
 }


### PR DESCRIPTION
## Goal

Allows R8 to optimize SPI by replacing reflexive instantiations during SDK initialization with a direct call in the bytecode. The previous approach to using `ServiceLoader` didn't fit the criteria that R8's rules use for optimizations so wasn't optimized.