### PR TITLE
Rename last.screen.name to app.screen.previous.name

### DIFF
--- a/instrumentation/activity/README.md
+++ b/instrumentation/activity/README.md
@@ -35,8 +35,9 @@ This instrumentation produces the following telemetry:
   `activityPreDestroyed` | `activityDestroyed` | `activityPostDestroyed` }
 * Attributes:
   * `activity.name`:  name of activity
-  * `screen.name`:  name of screen
-  * `last.screen.name`:  name of screen, only when span contains the `activityPostResumed` event.
+  * `app.screen.name`: name of screen
+  * `app.screen.previous.name`: name of the previously visible screen, only when the span contains
+    the `activityPostResumed` event.
 
 ## Installation
 

--- a/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityTracer.kt
+++ b/instrumentation/activity/src/main/java/io/opentelemetry/android/instrumentation/activity/ActivityTracer.kt
@@ -93,7 +93,7 @@ internal class ActivityTracer(
             spanBuilder.setParent(parentSpan.storeInContext(Context.current()))
         }
         val span = spanBuilder.startSpan()
-        // do this after the span is started, so we can override the default screen.name set by the
+        // do this after the span is started, so we can override the default app.screen.name set by the
         // RumAttributeAppender.
         span.setAttribute(map(APP_SCREEN_NAME), screenName)
         return span

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityCallbacksTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityCallbacksTest.kt
@@ -12,7 +12,7 @@ import io.opentelemetry.android.instrumentation.activity.startup.AppStartupTimer
 import io.opentelemetry.android.instrumentation.common.ScreenNameExtractor
 import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTracker
 import io.opentelemetry.android.semconv.ActivityAttributes.ACTIVITY_NAME_KEY
