### PR TITLE
feat(demo-app): use compose-navigation instrumentation for screen tracking

### DIFF
--- a/demo-app/README.md
+++ b/demo-app/README.md
@@ -52,13 +52,24 @@ The OpenTelemetry Android Demo App currently supports the following features:
   - The span includes attributes such as `activity.name`, `screen.name`, `count`, and network details to help diagnose performance issues.
   - To trigger a slowly rendering animation in the demo app, add any quantity of The Comet Book (the last product on the product list) to the cart. Note that the number of `slow-render` spans and their respective `count` attributes may vary between runs or across different machines.
 
+* Compose Navigation Instrumentation
+  - The shop's `NavController` is created by `rememberObservedNavController` in `Navigation.kt`, so
+    every completed navigation in the astronomy shop emits an `app.navigation.complete` event
+    carrying the resolved screen name in `app.navigation.destination.name`.
+  - Because it observes destination changes rather than individual call sites, it covers navigation
+    the app doesn't route through an explicit helper: bottom navigation bar taps, back/up presses,
+    and deep links.
+  - Demonstrates the `screenName` override: instead of the default route pattern, the
+    `astronomyShopScreenName` function in `Navigation.kt` maps each destination to a display name
+    (`Product List`, `Cart`, `Checkout Info`, ...). Product details reads the product id out of the
+    destination arguments, for example `Product Details: OLJCESPC7Z`.
+
 * Manual Instrumentation
   - Provides access to the OpenTelemetry APIs for manual instrumentation, allowing developers to create custom spans and events as needed.
   - See `OtelDemoApplication.kt` for an example of a tracer and an event builder initialization.
   - In the app, a custom span is emitted in `MainOtelButton.kt` after clicking on the OpenTelemetry logo button.
   - Custom events are emitted:
     - in `MainOtelButton.kt` after clicking on the OpenTelemetry logo button,
-    - in `Navigation.kt` for screen changes in the app,
     - in `AstronomyShopActivity.kt` after placing an order in the shop,
     - in `Cart.kt` after emptying a cart in the shop.
   - Note: Events aren't visible in the Jaeger UI, only in the collector output.

--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     // configured substitutions.
     implementation("io.opentelemetry.android:android-agent")    //parent dir
     implementation("io.opentelemetry.android.instrumentation:compose-click")
+    implementation("io.opentelemetry.android.instrumentation:compose-navigation")
     implementation("io.opentelemetry.android.instrumentation:sessions")
     implementation("io.opentelemetry.android.instrumentation:okhttp3-library")
     byteBuddy("io.opentelemetry.android.instrumentation:okhttp3-agent")

--- a/demo-app/settings.gradle.kts
+++ b/demo-app/settings.gradle.kts
@@ -26,6 +26,8 @@ includeBuild("..") {
             .using(project(":android-agent"))
         substitute(module("io.opentelemetry.android.instrumentation:compose-click"))
             .using(project(":instrumentation:compose:click"))
+        substitute(module("io.opentelemetry.android.instrumentation:compose-navigation"))
+            .using(project(":instrumentation:compose:navigation"))
         substitute(module("io.opentelemetry.android.instrumentation:sessions"))
             .using(project(":instrumentation:sessions"))
         substitute(module("io.opentelemetry.android.instrumentation:okhttp3-library"))

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/AstronomyShopActivity.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/AstronomyShopActivity.kt
@@ -91,7 +91,7 @@ fun AstronomyShopScreen() {
                             astronomyShopNavController.navigateToProductDetail(productId)
                         })
                     }
