### PR TITLE
Bump compose dependency in demo app

### DIFF
--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 
 android {
     namespace = "io.opentelemetry.android.demo"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "io.opentelemetry.android.demo"

--- a/demo-app/gradle/libs.versions.toml
+++ b/demo-app/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ desugarJdkLibs = "com.android.tools:desugar_jdk_libs:2.1.5"
 # demo-app
 androidx-core-ktx = "androidx.core:core-ktx:1.18.0"
 androidx-lifecycle-runtime-ktx = "androidx.lifecycle:lifecycle-runtime-ktx:2.10.0"
-androidx-compose-bom = "androidx.compose:compose-bom:2026.06.01"
+androidx-compose-bom = "androidx.compose:compose-bom:2026.08.00"
 androidx-activity-compose = "androidx.activity:activity-compose:1.13.0"
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }


### PR DESCRIPTION
Supersedes #1982 by increasing the compileSdk version used for building the demo app, as the latest version of compose requires compileSdk of 37 or above.