### PR TITLE
refactor: CacheStorageImpl with lazy initialization and add tests

### DIFF
--- a/core/src/main/java/io/opentelemetry/android/internal/services/storage/CacheStorageImpl.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/services/storage/CacheStorageImpl.kt
@@ -18,6 +18,5 @@ import java.io.File
 internal class CacheStorageImpl(
     private val appContext: Context,
 ) : CacheStorage {
-    override val cacheDir: File
-        get() = appContext.cacheDir
+    override val cacheDir: File by lazy { appContext.cacheDir }
 }

--- a/core/src/test/java/io/opentelemetry/android/internal/services/storage/CacheStorageImplTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/services/storage/CacheStorageImplTest.kt
@@ -10,11 +10,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
-import java.io.File
 import org.junit.Test
+import java.io.File
 
 class CacheStorageImplTest {
-
     @Test
     fun `check cacheDir is cached and calls appContext cacheDir only once`() {
         val context = mockk<Context>()

--- a/core/src/test/java/io/opentelemetry/android/internal/services/storage/CacheStorageImplTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/services/storage/CacheStorageImplTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.internal.services.storage
+
+import android.content.Context
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import java.io.File
+import org.junit.Test
+
+class CacheStorageImplTest {
+
+    @Test
+    fun `check cacheDir is cached and calls appContext cacheDir only once`() {
+        val context = mockk<Context>()
+        val expectedDir = File("/mock/cache/dir")
+        every { context.cacheDir } returns expectedDir
+
+        val cacheStorage = CacheStorageImpl(context)
+
+        // Read cacheDir 3 times and ensure the same value is returned each time.
+        repeat(3) {
+            assertThat(cacheStorage.cacheDir).isEqualTo(expectedDir)
+        }
+
+        // The underlying context cacheDir should only be queried once.
+        verify(exactly = 1) { context.cacheDir }
+    }
+}


### PR DESCRIPTION
Fixes #2006 

### Description
- `CacheStorageImpl` evaluated `appContext.cacheDir` on every property access via a custom getter. 
- Multiple components read `cacheDir` on startup, causing redundant disk checks

### Solution
- Updated `CacheStorageImpl.cacheDir` to use Kotlin's `by lazy` delegate.
- Added a unit test in `CacheStorageImplTest` to verify that `appContext.cacheDir` is evaluated only once on multiple reads.