### PR TITLE
test: add minified emulator smoke test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 ### 🛠️ Bug fixes
 
+- Fix R8 failures caused by optional Error Prone annotations in minified applications.
+  ([#1972](https://github.com/open-telemetry/opentelemetry-android/pull/1972))
+
 - Preserve explicit session IDs on logs so recovered native crashes and session-end events remain
   associated with the session they describe.
   ([#1939](https://github.com/open-telemetry/opentelemetry-android/pull/1939))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ kover {
         filters {
             excludes {
                 androidGeneratedClasses()
-                classes("*.BuildConfig")
+                classes("*.BuildConfig", "io.opentelemetry.android.smoketestapp.*")
             }
         }
     }

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,7 @@ coverage:
       default:
         target: auto
         threshold: 1%
+
+# This harness is exercised by Android instrumented tests, which Kover cannot collect.
+ignore:
+  - "smoke-test-app/**/*"

--- a/core/consumer-rules.pro
+++ b/core/consumer-rules.pro
@@ -2,8 +2,7 @@
 -dontwarn com.google.auto.value.AutoValue$CopyAnnotations
 -dontwarn com.google.auto.value.AutoValue
 -dontwarn com.google.auto.value.extension.memoized.Memoized
--dontwarn com.google.errorprone.annotations.CanIgnoreReturnValue
--dontwarn com.google.errorprone.annotations.MustBeClosed
+-dontwarn com.google.errorprone.annotations.**
 -dontwarn io.grpc.Channel
 -dontwarn io.grpc.MethodDescriptor$Builder
 -dontwarn io.grpc.MethodDescriptor$Marshaller

--- a/core/consumer-rules.pro
+++ b/core/consumer-rules.pro
@@ -2,6 +2,8 @@
 -dontwarn com.google.auto.value.AutoValue$CopyAnnotations
 -dontwarn com.google.auto.value.AutoValue
 -dontwarn com.google.auto.value.extension.memoized.Memoized
+-dontwarn com.google.errorprone.annotations.CanIgnoreReturnValue
+-dontwarn com.google.errorprone.annotations.MustBeClosed
 -dontwarn io.grpc.Channel
 -dontwarn io.grpc.MethodDescriptor$Builder
 -dontwarn io.grpc.MethodDescriptor$Marshaller

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -22,6 +22,8 @@ include(":services")
 include(":session")
 include(":semconv")
 include(":opentelemetry-android-bom")
+include(":smoke-test")
+include(":smoke-test-app")
 includeFromDir("instrumentation")
 
 fun includeFromDir(

--- a/smoke-test-app/build.gradle.kts
+++ b/smoke-test-app/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    id("otel.android-app-conventions")
+}
+
+android {
+    namespace = "io.opentelemetry.android.smoketestapp"
+
+    defaultConfig {
+        applicationId = "io.opentelemetry.android.smoketestapp"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+            signingConfig = signingConfigs.getByName("debug")
+        }
+    }
+}
+
+dependencies {
+    implementation(project(":android-agent"))
+}

--- a/smoke-test-app/proguard-rules.pro
+++ b/smoke-test-app/proguard-rules.pro
@@ -4,8 +4,3 @@
 # AGP treats dependencies shared by a minified target and its test APK as target-provided. Keep
 # Kotlin's runtime available to AndroidJUnitRunner, which executes inside the target process.
 -keep class kotlin.** { *; }
-
-# MockWebServer runs in the target process and shares OkHttp with the exporter. Retain that shared
-# runtime so test-only call paths are not removed while R8 optimizes the target in isolation.
--keep class okhttp3.** { *; }
--keep class okio.** { *; }

--- a/smoke-test-app/proguard-rules.pro
+++ b/smoke-test-app/proguard-rules.pro
@@ -1,0 +1,11 @@
+# AndroidJUnitRunner lives in the test APK and references this class from the target APK.
+-keep class androidx.tracing.Trace { *; }
+
+# AGP treats dependencies shared by a minified target and its test APK as target-provided. Keep
+# Kotlin's runtime available to AndroidJUnitRunner, which executes inside the target process.
+-keep class kotlin.** { *; }
+
+# MockWebServer runs in the target process and shares OkHttp with the exporter. Retain that shared
+# runtime so test-only call paths are not removed while R8 optimizes the target in isolation.
+-keep class okhttp3.** { *; }
+-keep class okio.** { *; }

--- a/smoke-test-app/src/main/AndroidManifest.xml
+++ b/smoke-test-app/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:theme="@android:style/Theme.Material.Light.NoActionBar"
+        android:usesCleartextTraffic="true"
+        tools:ignore="MissingApplicationIcon">
+        <activity
+            android:name=".SmokeTestActivity"
+            android:exported="false" />
+    </application>
+
+</manifest>

--- a/smoke-test-app/src/main/AndroidManifest.xml
+++ b/smoke-test-app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:label="minified-smoke-test"
         android:theme="@android:style/Theme.Material.Light.NoActionBar"
         android:usesCleartextTraffic="true"
         tools:ignore="MissingApplicationIcon">

--- a/smoke-test-app/src/main/kotlin/io/opentelemetry/android/smoketestapp/SmokeTestActivity.kt
+++ b/smoke-test-app/src/main/kotlin/io/opentelemetry/android/smoketestapp/SmokeTestActivity.kt
@@ -10,6 +10,7 @@ import android.os.Bundle
 import io.opentelemetry.android.agent.OpenTelemetryRumInitializer
 
 const val OTLP_ENDPOINT_EXTRA = "io.opentelemetry.android.smoketest.OTLP_ENDPOINT"
+const val SMOKE_TEST_SCOPE_NAME = "smoke-test"
 const val SMOKE_TEST_SPAN_NAME = "minified-app-smoke-test"
 
 class SmokeTestActivity : Activity() {
@@ -35,11 +36,12 @@ class SmokeTestActivity : Activity() {
         try {
             openTelemetryRum.openTelemetry
                 .tracerProvider
-                .get("smoke-test")
+                .get(SMOKE_TEST_SCOPE_NAME)
                 .spanBuilder(SMOKE_TEST_SPAN_NAME)
                 .startSpan()
                 .end()
         } finally {
+            // Shutdown starts the exporter flush; the instrumentation test waits for its request.
             openTelemetryRum.shutdown()
         }
     }

--- a/smoke-test-app/src/main/kotlin/io/opentelemetry/android/smoketestapp/SmokeTestActivity.kt
+++ b/smoke-test-app/src/main/kotlin/io/opentelemetry/android/smoketestapp/SmokeTestActivity.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.smoketestapp
+
+import android.app.Activity
+import android.os.Bundle
+import io.opentelemetry.android.agent.OpenTelemetryRumInitializer
+
+const val OTLP_ENDPOINT_EXTRA = "io.opentelemetry.android.smoketest.OTLP_ENDPOINT"
+const val SMOKE_TEST_SPAN_NAME = "minified-app-smoke-test"
+
+class SmokeTestActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val endpoint =
+            requireNotNull(intent.getStringExtra(OTLP_ENDPOINT_EXTRA)) {
+                "Missing OTLP endpoint"
+            }
+        val openTelemetryRum =
+            OpenTelemetryRumInitializer.initialize(application) {
+                httpExport {
+                    baseUrl = endpoint
+                }
+                diskBuffering {
+                    enabled(false)
+                }
+                disableLogging()
+                disableMetrics()
+            }
+
+        try {
+            openTelemetryRum.openTelemetry
+                .tracerProvider
+                .get("smoke-test")
+                .spanBuilder(SMOKE_TEST_SPAN_NAME)
+                .startSpan()
+                .end()
+        } finally {
+            openTelemetryRum.shutdown()
+        }
+    }
+}

--- a/smoke-test/build.gradle.kts
+++ b/smoke-test/build.gradle.kts
@@ -1,0 +1,64 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+
+plugins {
+    id("com.android.test")
+    id("otel.spotless-conventions")
+}
+
+android {
+    namespace = "io.opentelemetry.android.smoketest"
+    compileSdk = (property("android.compileSdk") as String).toInt()
+
+    defaultConfig {
+        minSdk = (property("android.minSdk") as String).toInt()
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    targetProjectPath = ":smoke-test-app"
+
+    buildTypes {
+        create("release") {
+            isMinifyEnabled = true
+            signingConfig = signingConfigs.getByName("debug")
+            testProguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility(rootProject.extra["java_version"] as JavaVersion)
+        targetCompatibility(rootProject.extra["java_version"] as JavaVersion)
+    }
+
+    kotlin {
+        compilerOptions {
+            jvmTarget.set(rootProject.extra["jvm_target"] as JvmTarget)
+            apiVersion.set(rootProject.extra["kotlin_min_supported_version"] as KotlinVersion)
+            languageVersion.set(rootProject.extra["kotlin_min_supported_version"] as KotlinVersion)
+        }
+    }
+
+    packaging.resources.excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
+}
+
+androidComponents {
+    beforeVariants(selector().withBuildType("debug")) {
+        it.enable = false
+    }
+}
+
+dependencies {
+    implementation(libs.androidx.junit)
+    implementation(libs.androidx.test.core)
+    implementation(libs.androidx.test.rules)
+    implementation(libs.androidx.test.runner)
+    implementation(libs.okhttp.mockwebserver)
+    implementation(libs.opentelemetry.proto)
+}
+
+configurations.implementation {
+    exclude(group = "io.opentelemetry", module = "opentelemetry-sdk-testing")
+}

--- a/smoke-test/build.gradle.kts
+++ b/smoke-test/build.gradle.kts
@@ -45,6 +45,7 @@ android {
 }
 
 androidComponents {
+    // The test must run against the target's minified release variant.
     beforeVariants(selector().withBuildType("debug")) {
         it.enable = false
     }
@@ -55,10 +56,5 @@ dependencies {
     implementation(libs.androidx.test.core)
     implementation(libs.androidx.test.rules)
     implementation(libs.androidx.test.runner)
-    implementation(libs.okhttp.mockwebserver)
     implementation(libs.opentelemetry.proto)
-}
-
-configurations.implementation {
-    exclude(group = "io.opentelemetry", module = "opentelemetry-sdk-testing")
 }

--- a/smoke-test/build.gradle.kts
+++ b/smoke-test/build.gradle.kts
@@ -40,8 +40,6 @@ android {
             languageVersion.set(rootProject.extra["kotlin_min_supported_version"] as KotlinVersion)
         }
     }
-
-    packaging.resources.excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
 }
 
 androidComponents {

--- a/smoke-test/proguard-rules.pro
+++ b/smoke-test/proguard-rules.pro
@@ -1,0 +1,11 @@
+# These dependencies run only in the test APK. Keep their complete runtime because R8 also sees
+# the optimized target APK, whose copies may have had classes removed as unreachable from the app.
+-keep class kotlin.** { *; }
+-keep class okhttp3.** { *; }
+-keep class okio.** { *; }
+
+# AndroidX Test references these compile-time annotations without requiring them at runtime.
+-dontwarn com.google.errorprone.annotations.**
+
+# The OTLP protobuf artifact includes optional gRPC stubs; this test only decodes HTTP payloads.
+-dontwarn io.grpc.**

--- a/smoke-test/proguard-rules.pro
+++ b/smoke-test/proguard-rules.pro
@@ -1,8 +1,6 @@
-# These dependencies run only in the test APK. Keep their complete runtime because R8 also sees
-# the optimized target APK, whose copies may have had classes removed as unreachable from the app.
+# Kotlin runs from the optimized target APK because AndroidJUnitRunner executes in its process.
+# Keep the runtime methods used only by the test APK.
 -keep class kotlin.** { *; }
--keep class okhttp3.** { *; }
--keep class okio.** { *; }
 
 # AndroidX Test references these compile-time annotations without requiring them at runtime.
 -dontwarn com.google.errorprone.annotations.**

--- a/smoke-test/proguard-rules.pro
+++ b/smoke-test/proguard-rules.pro
@@ -2,8 +2,5 @@
 # Keep the runtime methods used only by the test APK.
 -keep class kotlin.** { *; }
 
-# AndroidX Test references these compile-time annotations without requiring them at runtime.
--dontwarn com.google.errorprone.annotations.**
-
 # The OTLP protobuf artifact includes optional gRPC stubs; this test only decodes HTTP payloads.
 -dontwarn io.grpc.**

--- a/smoke-test/src/main/kotlin/io/opentelemetry/android/smoketest/MinifiedAppSmokeTest.kt
+++ b/smoke-test/src/main/kotlin/io/opentelemetry/android/smoketest/MinifiedAppSmokeTest.kt
@@ -9,13 +9,14 @@ import android.app.Activity
 import android.content.Intent
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.opentelemetry.android.smoketestapp.OTLP_ENDPOINT_EXTRA
+import io.opentelemetry.android.smoketestapp.SMOKE_TEST_SCOPE_NAME
+import io.opentelemetry.android.smoketestapp.SMOKE_TEST_SPAN_NAME
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
-import mockwebserver3.Dispatcher
-import mockwebserver3.MockResponse
-import mockwebserver3.MockWebServer
-import mockwebserver3.RecordedRequest
-import org.junit.After
-import org.junit.Before
+import io.opentelemetry.proto.common.v1.KeyValue
+import io.opentelemetry.proto.trace.v1.ResourceSpans
+import io.opentelemetry.proto.trace.v1.ScopeSpans
+import io.opentelemetry.proto.trace.v1.Span
 import org.junit.Test
 import org.junit.runner.RunWith
 import java.io.InputStream
@@ -24,96 +25,135 @@ import java.util.zip.GZIPInputStream
 
 @RunWith(AndroidJUnit4::class)
 class MinifiedAppSmokeTest {
-    private var server: MockWebServer? = null
-
-    @Before
-    fun setUp() {
-        server =
-            MockWebServer().apply {
-                dispatcher =
-                    object : Dispatcher() {
-                        override fun dispatch(request: RecordedRequest): MockResponse =
-                            if (request.target == "/v1/traces") {
-                                MockResponse(200)
-                            } else {
-                                MockResponse(404)
-                            }
-                    }
-                start()
-            }
-    }
-
-    @After
-    fun tearDown() {
-        server?.close()
-    }
-
     @Test
     fun appLaunchesAndExportsTrace() {
-        val server = checkNotNull(server)
-        val intent =
-            Intent()
-                .setClassName(TARGET_PACKAGE, TARGET_ACTIVITY)
-                .putExtra(OTLP_ENDPOINT_EXTRA, server.url("/").toString())
+        OtlpHttpServer().use { server ->
+            val intent =
+                Intent()
+                    .setClassName(TARGET_PACKAGE, TARGET_ACTIVITY)
+                    .putExtra(OTLP_ENDPOINT_EXTRA, server.url)
 
-        ActivityScenario.launch<Activity>(intent).use {
-            awaitTraceRequest(server, SMOKE_TEST_SPAN_NAME)
+            ActivityScenario.launch<Activity>(intent).use {
+                awaitExpectedTrace(server)
+            }
         }
     }
 
-    private fun awaitTraceRequest(
-        server: MockWebServer,
-        spanName: String,
-    ) {
-        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(15)
+    private fun awaitExpectedTrace(server: OtlpHttpServer) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(EXPORT_TIMEOUT_SECONDS)
+        val receivedTargets = mutableListOf<String>()
         val receivedSpanNames = mutableListOf<String>()
 
         while (System.nanoTime() < deadline) {
-            val remaining = deadline - System.nanoTime()
-            if (remaining <= 0) {
-                break
-            }
-            val recordedRequest = server.takeRequest(remaining, TimeUnit.NANOSECONDS) ?: break
-            check(recordedRequest.target == "/v1/traces") {
-                "Expected an OTLP trace request but received ${recordedRequest.target}"
+            val request =
+                server.takeRequest(deadline - System.nanoTime()) ?: break
+            receivedTargets.add("${request.method} ${request.target}")
+            if (request.target != TRACE_PATH) {
+                continue
             }
 
-            val exportRequest = parseTraceRequest(recordedRequest)
-            val spanNames =
-                exportRequest.resourceSpansList
-                    .flatMap { it.scopeSpansList }
-                    .flatMap { it.spansList }
-                    .map { it.name }
-            receivedSpanNames.addAll(spanNames)
-            if (spanName in spanNames) {
-                return
+            val exportRequest = parseTraceRequest(request)
+            exportRequest.resourceSpansList.forEach { resourceSpans ->
+                resourceSpans.scopeSpansList.forEach { scopeSpans ->
+                    scopeSpans.spansList.forEach { span ->
+                        receivedSpanNames.add(span.name)
+                        if (span.name == SMOKE_TEST_SPAN_NAME) {
+                            assertExpectedTrace(request, resourceSpans, scopeSpans, span)
+                            return
+                        }
+                    }
+                }
             }
         }
 
         throw AssertionError(
-            "Timed out waiting for span '$spanName'. Received spans: $receivedSpanNames",
+            "Timed out waiting for span '$SMOKE_TEST_SPAN_NAME'. " +
+                "Requests: $receivedTargets; spans: $receivedSpanNames",
         )
     }
 
-    private fun parseTraceRequest(recordedRequest: RecordedRequest): ExportTraceServiceRequest {
-        val requestBody =
-            checkNotNull(recordedRequest.body) {
-                "OTLP trace request did not contain a body"
-            }.toByteArray()
-        val inputStream: InputStream =
-            when (val encoding = recordedRequest.headers["Content-Encoding"]) {
-                null, "identity" -> requestBody.inputStream()
-                "gzip" -> GZIPInputStream(requestBody.inputStream())
-                else -> error("Unsupported OTLP content encoding: $encoding")
-            }
+    private fun assertExpectedTrace(
+        request: CapturedHttpRequest,
+        resourceSpans: ResourceSpans,
+        scopeSpans: ScopeSpans,
+        span: Span,
+    ) {
+        assertSmoke(request.method == "POST") { "Expected POST but received ${request.method}" }
+        assertSmoke(request.headers["content-type"]?.substringBefore(';') == PROTOBUF_CONTENT_TYPE) {
+            "Expected $PROTOBUF_CONTENT_TYPE but received ${request.headers["content-type"]}"
+        }
+        assertSmoke(request.headers["content-encoding"] == "gzip") {
+            "Expected gzip content encoding but received ${request.headers["content-encoding"]}"
+        }
+        assertSmoke(scopeSpans.scope.name == SMOKE_TEST_SCOPE_NAME) {
+            "Expected scope '$SMOKE_TEST_SCOPE_NAME' but received '${scopeSpans.scope.name}'"
+        }
 
+        val resourceAttributes = resourceSpans.resource.attributesList.stringValues()
+        EXPECTED_RESOURCE_ATTRIBUTES.forEach { (key, value) ->
+            assertSmoke(resourceAttributes[key] == value) {
+                "Expected $key=$value resource attribute: $resourceAttributes"
+            }
+        }
+        listOf("telemetry.sdk.version", "device.model.name", "device.model.identifier").forEach { key ->
+            assertSmoke(!resourceAttributes[key].isNullOrBlank()) {
+                "Missing $key resource attribute: $resourceAttributes"
+            }
+        }
+        val spanAttributes = span.attributesList.stringValues()
+        assertSmoke(!spanAttributes["session.id"].isNullOrBlank()) {
+            "Expected a non-empty session.id span attribute: $spanAttributes"
+        }
+        assertValidId("trace", span.traceId.toByteArray(), TRACE_ID_BYTES)
+        assertValidId("span", span.spanId.toByteArray(), SPAN_ID_BYTES)
+    }
+
+    private fun parseTraceRequest(request: CapturedHttpRequest): ExportTraceServiceRequest {
+        val inputStream: InputStream =
+            when (val encoding = request.headers["content-encoding"]) {
+                null, "identity" -> request.body.inputStream()
+                "gzip" -> GZIPInputStream(request.body.inputStream())
+                else -> throw AssertionError("Unsupported OTLP content encoding: $encoding")
+            }
         return inputStream.use(ExportTraceServiceRequest::parseFrom)
+    }
+
+    private fun List<KeyValue>.stringValues(): Map<String, String> = associate { it.key to it.value.stringValue }
+
+    private fun assertValidId(
+        name: String,
+        value: ByteArray,
+        expectedSize: Int,
+    ) {
+        assertSmoke(value.size == expectedSize && value.any { it != 0.toByte() }) {
+            "Expected a valid $name ID but received ${value.joinToString("") { "%02x".format(it) }}"
+        }
+    }
+
+    private fun assertSmoke(
+        condition: Boolean,
+        message: () -> String,
+    ) {
+        if (!condition) {
+            throw AssertionError(message())
+        }
     }
 
     private companion object {
         const val TARGET_PACKAGE = "io.opentelemetry.android.smoketestapp"
         const val TARGET_ACTIVITY = "$TARGET_PACKAGE.SmokeTestActivity"
-        const val OTLP_ENDPOINT_EXTRA = "io.opentelemetry.android.smoketest.OTLP_ENDPOINT"
-        const val SMOKE_TEST_SPAN_NAME = "minified-app-smoke-test"
+        const val TRACE_PATH = "/v1/traces"
+        const val PROTOBUF_CONTENT_TYPE = "application/x-protobuf"
+        const val SERVICE_NAME = "minified-smoke-test"
+        const val EXPORT_TIMEOUT_SECONDS = 15L
+        const val TRACE_ID_BYTES = 16
+        const val SPAN_ID_BYTES = 8
+        val EXPECTED_RESOURCE_ATTRIBUTES =
+            mapOf(
+                "service.name" to SERVICE_NAME,
+                "telemetry.sdk.name" to "opentelemetry",
+                "telemetry.sdk.language" to "java",
+                "os.type" to "linux",
+            )
     }
 }

--- a/smoke-test/src/main/kotlin/io/opentelemetry/android/smoketest/MinifiedAppSmokeTest.kt
+++ b/smoke-test/src/main/kotlin/io/opentelemetry/android/smoketest/MinifiedAppSmokeTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.smoketest
+
+import android.app.Activity
+import android.content.Intent
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest
+import mockwebserver3.Dispatcher
+import mockwebserver3.MockResponse
+import mockwebserver3.MockWebServer
+import mockwebserver3.RecordedRequest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.InputStream
+import java.util.concurrent.TimeUnit
+import java.util.zip.GZIPInputStream
+
+@RunWith(AndroidJUnit4::class)
+class MinifiedAppSmokeTest {
+    private var server: MockWebServer? = null
+
+    @Before
+    fun setUp() {
+        server =
+            MockWebServer().apply {
+                dispatcher =
+                    object : Dispatcher() {
+                        override fun dispatch(request: RecordedRequest): MockResponse =
+                            if (request.target == "/v1/traces") {
+                                MockResponse(200)
+                            } else {
+                                MockResponse(404)
+                            }
+                    }
+                start()
+            }
+    }
+
+    @After
+    fun tearDown() {
+        server?.close()
+    }
+
+    @Test
+    fun appLaunchesAndExportsTrace() {
+        val server = checkNotNull(server)
+        val intent =
+            Intent()
+                .setClassName(TARGET_PACKAGE, TARGET_ACTIVITY)
+                .putExtra(OTLP_ENDPOINT_EXTRA, server.url("/").toString())
+
+        ActivityScenario.launch<Activity>(intent).use {
+            awaitTraceRequest(server, SMOKE_TEST_SPAN_NAME)
+        }
+    }
+
+    private fun awaitTraceRequest(
+        server: MockWebServer,
+        spanName: String,
+    ) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(15)
+        val receivedSpanNames = mutableListOf<String>()
+
+        while (System.nanoTime() < deadline) {
+            val remaining = deadline - System.nanoTime()
+            if (remaining <= 0) {
+                break
+            }
+            val recordedRequest = server.takeRequest(remaining, TimeUnit.NANOSECONDS) ?: break
+            check(recordedRequest.target == "/v1/traces") {
+                "Expected an OTLP trace request but received ${recordedRequest.target}"
+            }
+
+            val exportRequest = parseTraceRequest(recordedRequest)
+            val spanNames =
+                exportRequest.resourceSpansList
+                    .flatMap { it.scopeSpansList }
+                    .flatMap { it.spansList }
+                    .map { it.name }
+            receivedSpanNames.addAll(spanNames)
+            if (spanName in spanNames) {
+                return
+            }
+        }
+
+        throw AssertionError(
+            "Timed out waiting for span '$spanName'. Received spans: $receivedSpanNames",
+        )
+    }
+
+    private fun parseTraceRequest(recordedRequest: RecordedRequest): ExportTraceServiceRequest {
+        val requestBody =
+            checkNotNull(recordedRequest.body) {
+                "OTLP trace request did not contain a body"
+            }.toByteArray()
+        val inputStream: InputStream =
+            when (val encoding = recordedRequest.headers["Content-Encoding"]) {
+                null, "identity" -> requestBody.inputStream()
+                "gzip" -> GZIPInputStream(requestBody.inputStream())
+                else -> error("Unsupported OTLP content encoding: $encoding")
+            }
+
+        return inputStream.use(ExportTraceServiceRequest::parseFrom)
+    }
+
+    private companion object {
+        const val TARGET_PACKAGE = "io.opentelemetry.android.smoketestapp"
+        const val TARGET_ACTIVITY = "$TARGET_PACKAGE.SmokeTestActivity"
+        const val OTLP_ENDPOINT_EXTRA = "io.opentelemetry.android.smoketest.OTLP_ENDPOINT"
+        const val SMOKE_TEST_SPAN_NAME = "minified-app-smoke-test"
+    }
+}

--- a/smoke-test/src/main/kotlin/io/opentelemetry/android/smoketest/OtlpHttpServer.kt
+++ b/smoke-test/src/main/kotlin/io/opentelemetry/android/smoketest/OtlpHttpServer.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.smoketest
+
+import java.io.BufferedInputStream
+import java.io.ByteArrayOutputStream
+import java.io.Closeable
+import java.io.DataInputStream
+import java.io.InputStream
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.util.Locale
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+internal data class CapturedHttpRequest(
+    val method: String,
+    val target: String,
+    val headers: Map<String, String>,
+    val body: ByteArray,
+)
+
+internal class OtlpHttpServer : Closeable {
+    private val events = LinkedBlockingQueue<Result<CapturedHttpRequest>>()
+    private val serverSocket = ServerSocket(0, 1, InetAddress.getByName(LOOPBACK_ADDRESS))
+    private val serverThread =
+        Thread(::serve, "otel-smoke-test-http").apply {
+            isDaemon = true
+            start()
+        }
+
+    val url = "http://$LOOPBACK_ADDRESS:${serverSocket.localPort}/"
+
+    fun takeRequest(timeoutNanos: Long): CapturedHttpRequest? {
+        val event = events.poll(timeoutNanos, TimeUnit.NANOSECONDS) ?: return null
+        return event.getOrElse { failure ->
+            throw AssertionError("Local OTLP server failed").apply { initCause(failure) }
+        }
+    }
+
+    override fun close() {
+        serverSocket.close()
+        serverThread.join(SERVER_SHUTDOWN_TIMEOUT_MILLIS)
+        check(!serverThread.isAlive) { "Local OTLP server did not stop" }
+    }
+
+    private fun serve() {
+        while (!serverSocket.isClosed) {
+            try {
+                serverSocket.accept().use { socket ->
+                    val request = readRequest(socket)
+                    writeResponse(socket)
+                    events.put(Result.success(request))
+                }
+            } catch (failure: Exception) {
+                if (!serverSocket.isClosed) {
+                    events.offer(Result.failure(failure))
+                }
+                return
+            }
+        }
+    }
+
+    private fun readRequest(socket: Socket): CapturedHttpRequest {
+        socket.soTimeout = SOCKET_TIMEOUT_MILLIS
+        val input = BufferedInputStream(socket.getInputStream())
+        val requestParts = readLine(input).split(' ', limit = 3)
+        require(requestParts.size == 3) { "Malformed HTTP request line" }
+
+        val headers = linkedMapOf<String, String>()
+        repeat(MAX_HEADER_COUNT) {
+            val line = readLine(input)
+            if (line.isEmpty()) {
+                return CapturedHttpRequest(
+                    requestParts[0],
+                    requestParts[1],
+                    headers,
+                    readBody(input, headers),
+                )
+            }
+            val separator = line.indexOf(':')
+            require(separator > 0) { "Malformed HTTP header" }
+            val name = line.substring(0, separator).lowercase(Locale.US)
+            val value = line.substring(separator + 1).trim()
+            headers[name] = value
+        }
+        error("Too many HTTP headers")
+    }
+
+    private fun readBody(
+        input: InputStream,
+        headers: Map<String, String>,
+    ): ByteArray =
+        if (headers["transfer-encoding"]?.contains("chunked", ignoreCase = true) == true) {
+            readChunkedBody(input)
+        } else {
+            val length = headers["content-length"]?.toIntOrNull() ?: 0
+            require(length in 0..MAX_BODY_BYTES) { "Invalid HTTP content length: $length" }
+            readBytes(input, length)
+        }
+
+    private fun readChunkedBody(input: InputStream): ByteArray {
+        val body = ByteArrayOutputStream()
+        while (true) {
+            val size = readLine(input).substringBefore(';').trim().toIntOrNull(16)
+            require(size != null && size >= 0 && size <= MAX_BODY_BYTES - body.size()) {
+                "Invalid HTTP chunk size"
+            }
+            if (size == 0) {
+                require(readLine(input).isEmpty()) { "Unexpected HTTP trailer headers" }
+                return body.toByteArray()
+            }
+            body.write(readBytes(input, size))
+            require(input.read() == '\r'.code && input.read() == '\n'.code) {
+                "Malformed HTTP chunk terminator"
+            }
+        }
+    }
+
+    private fun readBytes(
+        input: InputStream,
+        size: Int,
+    ): ByteArray = ByteArray(size).also { DataInputStream(input).readFully(it) }
+
+    private fun readLine(input: InputStream): String {
+        val line = StringBuilder()
+        repeat(MAX_LINE_BYTES) {
+            val next = input.read()
+            require(next >= 0) { "Unexpected end of HTTP headers" }
+            if (next == '\n'.code) {
+                return line.toString().removeSuffix("\r")
+            }
+            line.append(next.toChar())
+        }
+        error("HTTP header line is too long")
+    }
+
+    private fun writeResponse(socket: Socket) {
+        val output = socket.getOutputStream()
+        output.write("HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".toByteArray())
+        output.flush()
+    }
+
+    private companion object {
+        const val LOOPBACK_ADDRESS = "127.0.0.1"
+        const val MAX_BODY_BYTES = 1024 * 1024
+        const val MAX_LINE_BYTES = 8 * 1024
+        const val MAX_HEADER_COUNT = 100
+        const val SOCKET_TIMEOUT_MILLIS = 10_000
+        const val SERVER_SHUTDOWN_TIMEOUT_MILLIS = 1_000L
+    }
+}


### PR DESCRIPTION
Adds a small minified release app that initializes the Android agent, records a span, and exports it over OTLP/HTTP. A separate emulator test captures the request with a bounded loopback server and verifies the exported protobuf payload.

The test runs through the existing `connectedCheck` PR job and covers R8 shrinking, app startup, SDK initialization, and a real export.

## Test flow for clarity

```mermaid
flowchart TD
    A[connectedCheck] --> B[Start emulator smoke test]
    B --> C[Start bounded loopback server]
    B --> D[Launch minified release app]
    D --> E[Initialize Android agent]
    E --> F[Create one span]
    F -->|OTLP/HTTP protobuf| C
    C --> G[Decode payload and verify span]
```

Resolves #1955