### PR TITLE
feat(native-crash): define stack snapshot format

### DIFF
--- a/instrumentation/native-crash/README.md
+++ b/instrumentation/native-crash/README.md
@@ -23,8 +23,9 @@ timestamp.epoch_nanos=<positive integer>
 
 The native writer and Kotlin reader must keep these keys and value formats in sync.
 
-The versioned binary format used for native frame recovery is documented in
-[`SNAPSHOT_FORMAT.md`](SNAPSHOT_FORMAT.md).
+The proposed versioned binary format for future native frame recovery is documented in
+[`SNAPSHOT_FORMAT.md`](SNAPSHOT_FORMAT.md). Runtime snapshot capture and recovery are follow-up
+work.
 
 ## Telemetry
 

--- a/instrumentation/native-crash/README.md
+++ b/instrumentation/native-crash/README.md
@@ -23,6 +23,9 @@ timestamp.epoch_nanos=<positive integer>
 
 The native writer and Kotlin reader must keep these keys and value formats in sync.
 
+The versioned binary format used for native frame recovery is documented in
+[`SNAPSHOT_FORMAT.md`](SNAPSHOT_FORMAT.md).
+
 ## Telemetry
 
 The replayed event uses the original crash timestamp and includes:

--- a/instrumentation/native-crash/README.md
+++ b/instrumentation/native-crash/README.md
@@ -63,7 +63,7 @@ stack frames are available.
 
 Crashes that happen before native crash instrumentation finishes initialization are not recorded.
 
-The persisted crash marker is deleted immediately after its event is emitted. Replay is therefore
-at most once: if the application exits before the telemetry is exported, that crash event may be
-lost. A later change may add support for preserving multiple consecutive startup crashes.
-Unreadable or malformed markers are discarded rather than retried.
+The current marker-only implementation deletes the persisted marker immediately after its event is
+emitted. Replay is therefore at most once: if the application exits before the telemetry is
+exported, that crash event may be lost. A later change may add support for preserving multiple
+consecutive startup crashes. Unreadable or malformed markers are discarded rather than retried.

