### PR TITLE
fix lychee link check failure

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -12,4 +12,5 @@ exclude = [
   '^https://github.com/open-telemetry/opentelemetry-android/(issues|pull)/\d+$',
   "^https://maven-badges.sml.io/maven-central/io.opentelemetry.android/.*$",
   "^https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/.*$",
+  "https://cloud-native.slack.com/archives/C05J0T9K27Q",
 ]

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -12,5 +12,5 @@ exclude = [
   '^https://github.com/open-telemetry/opentelemetry-android/(issues|pull)/\d+$',
   "^https://maven-badges.sml.io/maven-central/io.opentelemetry.android/.*$",
   "^https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/.*$",
-  "https://cloud-native.slack.com/archives/C05J0T9K27Q",
+  "^https://cloud-native\.slack\.com/archives/C05J0T9K27Q$",
 ]


### PR DESCRIPTION
It [looks like](https://github.com/open-telemetry/opentelemetry-android/actions/runs/32415870458/job/96576756417#step:3:303) another site is blocking github, so let's omit it from the link check.