-import io.opentelemetry.android.semconv.LastAttributes.LAST_SCREEN_NAME_KEY
+import io.opentelemetry.android.semconv.AppAttributes.APP_SCREEN_PREVIOUS_NAME_KEY
 import io.opentelemetry.android.semconv.StartAttributes.START_TYPE_KEY
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_NAME
@@ -71,7 +71,7 @@ internal class ActivityCallbacksTest {
             activity.javaClass.simpleName,
             creationSpan.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(creationSpan.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(creationSpan.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         val events = creationSpan.events
         assertEquals(9, events.size)
@@ -112,7 +112,7 @@ internal class ActivityCallbacksTest {
             activity.javaClass.simpleName,
             span.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(span.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(span.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         val events = span.events
         assertEquals(9, events.size)
@@ -161,7 +161,7 @@ internal class ActivityCallbacksTest {
             activity.javaClass.simpleName,
             span.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(span.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(span.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         val events = span.events
         assertEquals(6, events.size)
@@ -202,7 +202,7 @@ internal class ActivityCallbacksTest {
         )
         assertEquals(
             "previousScreen",
-            span.attributes.get(LAST_SCREEN_NAME_KEY),
+            span.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY),
         )
 
         val events = span.events
@@ -237,7 +237,7 @@ internal class ActivityCallbacksTest {
             activity.javaClass.simpleName,
             span.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(span.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(span.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         val events = span.events
         assertEquals(3, events.size)
@@ -271,7 +271,7 @@ internal class ActivityCallbacksTest {
             activity.javaClass.simpleName,
             stoppedSpan.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(stoppedSpan.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(stoppedSpan.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         var events: List<EventData> = stoppedSpan.events
         assertEquals(3, events.size)
@@ -291,7 +291,7 @@ internal class ActivityCallbacksTest {
             activity.javaClass.simpleName,
             destroyedSpan.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(destroyedSpan.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(destroyedSpan.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         events = destroyedSpan.events
         assertEquals(3, events.size)
@@ -325,7 +325,7 @@ internal class ActivityCallbacksTest {
             activity.javaClass.simpleName,
             stoppedSpan.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(stoppedSpan.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(stoppedSpan.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         var events: List<EventData> = stoppedSpan.events
         assertEquals(3, events.size)
@@ -345,7 +345,7 @@ internal class ActivityCallbacksTest {
             activity.javaClass.simpleName,
             destroyedSpan.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(destroyedSpan.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(destroyedSpan.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         events = destroyedSpan.events
         assertEquals(3, events.size)

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityTracerTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/ActivityTracerTest.kt
@@ -13,7 +13,7 @@ import io.mockk.mockk
 import io.opentelemetry.android.instrumentation.activity.startup.AppStartupTimer
 import io.opentelemetry.android.instrumentation.common.ActiveSpan
 import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTracker
-import io.opentelemetry.android.semconv.LastAttributes.LAST_SCREEN_NAME_KEY
+import io.opentelemetry.android.semconv.AppAttributes.APP_SCREEN_PREVIOUS_NAME_KEY
 import io.opentelemetry.android.semconv.StartAttributes.START_TYPE_KEY
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.api.trace.Tracer
@@ -177,7 +177,7 @@ class ActivityTracerTest {
         trackableTracer.endActiveSpan()
 
         val span = this.singleSpan
-        assertNull(span.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(span.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
     }
 
     @Test
@@ -198,7 +198,7 @@ class ActivityTracerTest {
         trackableTracer.endActiveSpan()
 
         val span = this.singleSpan
-        assertNull(span.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(span.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
     }
 
     @Test
@@ -220,7 +220,7 @@ class ActivityTracerTest {
         val span = this.singleSpan
         assertEquals(
             "previousScreen",
-            span.attributes.get(LAST_SCREEN_NAME_KEY),
+            span.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY),
         )
     }
 

--- a/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/Pre29ActivityLifecycleCallbacksTest.kt
+++ b/instrumentation/activity/src/test/java/io/opentelemetry/android/instrumentation/activity/Pre29ActivityLifecycleCallbacksTest.kt
@@ -14,7 +14,7 @@ import io.opentelemetry.android.instrumentation.activity.startup.AppStartupTimer
 import io.opentelemetry.android.instrumentation.common.ScreenNameExtractor
 import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTracker
 import io.opentelemetry.android.semconv.ActivityAttributes.ACTIVITY_NAME_KEY
-import io.opentelemetry.android.semconv.LastAttributes.LAST_SCREEN_NAME_KEY
+import io.opentelemetry.android.semconv.AppAttributes.APP_SCREEN_PREVIOUS_NAME_KEY
 import io.opentelemetry.android.semconv.StartAttributes.START_TYPE_KEY
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_NAME
@@ -76,7 +76,7 @@ internal class Pre29ActivityLifecycleCallbacksTest {
             activity.javaClass.simpleName,
             creationSpan.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(creationSpan.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(creationSpan.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         val events = creationSpan.events
         assertEquals(3, events.size)
@@ -109,7 +109,7 @@ internal class Pre29ActivityLifecycleCallbacksTest {
             activity.javaClass.simpleName,
             span.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(span.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(span.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         val events = span.events
         assertEquals(3, events.size)
@@ -150,7 +150,7 @@ internal class Pre29ActivityLifecycleCallbacksTest {
             activity.javaClass.simpleName,
             span.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(span.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(span.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         val events = span.events
         assertEquals(2, events.size)
@@ -187,7 +187,7 @@ internal class Pre29ActivityLifecycleCallbacksTest {
         )
         assertEquals(
             "previousScreen",
-            span.attributes.get(LAST_SCREEN_NAME_KEY),
+            span.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY),
         )
 
         val events = span.events
@@ -220,7 +220,7 @@ internal class Pre29ActivityLifecycleCallbacksTest {
             activity.javaClass.simpleName,
             span.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(span.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(span.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         val events = span.events
         assertEquals(1, events.size)
@@ -252,7 +252,7 @@ internal class Pre29ActivityLifecycleCallbacksTest {
             activity.javaClass.simpleName,
             stoppedSpan.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(stoppedSpan.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(stoppedSpan.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         var events: List<EventData> = stoppedSpan.events
         assertEquals(1, events.size)
@@ -270,7 +270,7 @@ internal class Pre29ActivityLifecycleCallbacksTest {
             activity.javaClass.simpleName,
             destroyedSpan.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(destroyedSpan.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(destroyedSpan.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         events = destroyedSpan.events
         assertEquals(1, events.size)
@@ -302,7 +302,7 @@ internal class Pre29ActivityLifecycleCallbacksTest {
             activity.javaClass.simpleName,
             stoppedSpan.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(stoppedSpan.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(stoppedSpan.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         var events: List<EventData> = stoppedSpan.events
         assertEquals(1, events.size)
@@ -320,7 +320,7 @@ internal class Pre29ActivityLifecycleCallbacksTest {
             activity.javaClass.simpleName,
             destroyedSpan.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(destroyedSpan.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(destroyedSpan.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         events = destroyedSpan.events
         assertEquals(1, events.size)

--- a/instrumentation/common-api/src/main/java/io/opentelemetry/android/instrumentation/annotations/RumScreenName.kt
+++ b/instrumentation/common-api/src/main/java/io/opentelemetry/android/instrumentation/annotations/RumScreenName.kt
@@ -6,7 +6,7 @@
 package io.opentelemetry.android.instrumentation.annotations
 
 /**
- * This annotation can be used to customize the `screen.name` attribute for an instrumented
+ * This annotation can be used to customize the `app.screen.name` attribute for an instrumented
  * Fragment or Activity.
  */
 @Retention(AnnotationRetention.RUNTIME)

--- a/instrumentation/common-api/src/main/java/io/opentelemetry/android/instrumentation/common/ActiveSpan.kt
+++ b/instrumentation/common-api/src/main/java/io/opentelemetry/android/instrumentation/common/ActiveSpan.kt
@@ -5,7 +5,8 @@
 
 package io.opentelemetry.android.instrumentation.common
 
-import io.opentelemetry.android.semconv.LastAttributes.LAST_SCREEN_NAME_KEY
+import io.opentelemetry.android.semconv.AppAttributes.APP_SCREEN_PREVIOUS_NAME
+import io.opentelemetry.android.semconv.internal.SemconvCompat.Companion.map
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.context.Scope
 
@@ -46,7 +47,7 @@ class ActiveSpan(
         span?.let {
             val previouslyVisibleScreen = lastVisibleScreen()
             if (previouslyVisibleScreen != null && screenName != previouslyVisibleScreen) {
-                it.setAttribute(LAST_SCREEN_NAME_KEY, previouslyVisibleScreen)
+                it.setAttribute(map(APP_SCREEN_PREVIOUS_NAME), previouslyVisibleScreen)
             }
         }
     }

--- a/instrumentation/fragment/README.md
+++ b/instrumentation/fragment/README.md
@@ -20,8 +20,9 @@ This instrumentation produces the following telemetry:
   `fragmentViewDestroyed` | `fragmentDestroyed` | `fragmentDetached` }
 * Attributes:
     * `fragment.name`:  name of fragment
-    * `screen.name`:  name of screen
-    * `last.screen.name`:  name of screen, when span contains the `fragmentResumed` event.
+    * `app.screen.name`: name of screen
+    * `app.screen.previous.name`: name of the previously visible screen, when the span contains the
+      `fragmentResumed` event.
 
 ## Installation
 

--- a/instrumentation/fragment/src/main/java/io/opentelemetry/android/instrumentation/fragment/FragmentTracer.kt
+++ b/instrumentation/fragment/src/main/java/io/opentelemetry/android/instrumentation/fragment/FragmentTracer.kt
@@ -42,7 +42,7 @@ internal class FragmentTracer(
                 .spanBuilder(spanName)
                 .setAttribute(FRAGMENT_NAME_KEY, fragmentName)
                 .startSpan()
-        // do this after the span is started, so we can override the default screen.name set by the
+        // do this after the span is started, so we can override the default app.screen.name set by the
         // RumAttributeAppender.
         span.setAttribute(map(APP_SCREEN_NAME), screenName)
         return span

--- a/instrumentation/fragment/src/test/java/io/opentelemetry/android/instrumentation/fragment/FragmentTracerTest.kt
+++ b/instrumentation/fragment/src/test/java/io/opentelemetry/android/instrumentation/fragment/FragmentTracerTest.kt
@@ -10,7 +10,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.opentelemetry.android.instrumentation.common.ActiveSpan
 import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTracker
-import io.opentelemetry.android.semconv.LastAttributes.LAST_SCREEN_NAME_KEY
+import io.opentelemetry.android.semconv.AppAttributes.APP_SCREEN_PREVIOUS_NAME_KEY
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.sdk.testing.junit5.OpenTelemetryExtension
 import io.opentelemetry.sdk.trace.data.SpanData
@@ -67,7 +67,7 @@ internal class FragmentTracerTest {
         trackableTracer.endActiveSpan()
 
         val span = this.singleSpan
-        assertNull(span.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(span.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
     }
 
     @Test
@@ -88,7 +88,7 @@ internal class FragmentTracerTest {
         trackableTracer.endActiveSpan()
 
         val span = this.singleSpan
-        assertNull(span.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(span.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
     }
 
     @Test
@@ -112,7 +112,7 @@ internal class FragmentTracerTest {
         val span = this.singleSpan
         assertEquals(
             "previousScreen",
-            span.attributes.get(LAST_SCREEN_NAME_KEY),
+            span.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY),
         )
     }
 

--- a/instrumentation/fragment/src/test/java/io/opentelemetry/android/instrumentation/fragment/RumFragmentLifecycleCallbacksTest.kt
+++ b/instrumentation/fragment/src/test/java/io/opentelemetry/android/instrumentation/fragment/RumFragmentLifecycleCallbacksTest.kt
@@ -12,8 +12,8 @@ import io.mockk.junit5.MockKExtension
 import io.mockk.mockk
 import io.opentelemetry.android.instrumentation.common.ScreenNameExtractor
 import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTracker
+import io.opentelemetry.android.semconv.AppAttributes.APP_SCREEN_PREVIOUS_NAME_KEY
 import io.opentelemetry.android.semconv.FragmentAttributes.FRAGMENT_NAME_KEY
-import io.opentelemetry.android.semconv.LastAttributes.LAST_SCREEN_NAME_KEY
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_NAME
@@ -70,7 +70,7 @@ internal class RumFragmentLifecycleCallbacksTest {
             fragment.javaClass.simpleName,
             spanData.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(spanData.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(spanData.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         val events = spanData.events
         assertEquals(7, events.size)
@@ -107,7 +107,7 @@ internal class RumFragmentLifecycleCallbacksTest {
         )
         assertEquals(
             "previousScreen",
-            spanData.attributes.get(LAST_SCREEN_NAME_KEY),
+            spanData.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY),
         )
 
         val events = spanData.events
@@ -134,7 +134,7 @@ internal class RumFragmentLifecycleCallbacksTest {
             fragment.javaClass.simpleName,
             spanData.attributes.get(FRAGMENT_NAME_KEY),
         )
-        assertNull(spanData.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(spanData.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         val events = spanData.events
         assertEquals(1, events.size)
@@ -164,7 +164,7 @@ internal class RumFragmentLifecycleCallbacksTest {
             fragment.javaClass.simpleName,
             spanData.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(spanData.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(spanData.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         val events = spanData.events
         assertEquals(1, events.size)
@@ -181,7 +181,7 @@ internal class RumFragmentLifecycleCallbacksTest {
             fragment.javaClass.simpleName,
             stopSpan.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(stopSpan.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(stopSpan.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         val stopEvents = stopSpan.events
         assertEquals(1, stopEvents.size)
@@ -211,7 +211,7 @@ internal class RumFragmentLifecycleCallbacksTest {
             fragment.javaClass.simpleName,
             pauseSpan.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(pauseSpan.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(pauseSpan.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         var events: List<EventData> = pauseSpan.events
         assertEquals(1, events.size)
@@ -226,7 +226,7 @@ internal class RumFragmentLifecycleCallbacksTest {
             fragment.javaClass.simpleName,
             stopSpan.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(stopSpan.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(stopSpan.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         val stopEvents = stopSpan.events
         assertEquals(1, stopEvents.size)
@@ -243,7 +243,7 @@ internal class RumFragmentLifecycleCallbacksTest {
             fragment.javaClass.simpleName,
             destroyViewSpan.attributes.get(stringKey(APP_SCREEN_NAME)),
         )
-        assertNull(destroyViewSpan.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(destroyViewSpan.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         events = destroyViewSpan.events
         assertEquals(1, events.size)
@@ -255,7 +255,7 @@ internal class RumFragmentLifecycleCallbacksTest {
         Assertions.assertNotNull(
             detachSpan.attributes.get(FRAGMENT_NAME_KEY),
         )
-        assertNull(detachSpan.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(detachSpan.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         events = detachSpan.events
         assertEquals(2, events.size)
@@ -284,7 +284,7 @@ internal class RumFragmentLifecycleCallbacksTest {
             fragment.javaClass.simpleName,
             span.attributes.get(FRAGMENT_NAME_KEY),
         )
-        assertNull(span.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(span.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         val events = span.events
         assertEquals(1, events.size)
@@ -312,7 +312,7 @@ internal class RumFragmentLifecycleCallbacksTest {
             fragment.javaClass.simpleName,
             destroyViewSpan.attributes.get(FRAGMENT_NAME_KEY),
         )
-        assertNull(destroyViewSpan.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(destroyViewSpan.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         var events: List<EventData> = destroyViewSpan.events
         assertEquals(1, events.size)
@@ -325,7 +325,7 @@ internal class RumFragmentLifecycleCallbacksTest {
             fragment.javaClass.simpleName,
             detachSpan.attributes.get(FRAGMENT_NAME_KEY),
         )
-        assertNull(detachSpan.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(detachSpan.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         events = detachSpan.events
         assertEquals(2, events.size)
@@ -354,7 +354,7 @@ internal class RumFragmentLifecycleCallbacksTest {
             fragment.javaClass.simpleName,
             detachSpan.attributes.get(FRAGMENT_NAME_KEY),
         )
-        assertNull(detachSpan.attributes.get(LAST_SCREEN_NAME_KEY))
+        assertNull(detachSpan.attributes.get(APP_SCREEN_PREVIOUS_NAME_KEY))
 
         val events = detachSpan.events
         assertEquals(1, events.size)

--- a/semconv/model/android/registry.yaml
+++ b/semconv/model/android/registry.yaml
@@ -111,6 +111,15 @@ groups:
       - id: last.screen.name
         type: string
         stability: development
+        deprecated:
+          reason: renamed
+          renamed_to: app.screen.previous.name
+        brief: >
+          Deprecated, use `app.screen.previous.name` instead.
+        examples: ["MainActivity"]
+      - id: app.screen.previous.name
+        type: string
+        stability: development
         brief: >
           The previously visible screen name.
         examples: ["MainActivity"]
@@ -123,8 +132,11 @@ groups:
       - id: screen.name
         type: string
         stability: development
+        deprecated:
+          reason: renamed
+          renamed_to: app.screen.name
         brief: >
-          The current application screen name used by the Android SDK.
+          Deprecated, use `app.screen.name` instead.
         examples: ["user.login", "Cart"]
       - id: screen.orientation
         type:

--- a/semconv/src/main/java/io/opentelemetry/android/semconv/internal/SemconvCompat.kt
+++ b/semconv/src/main/java/io/opentelemetry/android/semconv/internal/SemconvCompat.kt
@@ -5,8 +5,10 @@
 
 package io.opentelemetry.android.semconv.internal
 
+import io.opentelemetry.android.semconv.AppAttributes.APP_SCREEN_PREVIOUS_NAME
+import io.opentelemetry.android.semconv.LastAttributes.LAST_SCREEN_NAME
 import io.opentelemetry.android.semconv.ScreenAttributes.SCREEN_NAME
-import io.opentelemetry.kotlin.semconv.AppAttributes
+import io.opentelemetry.kotlin.semconv.AppAttributes.APP_SCREEN_NAME
 import io.opentelemetry.kotlin.semconv.IncubatingApi
 
 /**
@@ -19,6 +21,7 @@ class SemconvCompat internal constructor() {
     companion object {
         var useLatestExperimental = true
 
+        @Suppress("DEPRECATION")
         fun map(key: String): String {
             if (useLatestExperimental) {
                 return key
@@ -27,7 +30,9 @@ class SemconvCompat internal constructor() {
                 // new -> old
                 "app.crash" -> "device.crash"
 
-                AppAttributes.APP_SCREEN_NAME -> SCREEN_NAME
+                APP_SCREEN_NAME -> SCREEN_NAME
+
+                APP_SCREEN_PREVIOUS_NAME -> LAST_SCREEN_NAME
 
                 else -> key
             }

--- a/semconv/src/test/java/io/opentelemetry/android/semconv/internal/SemconvCompatTest.kt
+++ b/semconv/src/test/java/io/opentelemetry/android/semconv/internal/SemconvCompatTest.kt
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.android.semconv.internal
 
+import io.opentelemetry.android.semconv.AppAttributes.APP_SCREEN_PREVIOUS_NAME
+import io.opentelemetry.android.semconv.LastAttributes.LAST_SCREEN_NAME
 import io.opentelemetry.android.semconv.ScreenAttributes.SCREEN_NAME
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -24,9 +26,11 @@ class SemconvCompatTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
     fun `test compat with legacy`() {
         SemconvCompat.useLatestExperimental = false
         assertThat(SemconvCompat.map("app.screen.name")).isEqualTo(SCREEN_NAME)
+        assertThat(SemconvCompat.map(APP_SCREEN_PREVIOUS_NAME)).isEqualTo(LAST_SCREEN_NAME)
         assertThat(SemconvCompat.map("app.crash")).isEqualTo("device.crash")
         assertThat(SemconvCompat.map("rando.semconv.thinger")).isEqualTo("rando.semconv.thinger")
     }
@@ -35,6 +39,7 @@ class SemconvCompatTest {
     fun `test compat with latest experimental`() {
         SemconvCompat.useLatestExperimental = true
         assertThat(SemconvCompat.map("app.screen.name")).isEqualTo("app.screen.name")
+        assertThat(SemconvCompat.map(APP_SCREEN_PREVIOUS_NAME)).isEqualTo(APP_SCREEN_PREVIOUS_NAME)
         assertThat(SemconvCompat.map("app.crash")).isEqualTo("app.crash")
         assertThat(SemconvCompat.map("rando.semconv.thinger")).isEqualTo("rando.semconv.thinger")
     }

--- a/semconv/templates/registry/kotlin/kotlin_semconv_template.kt.j2
+++ b/semconv/templates/registry/kotlin/kotlin_semconv_template.kt.j2
@@ -24,6 +24,10 @@ object {{ my_class_name }} {
 {%- if attribute.type != "any" %}
 {%- set itype = attribute.type | instantiated_type %}
 {%- if itype in ["string", "boolean", "int", "double", "string[]", "boolean[]", "int[]", "double[]"] %}
+{%- if attribute is deprecated %}
+    @Deprecated("{{ attribute.deprecated.note | replace('\n', ' ') | trim }}")
+    @Suppress("DEPRECATION")
+{%- endif %}
     @JvmField
     val {{ attribute.name | screaming_snake_case }}_KEY: AttributeKey<{{ itype | map_text("kotlin_key_generic") }}> =
         AttributeKey.{{ itype | map_text("kotlin_key_factory") }}({{ attribute.name | screaming_snake_case }})


### PR DESCRIPTION
So `last.screen.name` remains a legacy inherited name that doesn't match current otel conventions....most notably, "`last`" would be considered a terrible namespace. 😁 

So this leverages the SemconvCompat class to map the new name back to the old name for users that want t his.

This also updates the weaver templates to mark these attributes that are deprecated in semconv also `@Deprecated` in code.