--- a/instrumentation/native-crash/SNAPSHOT_FORMAT.md
+++ b/instrumentation/native-crash/SNAPSHOT_FORMAT.md
@@ -4,6 +4,9 @@ Status: proposed version 1 design for
 [#1940](https://github.com/open-telemetry/opentelemetry-android/issues/1940). Runtime capture,
 recovery, and replay are follow-up work and are not implemented by this change.
 
+The writer and reader rules below are normative requirements for those follow-up changes. They
+describe the completed version 1 behavior even though this PR defines only the shared contract.
+
 The native crash implementation uses a fixed-size snapshot so the signal handler can copy bounded
 state without allocation, locks, JNI, logging, or process-map parsing. Capture, parsing, unwinding,
 and replay are separate changes. `native_crash_snapshot.h` is the source of truth for the binary
@@ -49,6 +52,15 @@ satisfies `loadBias <= executableStart < executableEnd`. Names are nonblank UTF-
 characters, use at most 63 bytes, and always include a NUL terminator followed by zero padding.
 Build IDs longer than 32 bytes are recorded as unavailable rather than truncated.
 
+## Files And Pairing
+
+The marker and snapshot are separate fixed internal files whose paths are supplied when the native
+handler is installed. Temporary writes use the corresponding destination path with a `.tmp` suffix.
+Exact destination names are implementation details rather than part of the binary format.
+
+Recovery pairs a snapshot with a marker only when their signal number and timestamp match. A stale
+or otherwise mismatched snapshot is invalid and is never attached to the marker's crash event.
+
 ## Writer Rules
 
 Register and module addresses are unsigned. A 32-bit writer zero-extends every address into its
@@ -63,13 +75,12 @@ outside the signal handler. This costs 20,568 bytes of process storage but does 
 alternate signal stack or allocate during a crash.
 
 The marker and snapshot use the same signal number and a timestamp from a single `clock_gettime`
-call. The snapshot is written and atomically renamed before the marker, making the marker the commit
-record for a complete crash capture. The snapshot skips `fsync` to bound work in the fatal signal
-handler; process death does not discard completed page-cache writes. The smaller marker is synced
-before rename. A marker without a snapshot remains a valid crash without native frames. A snapshot
-without a marker is an orphan and is removed during startup recovery. This ordering treats the
-marker as the commit record, but an abrupt process termination during the snapshot write can lose
-the crash before the marker is created.
+call. The marker is written, synced, and atomically renamed first. The snapshot is then written and
+atomically renamed without `fsync` to bound work in the fatal signal handler. A second fault or
+abrupt process termination during the larger snapshot write therefore still leaves the marker as a
+valid crash without native frames. A snapshot without a marker is an orphan and is removed during
+startup recovery. Signal and timestamp matching prevents an older snapshot from being attached to
+a newer marker.
 
 Stack copying is fault-tolerant; a failed or short read produces a stack size from zero through
 4,096 rather than reading through an invalid page. The handler loops over interrupted short writes,
@@ -85,10 +96,12 @@ it is not an authenticity mechanism. Malformed module entries are skipped withou
 structurally valid entries. A record with no usable module entries remains valid but produces no
 native frames.
 
-Readers reject zero program counters or stack pointers, a stack start that differs from the stack
-pointer, and a stack start that is not aligned to the recorded architecture's pointer width. A
-misaligned or otherwise corrupt stack pointer therefore produces no native frames. Readers ignore
-the link-register field on x86 and x86_64.
+Readers reject zero stack pointers, a stack start that differs from the stack pointer, and a stack
+start that is not aligned to the recorded architecture's pointer width. A zero program counter is
+valid for crashes such as an indirect call through a null function pointer. Readers omit the
+program-counter frame in that case and continue with frame-pointer and link-register recovery. A
+misaligned or otherwise corrupt stack pointer produces no native frames. Readers ignore the
+link-register field on x86 and x86_64.
 
 ARM64 readers preserve captured values and try the raw address first. If it does not resolve, they
 retry after clearing bits 56 through 63, then 52 through 63, then 48 through 63 to account for
@@ -102,26 +115,40 @@ When a frame-pointer walk yields no caller, ARM and ARM64 readers may add a nonz
 The link register can be stale for a non-leaf crash, so readers preserve its provenance even when a
 stacktrace renderer cannot distinguish it from a frame-pointer result.
 
-A bounded stack scan may collect deduplicated heuristic candidates when no frame-pointer caller is
-recovered. Candidates are marked as unordered and are not rendered as confirmed stack frames. Only
-addresses inside a captured executable segment are retained. Confirmed frames are reported as
-`normalizedAddress - module.loadBias`, with the module build ID when available. The normalized
-address is the first architecture-specific candidate that resolves inside an executable segment.
+Confirmed frames are reported as `normalizedAddress - module.loadBias`, with the module build ID
+when available. The normalized address is the first architecture-specific candidate that resolves
+inside an executable segment.
 
-Recovery deletes the marker and snapshot only after replay succeeds. Retryable read or cleanup
-failures retain both files for a later launch; invalid snapshots are removed while the marker can
-still produce a crash without native frames. Implementations contain recovery exceptions so they
-cannot terminate the host application. Retries must be bounded by count or age; after the limit is
-reached, recovery files are discarded and the signal handler can be installed again.
+A malformed marker is discarded together with its snapshot and recovery state without emitting an
+event. A missing, malformed, or mismatched snapshot is discarded while its valid marker continues
+as a crash without native frames. Transient marker or snapshot read failures are retried. If
+snapshot retries are exhausted, recovery discards the snapshot and emits the valid marker-only
+crash. Other exhausted read failures discard all recovery files without emitting an event.
+
+Before emitting an event, recovery durably records that delivery has been claimed. If that state
+cannot be persisted, recovery does not emit and abandons the crash with best-effort cleanup. Once
+delivery is claimed, later launches perform cleanup only and never emit the event again. After the
+event is handed to OpenTelemetry, recovery deletes the marker, snapshot, and recovery state.
+Cleanup failures retain the remaining files for bounded cleanup-only retries.
+
+The signal handler is not installed while a retry is pending because version 1 uses one fixed marker
+and snapshot pair that a new crash would overwrite. Ordinary recovery exceptions and linkage errors
+are contained at the instrumentation boundary so they cannot terminate the host application;
+unrecoverable virtual-machine errors are not intercepted. Every retry path is bounded by count or
+age. After the applicable limit is reached, recovery performs best-effort cleanup and allows the
+signal handler to be installed again.
 
 ## Limitations
 
 Version 1 does not interpret DWARF or compact unwind metadata. ARM32 does not use frame-pointer
 walking, and optimized builds on other architectures can omit usable frame pointers, so recovery
-can contain only the crashing frame and, on ARM, a link-register candidate. Heuristic stack-scan
-candidates are not a call chain.
+can contain only the crashing frame and, on ARM and ARM64, a link-register candidate.
 
 The snapshot is limited to 128 executable segments and 4 KiB of stack memory. Modules loaded after
 the module table is prepared are not represented, so recovery can return a partial stack. A future
 CFI-aware unwinder or Crashpad integration can replace the reader without changing the
 signal-handler safety model. Symbol upload and backend symbolication remain separate work.
+
+While recovery is pending, native crashes in that process are not captured. Supporting concurrent
+pending and new crashes requires per-crash paths or renaming the pending files out of the handler's
+fixed destinations and is outside version 1.

--- a/instrumentation/native-crash/SNAPSHOT_FORMAT.md
+++ b/instrumentation/native-crash/SNAPSHOT_FORMAT.md
@@ -93,8 +93,8 @@ version, checksum, architecture, bounds, reserved fields, module metadata, and m
 signal and timestamp. The checksum uses 32-bit FNV-1a with offset basis `0x811c9dc5` and prime
 `0x01000193`, applying XOR before multiplication for each byte. It detects accidental corruption;
 it is not an authenticity mechanism. Malformed module entries are skipped without discarding
-structurally valid entries. A record with no usable module entries remains valid but produces no
-native frames.
+structurally valid entries. A record with one or more populated module entries remains valid if
+none of those entries are usable after validation, but it produces no native frames.
 
 Readers reject zero stack pointers, a stack start that differs from the stack pointer, and a stack
 start that is not aligned to the recorded architecture's pointer width. A zero program counter is

--- a/instrumentation/native-crash/SNAPSHOT_FORMAT.md
+++ b/instrumentation/native-crash/SNAPSHOT_FORMAT.md
@@ -1,0 +1,107 @@
+# Native Crash Snapshot Format
+
+Status: version 1 design for [#1940](https://github.com/open-telemetry/opentelemetry-android/issues/1940)
+
+The native crash implementation uses a fixed-size snapshot so the signal handler can copy bounded
+state without allocation, locks, JNI, logging, or process-map parsing. Capture, parsing, unwinding,
+and replay are separate changes. `native_crash_snapshot.h` is the source of truth for the binary
+layout; this document explains the corresponding fields and invariants. Keep both in sync.
+
+## Version 1
+
+Version 1 is a 20,568-byte, little-endian record. Readers require the exact version and record size.
+An incompatible record is discarded rather than interpreted using a newer layout.
+
+| Offset | Size | Field |
+| ---: | ---: | --- |
+| 0 | 8 | Magic: `OTELNCS\0` |
+| 8 | 4 | Format version (`1`) |
+| 12 | 4 | Architecture: ARM (`1`), ARM64 (`2`), x86 (`3`), or x86_64 (`4`) |
+| 16 | 4 | Total record size (`20568`) |
+| 20 | 4 | Fatal signal number |
+| 24 | 8 | Crash timestamp in Unix epoch nanoseconds |
+| 32 | 32 | Program counter, stack pointer, frame pointer, and link register |
+| 64 | 4 | Number of populated module entries (`1..128`) |
+| 68 | 4 | Number of captured stack bytes (`0..4096`) |
+| 72 | 8 | Address of the first captured stack byte; equal to the stack pointer |
+| 80 | 16384 | 128 fixed-size module entries |
+| 16464 | 4096 | Bounded stack bytes |
+| 20560 | 4 | Reserved; must be zero |
+| 20564 | 4 | 32-bit FNV-1a checksum of bytes 0 through 20563 |
+
+Each 128-byte module entry contains:
+
+| Relative offset | Size | Field |
+| ---: | ---: | --- |
+| 0 | 8 | Load bias |
+| 8 | 8 | Executable segment start |
+| 16 | 8 | Executable segment end |
+| 24 | 64 | NUL-terminated UTF-8 module basename |
+| 88 | 4 | ELF build-ID length (`0..32`; zero means unavailable) |
+| 92 | 32 | Raw ELF build-ID bytes followed by zero padding |
+| 124 | 4 | Reserved; must be zero |
+
+The writer zero-fills unused entries. It records app-owned modules before system modules and
+preserves loader order within each group, so the table is not address-sorted. Every populated entry
+satisfies `loadBias <= executableStart < executableEnd`. Names are nonblank UTF-8 without control
+characters, use at most 63 bytes, and always include a NUL terminator followed by zero padding.
+Build IDs longer than 32 bytes are recorded as unavailable rather than truncated.
+
+## Writer Rules
+
+Register and module addresses are unsigned. A 32-bit writer zero-extends every address into its
+64-bit field. Registers come from the signal handler's `ucontext_t.uc_mcontext`, never from the
+handler's own frame or alternate stack. The stack start equals the recorded stack pointer and is
+aligned to the architecture's pointer width. ARM64 register and stack values retain their raw tag
+and pointer-authentication bits; readers normalize those values before module comparisons.
+
+The snapshot record lives in pre-allocated static storage, including the module table prepared
+outside the signal handler. This costs 20,568 bytes of process storage but does not consume the
+alternate signal stack or allocate during a crash.
+
+The marker and snapshot use the same signal number and a timestamp from a single `clock_gettime`
+call. The snapshot is written and atomically renamed before the marker, making the marker the commit
+record for a complete crash capture. The snapshot skips `fsync` to bound work in the fatal signal
+handler; process death does not discard completed page-cache writes. The smaller marker is synced
+before rename. A marker without a snapshot remains a valid crash without native frames. A snapshot
+without a marker is an orphan and is removed during startup recovery.
+
+Stack copying is fault-tolerant; a failed or short read produces a stack size from zero through
+4,096 rather than reading through an invalid page. The handler loops over interrupted short writes,
+writes each file through a temporary path, closes it, and atomically renames it into place.
+
+## Reader Rules
+
+Readers treat snapshots as corrupt or stale until validated. They check the exact size, magic,
+version, checksum, architecture, bounds, reserved fields, module metadata, and matching marker
+signal and timestamp. The checksum uses 32-bit FNV-1a with offset basis `0x811c9dc5` and prime
+`0x01000193`, applying XOR before multiplication for each byte. It detects accidental corruption;
+it is not an authenticity mechanism. Malformed module entries are skipped without discarding
+structurally valid entries. A record with no usable module entries remains valid but produces no
+native frames.
+
+ARM64 readers preserve captured values but try module lookup after clearing bits 56 through 63,
+then 52 through 63, then 48 through 63 to account for top-byte tags and pointer authentication.
+ARM readers clear the Thumb bit before lookup. The first candidate inside a captured executable
+segment wins.
+
+Version 1 recovers at most 64 frames using a frame-pointer walk. A bounded stack scan may collect
+deduplicated heuristic candidates when no caller frame is recovered, but candidates are marked as
+unordered and are not rendered as confirmed stack frames. Only addresses inside a captured
+executable segment are retained. Confirmed frames are reported as module-relative addresses with
+the module build ID when available.
+
+Recovery deletes the marker and snapshot only after replay succeeds. Retryable read or cleanup
+failures retain both files for the next launch; invalid snapshots are removed while the marker can
+still produce a crash without native frames.
+
+## Limitations
+
+Version 1 does not interpret DWARF or compact unwind metadata. ARM32 and optimized builds commonly
+omit usable frame pointers, so recovery can contain only the crashing frame. Heuristic stack-scan
+candidates are not a call chain.
+
+The snapshot is limited to 128 executable segments and 4 KiB of stack memory. Modules loaded after
+the module table is prepared are not represented, so recovery can return a partial stack. A future
+CFI-aware unwinder or Crashpad integration can replace the reader without changing the
+signal-handler safety model. Symbol upload and backend symbolication remain separate work.

--- a/instrumentation/native-crash/SNAPSHOT_FORMAT.md
+++ b/instrumentation/native-crash/SNAPSHOT_FORMAT.md
@@ -1,6 +1,8 @@
 # Native Crash Snapshot Format
 
-Status: version 1 design for [#1940](https://github.com/open-telemetry/opentelemetry-android/issues/1940)
+Status: proposed version 1 design for
+[#1940](https://github.com/open-telemetry/opentelemetry-android/issues/1940). Runtime capture,
+recovery, and replay are follow-up work and are not implemented by this change.
 
 The native crash implementation uses a fixed-size snapshot so the signal handler can copy bounded
 state without allocation, locks, JNI, logging, or process-map parsing. Capture, parsing, unwinding,
@@ -51,9 +53,10 @@ Build IDs longer than 32 bytes are recorded as unavailable rather than truncated
 
 Register and module addresses are unsigned. A 32-bit writer zero-extends every address into its
 64-bit field. Registers come from the signal handler's `ucontext_t.uc_mcontext`, never from the
-handler's own frame or alternate stack. The stack start equals the recorded stack pointer and is
-aligned to the architecture's pointer width. ARM64 register and stack values retain their raw tag
-and pointer-authentication bits; readers normalize those values before module comparisons.
+handler's own frame or alternate stack. The stack start equals the unmodified recorded stack
+pointer. ARM64 register and stack values retain their raw tag and pointer-authentication bits;
+readers normalize those values before module comparisons. Writers set the link-register field to
+zero on x86 and x86_64.
 
 The snapshot record lives in pre-allocated static storage, including the module table prepared
 outside the signal handler. This costs 20,568 bytes of process storage but does not consume the
@@ -64,7 +67,9 @@ call. The snapshot is written and atomically renamed before the marker, making t
 record for a complete crash capture. The snapshot skips `fsync` to bound work in the fatal signal
 handler; process death does not discard completed page-cache writes. The smaller marker is synced
 before rename. A marker without a snapshot remains a valid crash without native frames. A snapshot
-without a marker is an orphan and is removed during startup recovery.
+without a marker is an orphan and is removed during startup recovery. This ordering treats the
+marker as the commit record, but an abrupt process termination during the snapshot write can lose
+the crash before the marker is created.
 
 Stack copying is fault-tolerant; a failed or short read produces a stack size from zero through
 4,096 rather than reading through an invalid page. The handler loops over interrupted short writes,
@@ -80,25 +85,40 @@ it is not an authenticity mechanism. Malformed module entries are skipped withou
 structurally valid entries. A record with no usable module entries remains valid but produces no
 native frames.
 
-ARM64 readers preserve captured values but try module lookup after clearing bits 56 through 63,
-then 52 through 63, then 48 through 63 to account for top-byte tags and pointer authentication.
-ARM readers clear the Thumb bit before lookup. The first candidate inside a captured executable
-segment wins.
+Readers reject zero program counters or stack pointers, a stack start that differs from the stack
+pointer, and a stack start that is not aligned to the recorded architecture's pointer width. A
+misaligned or otherwise corrupt stack pointer therefore produces no native frames. Readers ignore
+the link-register field on x86 and x86_64.
 
-Version 1 recovers at most 64 frames using a frame-pointer walk. A bounded stack scan may collect
-deduplicated heuristic candidates when no caller frame is recovered, but candidates are marked as
-unordered and are not rendered as confirmed stack frames. Only addresses inside a captured
-executable segment are retained. Confirmed frames are reported as module-relative addresses with
-the module build ID when available.
+ARM64 readers preserve captured values and try the raw address first. If it does not resolve, they
+retry after clearing bits 56 through 63, then 52 through 63, then 48 through 63 to account for
+top-byte tags and pointer authentication. ARM readers clear the Thumb bit before lookup. The first
+candidate inside a captured executable segment wins.
+
+Version 1 recovers at most 64 frames. ARM64, x86, and x86_64 readers walk frame records containing
+the previous frame pointer at `[fp]` and the return address at `[fp + pointerSize]`. ARM32 readers do
+not perform a frame-pointer walk; they report the program counter and may use the link register.
+When a frame-pointer walk yields no caller, ARM and ARM64 readers may add a nonzero link register.
+The link register can be stale for a non-leaf crash, so readers preserve its provenance even when a
+stacktrace renderer cannot distinguish it from a frame-pointer result.
+
+A bounded stack scan may collect deduplicated heuristic candidates when no frame-pointer caller is
+recovered. Candidates are marked as unordered and are not rendered as confirmed stack frames. Only
+addresses inside a captured executable segment are retained. Confirmed frames are reported as
+`normalizedAddress - module.loadBias`, with the module build ID when available. The normalized
+address is the first architecture-specific candidate that resolves inside an executable segment.
 
 Recovery deletes the marker and snapshot only after replay succeeds. Retryable read or cleanup
-failures retain both files for the next launch; invalid snapshots are removed while the marker can
-still produce a crash without native frames.
+failures retain both files for a later launch; invalid snapshots are removed while the marker can
+still produce a crash without native frames. Implementations contain recovery exceptions so they
+cannot terminate the host application. Retries must be bounded by count or age; after the limit is
+reached, recovery files are discarded and the signal handler can be installed again.
 
 ## Limitations
 
-Version 1 does not interpret DWARF or compact unwind metadata. ARM32 and optimized builds commonly
-omit usable frame pointers, so recovery can contain only the crashing frame. Heuristic stack-scan
+Version 1 does not interpret DWARF or compact unwind metadata. ARM32 does not use frame-pointer
+walking, and optimized builds on other architectures can omit usable frame pointers, so recovery
+can contain only the crashing frame and, on ARM, a link-register candidate. Heuristic stack-scan
 candidates are not a call chain.
 
 The snapshot is limited to 128 executable segments and 4 KiB of stack memory. Modules loaded after

--- a/instrumentation/native-crash/SNAPSHOT_FORMAT.md
+++ b/instrumentation/native-crash/SNAPSHOT_FORMAT.md
@@ -16,6 +16,8 @@ layout; this document explains the corresponding fields and invariants. Keep bot
 
 Version 1 is a 20,568-byte, little-endian record. Readers require the exact version and record size.
 An incompatible record is discarded rather than interpreted using a newer layout.
+It covers the four Android NDK ABIs currently produced by this module's native build. The explicit
+architecture value lets readers apply the correct pointer width and register rules.
 
 | Offset | Size | Field |
 | ---: | ---: | --- |
@@ -34,6 +36,11 @@ An incompatible record is discarded rather than interpreted using a newer layout
 | 20560 | 4 | Reserved; must be zero |
 | 20564 | 4 | 32-bit FNV-1a checksum of bytes 0 through 20563 |
 
+Each module entry identifies one executable `PT_LOAD` segment from an ELF image loaded in the
+process. Its address range and load bias let the reader turn a captured address into a
+module-relative frame; its basename and build ID identify the corresponding binary for downstream
+symbolication.
+
 Each 128-byte module entry contains:
 
 | Relative offset | Size | Field |
@@ -50,7 +57,9 @@ The writer zero-fills unused entries. It records app-owned modules before system
 preserves loader order within each group, so the table is not address-sorted. Every populated entry
 satisfies `loadBias <= executableStart < executableEnd`. Names are nonblank UTF-8 without control
 characters, use at most 63 bytes, and always include a NUL terminator followed by zero padding.
-Build IDs longer than 32 bytes are recorded as unavailable rather than truncated.
+The 32-byte capacity accommodates build IDs up through 256 bits. Longer IDs are recorded as
+unavailable rather than truncated because a partial identifier is not safe for exact artifact
+matching; increasing a fixed-size field would only move that bound.
 
 ## Files And Pairing
 
@@ -70,9 +79,12 @@ pointer. ARM64 register and stack values retain their raw tag and pointer-authen
 readers normalize those values before module comparisons. Writers set the link-register field to
 zero on x86 and x86_64.
 
-The snapshot record lives in pre-allocated static storage, including the module table prepared
-outside the signal handler. This costs 20,568 bytes of process storage but does not consume the
-alternate signal stack or allocate during a crash.
+The snapshot record lives in pre-allocated static storage. Before installing the signal handler,
+the writer walks the loaded ELF program headers and prepares the module table while normal runtime
+services are available. At crash time, the handler uses that table as-is; it does not inspect ELF
+metadata. If module preparation fails, marker capture remains enabled but snapshot capture is
+omitted. This costs 20,568 bytes of process storage but does not consume the alternate signal stack
+or allocate during a crash.
 
 The marker and snapshot use the same signal number and a timestamp from a single `clock_gettime`
 call. The marker is written, synced, and atomically renamed first. The snapshot is then written and

--- a/instrumentation/native-crash/SNAPSHOT_FORMAT.md
+++ b/instrumentation/native-crash/SNAPSHOT_FORMAT.md
@@ -17,7 +17,9 @@ layout; this document explains the corresponding fields and invariants. Keep bot
 Version 1 is a 20,568-byte, little-endian record. Readers require the exact version and record size.
 An incompatible record is discarded rather than interpreted using a newer layout.
 It covers the four Android NDK ABIs currently produced by this module's native build. The explicit
-architecture value lets readers apply the correct pointer width and register rules.
+architecture value lets readers apply the correct pointer width and register rules. Value `0`
+(`OTEL_NCS_ARCH_UNKNOWN`) is an internal compile-time sentinel and is not a valid serialized
+architecture.
 
 | Offset | Size | Field |
 | ---: | ---: | --- |
@@ -82,9 +84,9 @@ zero on x86 and x86_64.
 The snapshot record lives in pre-allocated static storage. Before installing the signal handler,
 the writer walks the loaded ELF program headers and prepares the module table while normal runtime
 services are available. At crash time, the handler uses that table as-is; it does not inspect ELF
-metadata. If module preparation fails, marker capture remains enabled but snapshot capture is
-omitted. This costs 20,568 bytes of process storage but does not consume the alternate signal stack
-or allocate during a crash.
+metadata. If `OTEL_NCS_ARCH_CURRENT` is `OTEL_NCS_ARCH_UNKNOWN`, or if module preparation fails,
+marker capture remains enabled but snapshot capture is omitted. This costs 20,568 bytes of process
+storage but does not consume the alternate signal stack or allocate during a crash.
 
 The marker and snapshot use the same signal number and a timestamp from a single `clock_gettime`
 call. The marker is written, synced, and atomically renamed first. The snapshot is then written and

--- a/instrumentation/native-crash/src/main/cpp/native_crash_handler.c
+++ b/instrumentation/native-crash/src/main/cpp/native_crash_handler.c
@@ -18,6 +18,9 @@
 #include <time.h>
 #include <unistd.h>
 
+// Compile the snapshot format's layout assertions before capture uses the record.
+#include "native_crash_snapshot.h"
+
 #define SIGNAL_COUNT 7
 #define TEMPORARY_SUFFIX ".tmp"
 #define MARKER_BUFFER_SIZE 128
@@ -149,6 +152,7 @@ static bool write_crash_marker_at(
 }
 
 static void write_crash_marker(int signal_number) {
+    // Snapshot capture must reuse this timestamp; see SNAPSHOT_FORMAT.md.
     struct timespec crash_time;
     if (clock_gettime(CLOCK_REALTIME, &crash_time) != 0 || crash_time.tv_sec < 0 ||
         crash_time.tv_nsec < 0) {

--- a/instrumentation/native-crash/src/main/cpp/native_crash_snapshot.h
+++ b/instrumentation/native-crash/src/main/cpp/native_crash_snapshot.h
@@ -33,7 +33,7 @@
 #elif defined(__x86_64__)
 #define OTEL_NCS_ARCH_CURRENT OTEL_NCS_ARCH_X86_64
 #else
-#define OTEL_NCS_ARCH_CURRENT UINT32_C(0)
+#error "Unsupported architecture for native crash snapshots"
 #endif
 
 // The binary layout is documented in SNAPSHOT_FORMAT.md. Keep both in sync.
@@ -75,9 +75,19 @@ _Static_assert(offsetof(struct otel_native_crash_module, build_id_size) == 88, "
 _Static_assert(offsetof(struct otel_native_crash_module, build_id) == 92, "Unexpected build ID offset");
 _Static_assert(offsetof(struct otel_native_crash_module, reserved) == 124, "Unexpected module reserved offset");
 _Static_assert(sizeof(struct otel_native_crash_module) == 128, "Unexpected module layout");
+_Static_assert(OTEL_NCS_MAGIC_SIZE == 8, "Unexpected magic size");
+_Static_assert(offsetof(struct otel_native_crash_snapshot, magic) == 0, "Unexpected magic offset");
+_Static_assert(offsetof(struct otel_native_crash_snapshot, version) == 8, "Unexpected version offset");
+_Static_assert(offsetof(struct otel_native_crash_snapshot, architecture) == 12, "Unexpected architecture offset");
+_Static_assert(offsetof(struct otel_native_crash_snapshot, record_size) == 16, "Unexpected record size offset");
+_Static_assert(offsetof(struct otel_native_crash_snapshot, signal_number) == 20, "Unexpected signal number offset");
 _Static_assert(offsetof(struct otel_native_crash_snapshot, timestamp_epoch_nanos) == 24, "Unexpected timestamp offset");
 _Static_assert(offsetof(struct otel_native_crash_snapshot, program_counter) == 32, "Unexpected program counter offset");
+_Static_assert(offsetof(struct otel_native_crash_snapshot, stack_pointer) == 40, "Unexpected stack pointer offset");
+_Static_assert(offsetof(struct otel_native_crash_snapshot, frame_pointer) == 48, "Unexpected frame pointer offset");
+_Static_assert(offsetof(struct otel_native_crash_snapshot, link_register) == 56, "Unexpected link register offset");
 _Static_assert(offsetof(struct otel_native_crash_snapshot, module_count) == 64, "Unexpected module count offset");
+_Static_assert(offsetof(struct otel_native_crash_snapshot, stack_size) == 68, "Unexpected stack size offset");
 _Static_assert(offsetof(struct otel_native_crash_snapshot, stack_start) == 72, "Unexpected stack start offset");
 _Static_assert(offsetof(struct otel_native_crash_snapshot, modules) == 80, "Unexpected header layout");
 _Static_assert(offsetof(struct otel_native_crash_snapshot, stack) == 16464, "Unexpected stack offset");

--- a/instrumentation/native-crash/src/main/cpp/native_crash_snapshot.h
+++ b/instrumentation/native-crash/src/main/cpp/native_crash_snapshot.h
@@ -19,6 +19,7 @@
 #define OTEL_NCS_BUILD_ID_SIZE 32
 #define OTEL_NCS_STACK_CAPACITY 4096
 
+#define OTEL_NCS_ARCH_UNKNOWN UINT32_C(0)
 #define OTEL_NCS_ARCH_ARM UINT32_C(1)
 #define OTEL_NCS_ARCH_ARM64 UINT32_C(2)
 #define OTEL_NCS_ARCH_X86 UINT32_C(3)
@@ -33,7 +34,7 @@
 #elif defined(__x86_64__)
 #define OTEL_NCS_ARCH_CURRENT OTEL_NCS_ARCH_X86_64
 #else
-#error "Unsupported architecture for native crash snapshots"
+#define OTEL_NCS_ARCH_CURRENT OTEL_NCS_ARCH_UNKNOWN
 #endif
 
 // The binary layout is documented in SNAPSHOT_FORMAT.md. Keep both in sync.

--- a/instrumentation/native-crash/src/main/cpp/native_crash_snapshot.h
+++ b/instrumentation/native-crash/src/main/cpp/native_crash_snapshot.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef OTEL_ANDROID_NATIVE_CRASH_SNAPSHOT_H
+#define OTEL_ANDROID_NATIVE_CRASH_SNAPSHOT_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define OTEL_NCS_MAGIC_SIZE 8
+#define OTEL_NCS_MAGIC {'O', 'T', 'E', 'L', 'N', 'C', 'S', '\0'}
+#define OTEL_NCS_VERSION UINT32_C(1)
+#define OTEL_NCS_FNV_OFFSET_BASIS UINT32_C(0x811C9DC5)
+#define OTEL_NCS_FNV_PRIME UINT32_C(0x01000193)
+#define OTEL_NCS_MAX_MODULES 128
+#define OTEL_NCS_MODULE_NAME_SIZE 64
+#define OTEL_NCS_BUILD_ID_SIZE 32
+#define OTEL_NCS_STACK_CAPACITY 4096
+
+#define OTEL_NCS_ARCH_ARM UINT32_C(1)
+#define OTEL_NCS_ARCH_ARM64 UINT32_C(2)
+#define OTEL_NCS_ARCH_X86 UINT32_C(3)
+#define OTEL_NCS_ARCH_X86_64 UINT32_C(4)
+
+#if defined(__arm__)
+#define OTEL_NCS_ARCH_CURRENT OTEL_NCS_ARCH_ARM
+#elif defined(__aarch64__)
+#define OTEL_NCS_ARCH_CURRENT OTEL_NCS_ARCH_ARM64
+#elif defined(__i386__)
+#define OTEL_NCS_ARCH_CURRENT OTEL_NCS_ARCH_X86
+#elif defined(__x86_64__)
+#define OTEL_NCS_ARCH_CURRENT OTEL_NCS_ARCH_X86_64
+#else
+#define OTEL_NCS_ARCH_CURRENT UINT32_C(0)
+#endif
+
+// The binary layout is documented in SNAPSHOT_FORMAT.md. Keep both in sync.
+struct otel_native_crash_module {
+    uint64_t load_bias;
+    uint64_t executable_start;
+    uint64_t executable_end;
+    char name[OTEL_NCS_MODULE_NAME_SIZE];
+    uint32_t build_id_size;
+    unsigned char build_id[OTEL_NCS_BUILD_ID_SIZE];
+    uint32_t reserved;
+};
+
+struct otel_native_crash_snapshot {
+    unsigned char magic[OTEL_NCS_MAGIC_SIZE];
+    uint32_t version;
+    uint32_t architecture;
+    uint32_t record_size;
+    uint32_t signal_number;
+    uint64_t timestamp_epoch_nanos;
+    uint64_t program_counter;
+    uint64_t stack_pointer;
+    uint64_t frame_pointer;
+    uint64_t link_register;
+    uint32_t module_count;
+    uint32_t stack_size;
+    uint64_t stack_start;
+    struct otel_native_crash_module modules[OTEL_NCS_MAX_MODULES];
+    unsigned char stack[OTEL_NCS_STACK_CAPACITY];
+    uint32_t reserved;
+    uint32_t checksum;
+};
+
+_Static_assert(offsetof(struct otel_native_crash_module, load_bias) == 0, "Unexpected load bias offset");
+_Static_assert(offsetof(struct otel_native_crash_module, executable_start) == 8, "Unexpected executable start offset");
+_Static_assert(offsetof(struct otel_native_crash_module, executable_end) == 16, "Unexpected executable end offset");
+_Static_assert(offsetof(struct otel_native_crash_module, name) == 24, "Unexpected module name offset");
+_Static_assert(offsetof(struct otel_native_crash_module, build_id_size) == 88, "Unexpected build ID size offset");
+_Static_assert(offsetof(struct otel_native_crash_module, build_id) == 92, "Unexpected build ID offset");
+_Static_assert(offsetof(struct otel_native_crash_module, reserved) == 124, "Unexpected module reserved offset");
+_Static_assert(sizeof(struct otel_native_crash_module) == 128, "Unexpected module layout");
+_Static_assert(offsetof(struct otel_native_crash_snapshot, timestamp_epoch_nanos) == 24, "Unexpected timestamp offset");
+_Static_assert(offsetof(struct otel_native_crash_snapshot, program_counter) == 32, "Unexpected program counter offset");
+_Static_assert(offsetof(struct otel_native_crash_snapshot, module_count) == 64, "Unexpected module count offset");
+_Static_assert(offsetof(struct otel_native_crash_snapshot, stack_start) == 72, "Unexpected stack start offset");
+_Static_assert(offsetof(struct otel_native_crash_snapshot, modules) == 80, "Unexpected header layout");
+_Static_assert(offsetof(struct otel_native_crash_snapshot, stack) == 16464, "Unexpected stack offset");
+_Static_assert(offsetof(struct otel_native_crash_snapshot, reserved) == 20560, "Unexpected reserved offset");
+_Static_assert(offsetof(struct otel_native_crash_snapshot, checksum) == 20564, "Unexpected checksum offset");
+_Static_assert(sizeof(struct otel_native_crash_snapshot) == 20568, "Unexpected record size");
+
+#endif


### PR DESCRIPTION
Defines the versioned native crash snapshot contract for #1940 before capture and recovery are added.

The shared C header pins the magic value, checksum constants, ABI mapping, field offsets, and total size with compile-time assertions. The format document records the writer and reader rules, crash-handler constraints, recovery ordering, and current limitations.

## Scope

This is a contract-only change. It does not change runtime crash behavior and can merge independently.

## Follow-up sequence

The implementation is prepared as small, stacked changes so each safety boundary can be reviewed separately:

1. Parse and validate the snapshot, rejecting malformed records and module entries.
2. Recover best-effort module-relative frames from the program counter, frame-pointer chain, and link register. Version 1 will not use heuristic stack scanning.
3. Add recovered frames to the replayed `app.crash` event, with bounded retries and cleanup only after successful processing. Recovery boundaries will contain ordinary exceptions and linkage failures.
4. Capture the fixed-size record in the signal handler without allocation, locks, JNI, logging, or process-map parsing, while preserving `errno`, handler chaining, and reentrancy behavior.
5. Validate the complete path across the four supported ABIs, debug and release builds, malformed and partial records, cleanup failures, and handler interoperability.

Each follow-up can be reviewed and merged independently after its prerequisite lands. Symbol upload and backend symbolication remain separate work tracked outside this stack.

Related to #1940