-                    composable("${MainDestinations.PRODUCT_DETAIL_ROUTE}/{${MainDestinations.PRODUCT_ID_KEY}}") { backStackEntry ->
+                    composable(MainDestinations.PRODUCT_DETAIL_ROUTE_PATTERN) { backStackEntry ->
                         val productId = backStackEntry.arguments?.getString(MainDestinations.PRODUCT_ID_KEY)
                         val product = products.find { it.id == productId }
                         product?.let { ProductDetails(

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/AstronomyShopActivity.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/AstronomyShopActivity.kt
@@ -128,7 +128,7 @@ fun AstronomyShopScreen() {
 }
 
 private fun instrumentedPlaceOrder(
-    astronomyShopNavController: InstrumentedAstronomyShopNavController,
+    astronomyShopNavController: AstronomyShopNavController,
     cartViewModel: CartViewModel,
     checkoutInfoViewModel: CheckoutInfoViewModel
 ){

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/Navigation.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/Navigation.kt
@@ -1,5 +1,6 @@
 package io.opentelemetry.android.demo.shop.ui
 
+import android.os.Bundle
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.automirrored.filled.List
@@ -12,8 +13,9 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import androidx.compose.material3.*
+import androidx.navigation.NavDestination
 import io.opentelemetry.android.demo.OtelDemoApplication
-import io.opentelemetry.api.common.AttributeKey.stringKey
+import io.opentelemetry.instrumentation.compose.navigation.rememberObservedNavController
 
 
 sealed class BottomNavItem(val route: String, val icon: ImageVector, val label: String) {
@@ -31,10 +33,20 @@ object MainDestinations {
 }
 
 @Composable
-fun rememberAstronomyShopNavController(navController: NavHostController = rememberNavController())
-        : InstrumentedAstronomyShopNavController = remember(navController)
-{
-    InstrumentedAstronomyShopNavController(AstronomyShopNavController(navController))
+fun rememberAstronomyShopNavController(
+    navController: NavHostController = rememberAstronomyShopHostController(),
+): AstronomyShopNavController = remember(navController) {
+    AstronomyShopNavController(navController)
+}
+
+@Composable
+private fun rememberAstronomyShopHostController(): NavHostController {
+    val rum = OtelDemoApplication.rum
+    return if (rum != null) {
+        rememberObservedNavController(rum = rum, screenName = ::astronomyShopScreenName)
+    } else {
+        rememberNavController()
+    }
 }
 
 @Stable
@@ -61,52 +73,6 @@ class AstronomyShopNavController(
     }
 }
 
-class InstrumentedAstronomyShopNavController(
-    private val delegate : AstronomyShopNavController
-){
-    val navController: NavHostController
-        get() = delegate.navController
-
-    val currentRoute: String?
-        get() = delegate.currentRoute
-
-    fun upPress() {
-        delegate.upPress()
-    }
-
-    fun navigateToProductDetail(productId: String) {
-        delegate.navigateToProductDetail(productId)
-        generateNavigationEvent(
-            eventName = "navigate.to.product.details",
-            payload = mapOf("product.id" to productId)
-        )
-    }
-
-    fun navigateToCheckoutInfo() {
-        delegate.navigateToCheckoutInfo()
-        generateNavigationEvent(
-            eventName = "navigate.to.checkout.info",
-            payload = emptyMap()
-        )
-    }
-
-    fun navigateToCheckoutConfirmation() {
-        delegate.navigateToCheckoutConfirmation()
-        generateNavigationEvent(
-            eventName = "navigate.to.checkout.confirmation",
-            payload = emptyMap()
-        )
-    }
-
-    private fun generateNavigationEvent(eventName: String, payload: Map<String, String>) {
-        val eventBuilder = OtelDemoApplication.eventBuilder("otel.demo.app.navigation", eventName)
-        payload.forEach { (key, value) ->
-            eventBuilder.setAttribute(stringKey(key), value)
-        }
-        eventBuilder.emit()
-    }
-}
-
 @Composable
 fun BottomNavigationBar(
     items: List<BottomNavItem>,
@@ -129,5 +95,20 @@ fun BottomNavigationBar(
                 label = { Text(item.label) }
             )
         }
+    }
+}
+
+// Maps the shop's route patterns to display names. Product details reads the product id out of
+// `arguments` so the screen name identifies which product was viewed
+private fun astronomyShopScreenName(destination: NavDestination, arguments: Bundle?): String {
+    arguments?.getString(MainDestinations.PRODUCT_ID_KEY)?.let {
+        return "Product Details: $it"
+    }
+    return when (destination.route) {
+        MainDestinations.HOME_ROUTE -> "Product List"
+        BottomNavItem.Cart.route -> "Cart"
+        MainDestinations.CHECKOUT_INFO_ROUTE -> "Checkout Info"
+        MainDestinations.CHECKOUT_CONFIRMATION_ROUTE -> "Checkout Confirmation"
+        else -> destination.route ?: "unknown"
     }
 }

--- a/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/Navigation.kt
+++ b/demo-app/src/main/java/io/opentelemetry/android/demo/shop/ui/Navigation.kt
@@ -5,7 +5,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ExitToApp
 import androidx.compose.material.icons.automirrored.filled.List
 import androidx.compose.material.icons.filled.ShoppingCart
-import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.remember
@@ -28,6 +27,7 @@ object MainDestinations {
     const val HOME_ROUTE = "prod-list"
     const val PRODUCT_DETAIL_ROUTE = "product"
     const val PRODUCT_ID_KEY = "productId"
+    const val PRODUCT_DETAIL_ROUTE_PATTERN = "$PRODUCT_DETAIL_ROUTE/{$PRODUCT_ID_KEY}"
     const val CHECKOUT_INFO_ROUTE = "checkout-info"
     const val CHECKOUT_CONFIRMATION_ROUTE = "checkout-confirmation"
 }
@@ -100,15 +100,15 @@ fun BottomNavigationBar(
 
 // Maps the shop's route patterns to display names. Product details reads the product id out of
 // `arguments` so the screen name identifies which product was viewed
-private fun astronomyShopScreenName(destination: NavDestination, arguments: Bundle?): String {
-    arguments?.getString(MainDestinations.PRODUCT_ID_KEY)?.let {
-        return "Product Details: $it"
-    }
-    return when (destination.route) {
+private fun astronomyShopScreenName(destination: NavDestination, arguments: Bundle?): String =
+    when (destination.route) {
+        MainDestinations.PRODUCT_DETAIL_ROUTE_PATTERN ->
+            arguments?.getString(MainDestinations.PRODUCT_ID_KEY)
+                ?.let { "Product Details: $it" }
+                ?: "Product Details"
         MainDestinations.HOME_ROUTE -> "Product List"
         BottomNavItem.Cart.route -> "Cart"
         MainDestinations.CHECKOUT_INFO_ROUTE -> "Checkout Info"
         MainDestinations.CHECKOUT_CONFIRMATION_ROUTE -> "Checkout Confirmation"
         else -> destination.route ?: "unknown"
     }
-}


### PR DESCRIPTION
## Description

Switches the demo app's astronomy shop to the `compose-navigation`
instrumentation added in #1964, replacing the bespoke
`InstrumentedAstronomyShopNavController` wrapper.

The old wrapper emitted a custom event from each navigation helper it
wrapped (`navigate.to.product.details`, `navigate.to.checkout.info`,
`navigate.to.checkout.confirmation`). Navigation that didn't go through
those helpers — bottom navigation bar taps, back/up presses, deep links —
was invisible. `rememberObservedNavController` observes destination
changes instead, so every completed navigation emits
`app.navigation.complete` with `app.navigation.destination.name`.

Also serves as the demo-app example of the `screenName` override:
`astronomyShopScreenName` maps route patterns to human-readable names
instead of the default route pattern, and pulls the product id out of the
destination arguments for product details
(`Product Details: OLJCESPC7Z`).

## Changes

- Add the `compose-navigation` instrumentation dependency and its
  composite-build substitution.
- Delete `InstrumentedAstronomyShopNavController`; call sites now use
  `AstronomyShopNavController` directly.
- Add `astronomyShopScreenName` to map destinations to display names.
- Document the new instrumentation in the demo app README and remove the
  stale reference to Navigation.kt under Manual Instrumentation.

## Testing

Ran the demo app against the local collector and confirmed
`app.navigation.complete` events appear with the expected
`app.navigation.destination.name` for each screen, including bottom
nav taps and back presses.
<img width="625" height="404" alt="Screenshot 2026-08-10 at 10 32 52 AM" src="https://github.com/user-attachments/assets/5d24421c-4198-4f1e-b83a-ca0ef90058e3" />
