### PR TITLE
Using gradle catalog named version for junit-platform-launcher

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,7 @@ mockk = "io.mockk:mockk:1.14.11"
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit" }
-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "junit" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit" }
 robolectric = "org.robolectric:robolectric:4.16.1"
 assertj-core = "org.assertj:assertj-core:3.27.7"
 awaitility = "org.awaitility:awaitility:4.3.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -69,7 +69,7 @@ mockk = "io.mockk:mockk:1.14.11"
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit" }
-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "6.1.3" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "junit" }
 robolectric = "org.robolectric:robolectric:4.16.1"
 assertj-core = "org.assertj:assertj-core:3.27.7"
 awaitility = "org.awaitility:awaitility:4.3.0"


### PR DESCRIPTION
Small adjustment discovered by copilot [here](https://github.com/open-telemetry/opentelemetry-android/pull/1975#discussion_r3745821726).