### PR TITLE
fix: change default dispatcher to IO for PeriodicTaskScheduler

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/internal/services/periodic/PeriodicTaskSchedulerImpl.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/services/periodic/PeriodicTaskSchedulerImpl.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 internal class PeriodicTaskSchedulerImpl(
-    dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : PeriodicTaskScheduler {
     private val job = SupervisorJob()
     private val scope = CoroutineScope(job + dispatcher)


### PR DESCRIPTION
Fixes #2005 