### PR TITLE
feat(compose-navigation): emit app.navigation.complete event on destination change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### 📈 Enhancements
 
 - The Compose Navigation instrumentation, which shipped in 1.6.0 without emitting any telemetry,
-  now records an `app.navigation` event carrying the `app.navigation.destination.name` attribute
-  whenever a navigation completes.
+  now records an `app.navigation.complete` event carrying the `app.navigation.destination.name`
+  attribute whenever a navigation completes.
   ([#1920](https://github.com/open-telemetry/opentelemetry-android/issues/1920))
 
 ### 🛠️ Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### 📈 Enhancements
+
+- The Compose Navigation instrumentation, which shipped in 1.6.0 without emitting any telemetry,
+  now records an `app.navigation` event carrying the `app.navigation.destination.name` attribute
+  whenever a navigation completes.
+  ([#1920](https://github.com/open-telemetry/opentelemetry-android/issues/1920))
+
 ### 🛠️ Bug fixes
 
 - Preserve explicit session IDs on logs so recovered native crashes and session-end events remain
@@ -21,8 +28,10 @@ priorities and future direction.
   context.
   ([#1887](https://github.com/open-telemetry/opentelemetry-android/pull/1887),
   [#1899](https://github.com/open-telemetry/opentelemetry-android/pull/1899))
-- Add manual Jetpack Compose Navigation 2 instrumentation that emits an `app.screen.view` event
-  when the navigation destination changes.
+- Add manual Jetpack Compose Navigation 2 instrumentation that resolves a screen name whenever the
+  navigation destination changes. Note: this release emits no telemetry for those changes. An
+  earlier version of this entry incorrectly stated that it emits an `app.screen.view` event; event
+  emission was removed during review of the pull request and did not ship in 1.6.0.
   ([#1901](https://github.com/open-telemetry/opentelemetry-android/pull/1901))
 
 ### 📈 Enhancements

--- a/instrumentation/compose/navigation/README.md
+++ b/instrumentation/compose/navigation/README.md
@@ -19,13 +19,27 @@ This instrumentation is not currently enabled by default.
 
 ## Telemetry
 
-This instrumentation does not emit any telemetry yet. Destination changes are
-resolved to screen names (by default the route *pattern*, for example
-`user/{id}` — not the filled-in arguments — to avoid leaking PII). How they are
-reported — as an event and/or as screen attribution on other telemetry — is
-tracked in
-[#1909](https://github.com/open-telemetry/opentelemetry-android/issues/1909),
-pending the mobile semantic-conventions discussion on modelling navigation.
+This instrumentation produces the following telemetry:
+
+### Navigation
+
+* Type: Event
+* Name: `app.navigation`
+* Description: An event that fires whenever a navigation completes, that is,
+  whenever the destination of an instrumented `NavController` changes.
+* Attributes:
+
+| Attribute | Type | Description | Values | Requirement Level |
+|---|---|---|---|---|
+| `app.navigation.destination.name` | string | The name of the navigation destination reached by the completed navigation. | `home`; `user/{id}` | Required |
+
+The destination name defaults to the route *pattern*, for example `user/{id}` —
+not the filled-in arguments — to avoid leaking PII. Override it with the
+`screenName` parameter shown below.
+
+Using these Compose screen names for screen attribution on unrelated telemetry
+is tracked separately in
+[#1909](https://github.com/open-telemetry/opentelemetry-android/issues/1909).
 
 ## Installation
 

--- a/instrumentation/compose/navigation/README.md
+++ b/instrumentation/compose/navigation/README.md
@@ -24,9 +24,9 @@ This instrumentation produces the following telemetry:
 ### Navigation
 
 * Type: Event
-* Name: `app.navigation`
-* Description: An event that fires whenever a navigation completes, that is,
-  whenever the destination of an instrumented `NavController` changes.
+* Name: `app.navigation.complete`
+* Description: An event that fires on every completed navigation of an instrumented
+  `NavController`, plus on listener attach (see below).
 * Attributes:
 
 | Attribute | Type | Description | Values | Requirement Level |
@@ -36,6 +36,17 @@ This instrumentation produces the following telemetry:
 The destination name defaults to the route *pattern*, for example `user/{id}` —
 not the filled-in arguments — to avoid leaking PII. Override it with the
 `screenName` parameter shown below.
+
+The event maps 1:1 to `NavController.OnDestinationChangedListener` callbacks, so it
+also fires:
+
+* **on attach** — registering replays the current destination, so the screen visible
+  at attach time is recorded. A configuration change re-attaches and replays again
+  without a navigation. The replay supplies no `arguments`, even for a parameterised
+  start destination.
+* **on argument-only changes** — `user/1` → `user/2` is a real navigation, but the
+  default resolver names both `user/{id}`. Read `arguments` in `screenName` to tell
+  them apart, subject to the attach caveat above.
 
 Using these Compose screen names for screen attribution on unrelated telemetry
 is tracked separately in

--- a/instrumentation/compose/navigation/src/main/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavControllerExtensions.kt
+++ b/instrumentation/compose/navigation/src/main/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavControllerExtensions.kt
@@ -24,6 +24,11 @@ import io.opentelemetry.android.OpenTelemetryRum
  * `app.navigation.complete` event through [rum]. The listener is scoped to the composition via
  * [DisposableEffect] and removed when the controller leaves it.
  *
+ * Registering the listener replays the current destination, so attaching emits for the screen
+ * already showing, and re-attaching (for example after a configuration change) emits again without
+ * a navigation. The replay supplies no arguments, even for a parameterised start destination. See
+ * the module README for the full event contract.
+ *
  * Works for any controller you already hold, including nested/child controllers, not just the host
  * controller returned by `rememberNavController()`. The receiver is returned with its static type
  * preserved (e.g. [NavHostController]), so the call can be grafted onto a `rememberNavController()`

--- a/instrumentation/compose/navigation/src/main/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavControllerExtensions.kt
+++ b/instrumentation/compose/navigation/src/main/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavControllerExtensions.kt
@@ -20,9 +20,9 @@ import io.opentelemetry.android.OpenTelemetryRum
 
 /**
  * Attaches OpenTelemetry navigation instrumentation to this [NavController]: on every completed
- * destination change the new destination is resolved to a screen name and handed to the
- * instrumentation backed by [rum] (telemetry emission is tracked in issue #1909). The listener is
- * scoped to the composition via [DisposableEffect] and removed when the controller leaves it.
+ * destination change, the new destination is resolved to a screen name and emitted as an
+ * `app.navigation` event through [rum]. The listener is scoped to the composition via
+ * [DisposableEffect] and removed when the controller leaves it.
  *
  * Works for any controller you already hold, including nested/child controllers, not just the host
  * controller returned by `rememberNavController()`. The receiver is returned with its static type

--- a/instrumentation/compose/navigation/src/main/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavControllerExtensions.kt
+++ b/instrumentation/compose/navigation/src/main/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavControllerExtensions.kt
@@ -21,7 +21,7 @@ import io.opentelemetry.android.OpenTelemetryRum
 /**
  * Attaches OpenTelemetry navigation instrumentation to this [NavController]: on every completed
  * destination change, the new destination is resolved to a screen name and emitted as an
- * `app.navigation` event through [rum]. The listener is scoped to the composition via
+ * `app.navigation.complete` event through [rum]. The listener is scoped to the composition via
  * [DisposableEffect] and removed when the controller leaves it.
  *
  * Works for any controller you already hold, including nested/child controllers, not just the host
@@ -77,7 +77,7 @@ internal fun NavController.attachOpenTelemetry(
 ): NavController.OnDestinationChangedListener {
     val listener =
         NavController.OnDestinationChangedListener { _, destination, arguments ->
-            emitter().onScreenView(screenName()(destination, arguments))
+            emitter().onNavigation(screenName()(destination, arguments))
         }
     addOnDestinationChangedListener(listener)
     return listener

--- a/instrumentation/compose/navigation/src/main/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationEmitter.kt
+++ b/instrumentation/compose/navigation/src/main/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationEmitter.kt
@@ -13,7 +13,11 @@ internal const val INSTRUMENTATION_SCOPE_NAME =
     "io.opentelemetry.android.instrumentation.compose.navigation"
 
 /**
- * Emits an `app.navigation.complete` event each time a navigation completes (the destination changes).
+ * Emits an `app.navigation.complete` event for each screen name it is handed.
+ *
+ * Callers drive this from a [androidx.navigation.NavController.OnDestinationChangedListener], which
+ * is not one-to-one with user-initiated navigation: it also replays the current destination when the
+ * listener is registered, so re-attaching emits without a navigation having happened.
  */
 internal class NavigationEmitter(
     private val eventLogger: Logger,

--- a/instrumentation/compose/navigation/src/main/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationEmitter.kt
+++ b/instrumentation/compose/navigation/src/main/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationEmitter.kt
@@ -6,19 +6,16 @@
 package io.opentelemetry.instrumentation.compose.navigation
 
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.semconv.events.AppNavigationEvent
 import io.opentelemetry.api.logs.Logger
 
 internal const val INSTRUMENTATION_SCOPE_NAME =
     "io.opentelemetry.android.instrumentation.compose.navigation"
 
 /**
- * Receives the resolved screen name each time a navigation completes (the destination changes).
- * Telemetry emission is tracked in issue #1909, pending the mobile semantic-conventions
- * discussion on modelling navigation.
+ * Emits an `app.navigation` event each time a navigation completes (the destination changes).
  */
 internal class NavigationEmitter(
-    // Kept for the event emission implementation tracked in issue #1909.
-    @Suppress("UnusedPrivateProperty", "unused")
     private val eventLogger: Logger,
 ) {
     constructor(rum: OpenTelemetryRum) : this(
@@ -27,8 +24,7 @@ internal class NavigationEmitter(
             .build(),
     )
 
-    @Suppress("UnusedParameter", "UNUSED_PARAMETER")
     fun onScreenView(screenName: String) {
-        // TODO: https://github.com/open-telemetry/opentelemetry-android/issues/1909
+        AppNavigationEvent(appNavigationDestinationName = screenName).emit(eventLogger)
     }
 }

--- a/instrumentation/compose/navigation/src/main/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationEmitter.kt
+++ b/instrumentation/compose/navigation/src/main/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationEmitter.kt
@@ -6,14 +6,14 @@
 package io.opentelemetry.instrumentation.compose.navigation
 
 import io.opentelemetry.android.OpenTelemetryRum
-import io.opentelemetry.android.semconv.events.AppNavigationEvent
+import io.opentelemetry.android.semconv.events.AppNavigationCompleteEvent
 import io.opentelemetry.api.logs.Logger
 
 internal const val INSTRUMENTATION_SCOPE_NAME =
     "io.opentelemetry.android.instrumentation.compose.navigation"
 
 /**
- * Emits an `app.navigation` event each time a navigation completes (the destination changes).
+ * Emits an `app.navigation.complete` event each time a navigation completes (the destination changes).
  */
 internal class NavigationEmitter(
     private val eventLogger: Logger,
@@ -24,7 +24,7 @@ internal class NavigationEmitter(
             .build(),
     )
 
-    fun onScreenView(screenName: String) {
-        AppNavigationEvent(appNavigationDestinationName = screenName).emit(eventLogger)
+    fun onNavigation(screenName: String) {
+        AppNavigationCompleteEvent(appNavigationDestinationName = screenName).emit(eventLogger)
     }
 }

--- a/instrumentation/compose/navigation/src/test/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavControllerExtensionsTest.kt
+++ b/instrumentation/compose/navigation/src/test/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavControllerExtensionsTest.kt
@@ -25,7 +25,7 @@ class NavControllerExtensionsTest {
 
         listener.onDestinationChanged(controller, mockk<NavDestination>(), null)
 
-        verify(exactly = 1) { emitter.onScreenView("home") }
+        verify(exactly = 1) { emitter.onNavigation("home") }
     }
 
     @Test
@@ -40,8 +40,8 @@ class NavControllerExtensionsTest {
         listener.onDestinationChanged(controller, destination, null)
 
         verifyOrder {
-            emitter.onScreenView("first")
-            emitter.onScreenView("second")
+            emitter.onNavigation("first")
+            emitter.onNavigation("second")
         }
     }
 }

--- a/instrumentation/compose/navigation/src/test/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationEmitterTest.kt
+++ b/instrumentation/compose/navigation/src/test/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationEmitterTest.kt
@@ -17,7 +17,7 @@ import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
-// Emitted by the generated AppNavigationEvent (semconv/model/android/events.yaml).
+// Emitted by the generated AppNavigationCompleteEvent (semconv/model/android/events.yaml).
 internal const val NAVIGATION_EVENT_NAME = "app.navigation.complete"
 internal const val DESTINATION_NAME_KEY = "app.navigation.destination.name"
 

--- a/instrumentation/compose/navigation/src/test/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationEmitterTest.kt
+++ b/instrumentation/compose/navigation/src/test/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationEmitterTest.kt
@@ -18,7 +18,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 
 // Emitted by the generated AppNavigationEvent (semconv/model/android/events.yaml).
-internal const val NAVIGATION_EVENT_NAME = "app.navigation"
+internal const val NAVIGATION_EVENT_NAME = "app.navigation.complete"
 internal const val DESTINATION_NAME_KEY = "app.navigation.destination.name"
 
 @RunWith(AndroidJUnit4::class)
@@ -39,7 +39,7 @@ class NavigationEmitterTest {
 
     @Test
     fun `emits a navigation event carrying the destination name`() {
-        navigationEmitter.onScreenView("home")
+        navigationEmitter.onNavigation("home")
 
         val events = openTelemetryRule.logRecords
         assertThat(events).hasSize(1)
@@ -57,7 +57,7 @@ class NavigationEmitterTest {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
             }
 
-        NavigationEmitter(rum).onScreenView("home")
+        NavigationEmitter(rum).onNavigation("home")
 
         val events = openTelemetryRule.logRecords
         assertThat(events).hasSize(1)
@@ -69,9 +69,9 @@ class NavigationEmitterTest {
     }
 
     @Test
-    fun `emits one event per destination change`() {
-        navigationEmitter.onScreenView("home")
-        navigationEmitter.onScreenView("cart")
+    fun `emits one event per onNavigation invocation`() {
+        navigationEmitter.onNavigation("home")
+        navigationEmitter.onNavigation("cart")
 
         val events = openTelemetryRule.logRecords
         assertThat(events).hasSize(2)

--- a/instrumentation/compose/navigation/src/test/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationEmitterTest.kt
+++ b/instrumentation/compose/navigation/src/test/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationEmitterTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.compose.navigation
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.api.common.AttributeKey.stringKey
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
+import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+// Emitted by the generated AppNavigationEvent (semconv/model/android/events.yaml).
+internal const val NAVIGATION_EVENT_NAME = "app.navigation"
+internal const val DESTINATION_NAME_KEY = "app.navigation.destination.name"
+
+@RunWith(AndroidJUnit4::class)
+class NavigationEmitterTest {
+    private lateinit var openTelemetryRule: OpenTelemetryRule
+    private lateinit var navigationEmitter: NavigationEmitter
+
+    @Before
+    fun setup() {
+        openTelemetryRule = OpenTelemetryRule.create()
+        navigationEmitter =
+            NavigationEmitter(
+                openTelemetryRule.openTelemetry.logsBridge
+                    .loggerBuilder(INSTRUMENTATION_SCOPE_NAME)
+                    .build(),
+            )
+    }
+
+    @Test
+    fun `emits a navigation event carrying the destination name`() {
+        navigationEmitter.onScreenView("home")
+
+        val events = openTelemetryRule.logRecords
+        assertThat(events).hasSize(1)
+        assertThat(events[0])
+            .hasEventName(NAVIGATION_EVENT_NAME)
+            .hasAttributesSatisfyingExactly(
+                equalTo(stringKey(DESTINATION_NAME_KEY), "home"),
+            )
+    }
+
+    @Test
+    fun `resolves its logger from an OpenTelemetryRum instance`() {
+        val rum =
+            mockk<OpenTelemetryRum> {
+                every { openTelemetry } returns openTelemetryRule.openTelemetry
+            }
+
+        NavigationEmitter(rum).onScreenView("home")
+
+        val events = openTelemetryRule.logRecords
+        assertThat(events).hasSize(1)
+        assertThat(events[0])
+            .hasEventName(NAVIGATION_EVENT_NAME)
+            .hasAttributesSatisfyingExactly(
+                equalTo(stringKey(DESTINATION_NAME_KEY), "home"),
+            )
+    }
+
+    @Test
+    fun `emits one event per destination change`() {
+        navigationEmitter.onScreenView("home")
+        navigationEmitter.onScreenView("cart")
+
+        val events = openTelemetryRule.logRecords
+        assertThat(events).hasSize(2)
+        assertThat(events[0])
+            .hasEventName(NAVIGATION_EVENT_NAME)
+            .hasAttributesSatisfyingExactly(
+                equalTo(stringKey(DESTINATION_NAME_KEY), "home"),
+            )
+        assertThat(events[1])
+            .hasEventName(NAVIGATION_EVENT_NAME)
+            .hasAttributesSatisfyingExactly(
+                equalTo(stringKey(DESTINATION_NAME_KEY), "cart"),
+            )
+    }
+}

--- a/instrumentation/compose/navigation/src/test/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationEventComposeTest.kt
+++ b/instrumentation/compose/navigation/src/test/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationEventComposeTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.compose.navigation
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.api.common.AttributeKey.stringKey
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.equalTo
+import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * End-to-end coverage: drives a real [NavHostController] through a composition and asserts on the
+ * log records that come out of the SDK, rather than stubbing the controller or the emitter. This is
+ * the only place the listener -> emitter -> logger chain is exercised as a whole.
+ */
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@RunWith(AndroidJUnit4::class)
+class NavigationEventComposeTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private lateinit var otel: OpenTelemetryRule
+    private lateinit var rum: OpenTelemetryRum
+
+    @Before
+    fun setup() {
+        otel = OpenTelemetryRule.create()
+        rum =
+            mockk<OpenTelemetryRum> {
+                every { openTelemetry } returns otel.openTelemetry
+            }
+    }
+
+    private fun destinationNames(): List<String?> = otel.logRecords.map { it.attributes[stringKey(DESTINATION_NAME_KEY)] }
+
+    @Test
+    fun `emits an event for the start destination when the listener attaches`() {
+        composeRule.setContent {
+            val navController = rememberObservedNavController(rum)
+            NavHost(navController, startDestination = "a") {
+                composable("a") {}
+                composable("b") {}
+            }
+        }
+        composeRule.waitForIdle()
+
+        assertThat(otel.logRecords).hasSize(1)
+        assertThat(otel.logRecords[0])
+            .hasEventName(NAVIGATION_EVENT_NAME)
+            .hasAttributesSatisfyingExactly(
+                equalTo(stringKey(DESTINATION_NAME_KEY), "a"),
+            )
+    }
+
+    @Test
+    fun `emits an event through the RUM logger on navigation`() {
+        lateinit var navController: NavHostController
+        composeRule.setContent {
+            navController = rememberObservedNavController(rum)
+            NavHost(navController, startDestination = "a") {
+                composable("a") {}
+                composable("b") {}
+            }
+        }
+
+        composeRule.runOnIdle { navController.navigate("b") }
+        composeRule.waitForIdle()
+
+        assertThat(destinationNames()).containsExactly("a", "b")
+        assertThat(otel.logRecords.last())
+            .hasEventName(NAVIGATION_EVENT_NAME)
+            .hasAttributesSatisfyingExactly(
+                equalTo(stringKey(DESTINATION_NAME_KEY), "b"),
+            )
+    }
+
+    @Test
+    fun `emits an event when only the arguments change`() {
+        lateinit var navController: NavHostController
+        composeRule.setContent {
+            navController = rememberObservedNavController(rum)
+            NavHost(navController, startDestination = "user/1") {
+                composable("user/{id}") {}
+            }
+        }
+
+        composeRule.runOnIdle { navController.navigate("user/2") }
+        composeRule.waitForIdle()
+
+        // A new back stack entry, so a real navigation - but the default resolver reports the route
+        // pattern, so both events carry the same name.
+        assertThat(destinationNames()).containsExactly("user/{id}", "user/{id}")
+    }
+
+    @Test
+    fun `screenName reading arguments tells navigations apart but sees none on attach`() {
+        lateinit var navController: NavHostController
+        composeRule.setContent {
+            navController =
+                rememberObservedNavController(rum, screenName = { _, arguments ->
+                    arguments?.getString("id")?.let { "user/$it" } ?: "user/unknown"
+                })
+            NavHost(navController, startDestination = "user/1") {
+                composable("user/{id}") {}
+            }
+        }
+
+        composeRule.runOnIdle { navController.navigate("user/2") }
+        composeRule.runOnIdle { navController.navigate("user/3") }
+        composeRule.waitForIdle()
+
+        // The attach replay carries a null arguments bundle even for a parameterised start
+        // destination, so `id` is unavailable there; real navigations do supply it.
+        assertThat(destinationNames()).containsExactly("user/unknown", "user/2", "user/3")
+    }
+
+    @Test
+    fun `re-attaching emits again without a navigation`() {
+        var instrumented by mutableStateOf(true)
+        lateinit var navController: NavHostController
+        composeRule.setContent {
+            navController = rememberNavController()
+            if (instrumented) {
+                navController.withOpenTelemetry(rum)
+            }
+            NavHost(navController, startDestination = "a") {
+                composable("a") {}
+                composable("b") {}
+            }
+        }
+        composeRule.waitForIdle()
+        val afterFirstAttach = otel.logRecords.size
+
+        composeRule.runOnIdle { instrumented = false }
+        composeRule.waitForIdle()
+        composeRule.runOnIdle { instrumented = true }
+        composeRule.waitForIdle()
+
+        assertThat(otel.logRecords).hasSize(afterFirstAttach + 1)
+        assertThat(otel.logRecords.last())
+            .hasEventName(NAVIGATION_EVENT_NAME)
+            .hasAttributesSatisfyingExactly(
+                equalTo(stringKey(DESTINATION_NAME_KEY), "a"),
+            )
+    }
+}

--- a/semconv/README.md
+++ b/semconv/README.md
@@ -32,5 +32,3 @@ automatically. To run it explicitly:
 ```bash
 ./gradlew :semconv:generateSemanticConventions
 ```
-
-Production code usage of the generated event classes will be added in a later phase.

--- a/semconv/model/android/events.yaml
+++ b/semconv/model/android/events.yaml
@@ -1,4 +1,13 @@
 groups:
+  - id: event.app.navigation
+    type: event
+    name: app.navigation
+    stability: development
+    brief: >
+      This event represents a completed navigation to a destination of an application.
+    attributes:
+      - ref: app.navigation.destination.name
+        requirement_level: required
   - id: event.app.screen.longpress
     type: event
     name: app.screen.longpress

--- a/semconv/model/android/events.yaml
+++ b/semconv/model/android/events.yaml
@@ -1,5 +1,5 @@
 groups:
-  - id: event.app.navigation
+  - id: event.app.navigation.complete
     type: event
     name: app.navigation.complete
     stability: development

--- a/semconv/model/android/events.yaml
+++ b/semconv/model/android/events.yaml
@@ -1,7 +1,7 @@
 groups:
   - id: event.app.navigation
     type: event
-    name: app.navigation
+    name: app.navigation.complete
     stability: development
     brief: >
       This event represents a completed navigation to a destination of an application.

--- a/semconv/model/android/registry.yaml
+++ b/semconv/model/android/registry.yaml
@@ -39,6 +39,15 @@ groups:
         brief: >
           The Android thermal throttling status.
         examples: ["none", "light", "moderate", "severe", "critical", "emergency", "shutdown", "unknown"]
+      - id: app.navigation.destination.name
+        type: string
+        stability: development
+        brief: >
+          The name of the navigation destination reached by a completed navigation.
+        note: >
+          By default, for route-based navigation this is the route pattern rather than the filled-in
+          arguments, so that argument values are not recorded.
+        examples: ["home", "user/{id}"]
       - id: battery.percent
         type: double
         stability: development


### PR DESCRIPTION
The Compose Navigation instrumentation resolved a screen name on every
completed navigation but did not emit any events. This change
defines `app.navigation.complete` in the local federated semconv registry, add the
`app.navigation.destination.name` attribute it carries, and emit the
generated `AppNavigationCompleteEvent` from `NavigationEmitter`.

The attribute holds the route pattern rather than the filled-in
arguments by default, so argument values are not recorded. Callers who
want something else can still override the existing `screenName` parameter.

Also correct the 1.6.0 changelog entry, which claimed the instrumentation
emits an `app.screen.view` event. That was transcribed from the #1901
description, which had gone stale by merge time.

Resolves #1920