### PR TITLE
Only use sonatype staging for prod/release builds

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ allprojects {
 }
 
 nexusPublishing {
+    useStaging.set(findProperty("final") == "true")
     repositories {
         // see https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration
         sonatype {


### PR DESCRIPTION
It looks like the snapshot publishing is currently broken. The builds seem to indicate that our snapshot artifacts are being built and pushed to the "staging" sonatype repo just fine, but then they just sit there and age out. 

I think the fix might be to bypass the staging repository when doing the non-release builds (eg. snapshot).