### PR TITLE
Make VisibleScreenTracker aware of Compose Navigation destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   now records an `app.navigation.complete` event carrying the `app.navigation.destination.name`
   attribute whenever a navigation completes.
   ([#1920](https://github.com/open-telemetry/opentelemetry-android/issues/1920))
+- `VisibleScreenTracker` can now be told about a screen that is neither an Activity nor a Fragment,
+  and the Compose Navigation instrumentation reports its resolved destination name through it. For
+  apps that attach that instrumentation, the destination takes precedence over the last resumed
+  fragment and activity until the controller leaves the composition.
+  ([#1909](https://github.com/open-telemetry/opentelemetry-android/issues/1909))
 
 ### 🛠️ Bug fixes
 

--- a/instrumentation/compose/navigation/build.gradle.kts
+++ b/instrumentation/compose/navigation/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     implementation(project(":agent-api"))
     implementation(project(":common"))
     implementation(project(":semconv"))
+    implementation(project(":services"))
 
     compileOnly(libs.compose) {
         exclude(group = "org.jetbrains.kotlinx")

--- a/instrumentation/compose/navigation/src/main/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavControllerExtensions.kt
+++ b/instrumentation/compose/navigation/src/main/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavControllerExtensions.kt
@@ -11,12 +11,14 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.Navigator
 import androidx.navigation.compose.rememberNavController
 import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.internal.services.Services
 
 /**
  * Attaches OpenTelemetry navigation instrumentation to this [NavController]: on every completed
@@ -28,6 +30,11 @@ import io.opentelemetry.android.OpenTelemetryRum
  * already showing, and re-attaching (for example after a configuration change) emits again without
  * a navigation. The replay supplies no arguments, even for a parameterised start destination. See
  * the module README for the full event contract.
+ *
+ * The resolved screen name is also reported to the visible screen tracker, which uses it as the
+ * currently visible screen until this controller leaves the composition and clears it. Clearing
+ * only takes effect while this controller's destination is still the recorded one, so a nested or
+ * sibling controller's newer destination survives.
  *
  * Works for any controller you already hold, including nested/child controllers, not just the host
  * controller returned by `rememberNavController()`. The receiver is returned with its static type
@@ -49,9 +56,16 @@ fun <T : NavController> T.withOpenTelemetry(
     val emitter = remember(rum) { NavigationEmitter(rum) }
     val currentEmitter by rememberUpdatedState(emitter)
     val currentScreenName by rememberUpdatedState(screenName)
-    DisposableEffect(this) {
-        val listener = attachOpenTelemetry({ currentEmitter }, { currentScreenName })
-        onDispose { removeOnDestinationChangedListener(listener) }
+    val appContext = LocalContext.current.applicationContext
+    val visibleScreenTracker =
+        remember(appContext) { Services.get(appContext).visibleScreenTracker }
+    DisposableEffect(this, visibleScreenTracker) {
+        val reporter = NavigationDestinationReporter(visibleScreenTracker)
+        val listener = attachOpenTelemetry({ currentEmitter }, { currentScreenName }, reporter)
+        onDispose {
+            removeOnDestinationChangedListener(listener)
+            reporter.clear()
+        }
     }
     return this
 }
@@ -70,8 +84,9 @@ fun rememberObservedNavController(
 
 /**
  * Registers an [NavController.OnDestinationChangedListener] that resolves a screen name and hands
- * it to the [emitter] on each destination change. The [emitter] and [screenName] are resolved
- * lazily on every change, so callers can back them with values that vary over time.
+ * it to the [emitter] and the [reporter] on each destination change. The [emitter] and
+ * [screenName] are resolved lazily on every change, so callers can back them with values that vary
+ * over time.
  *
  * This is the non-Compose core of [withOpenTelemetry], extracted so it can be tested by invoking
  * the returned listener directly.
@@ -79,10 +94,13 @@ fun rememberObservedNavController(
 internal fun NavController.attachOpenTelemetry(
     emitter: () -> NavigationEmitter,
     screenName: () -> (NavDestination, Bundle?) -> String,
+    reporter: NavigationDestinationReporter,
 ): NavController.OnDestinationChangedListener {
     val listener =
         NavController.OnDestinationChangedListener { _, destination, arguments ->
-            emitter().onNavigation(screenName()(destination, arguments))
+            val resolvedScreenName = screenName()(destination, arguments)
+            reporter.report(resolvedScreenName)
+            emitter().onNavigation(resolvedScreenName)
         }
     addOnDestinationChangedListener(listener)
     return listener

--- a/instrumentation/compose/navigation/src/main/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationDestinationReporter.kt
+++ b/instrumentation/compose/navigation/src/main/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationDestinationReporter.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.compose.navigation
+
+import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTracker
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Reports resolved screen names to the [VisibleScreenTracker] on behalf of a single attached
+ * controller, remembering the last name it reported so that [clear] can name it.
+ *
+ * Each attached controller owns its own reporter. A nested or sibling controller that has since
+ * recorded a newer destination therefore keeps it when an older controller leaves the composition,
+ * because the tracker only honours a clear for the destination it still holds.
+ */
+internal class NavigationDestinationReporter(
+    private val visibleScreenTracker: VisibleScreenTracker,
+) {
+    private val lastReportedName = AtomicReference<String?>()
+
+    fun report(destinationName: String) {
+        lastReportedName.set(destinationName)
+        visibleScreenTracker.navigationDestinationChanged(destinationName)
+    }
+
+    fun clear() {
+        lastReportedName.getAndSet(null)?.let(visibleScreenTracker::navigationDestinationCleared)
+    }
+}

--- a/instrumentation/compose/navigation/src/test/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavControllerExtensionsTest.kt
+++ b/instrumentation/compose/navigation/src/test/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavControllerExtensionsTest.kt
@@ -17,22 +17,24 @@ import org.junit.runner.RunWith
 @RunWith(AndroidJUnit4::class)
 class NavControllerExtensionsTest {
     private val emitter = mockk<NavigationEmitter>(relaxed = true)
+    private val reporter = mockk<NavigationDestinationReporter>(relaxed = true)
 
     @Test
     fun `notifies the emitter on each destination change`() {
         val controller = mockk<NavController>(relaxed = true)
-        val listener = controller.attachOpenTelemetry({ emitter }, { { _, _ -> "home" } })
+        val listener = controller.attachOpenTelemetry({ emitter }, { { _, _ -> "home" } }, reporter)
 
         listener.onDestinationChanged(controller, mockk<NavDestination>(), null)
 
         verify(exactly = 1) { emitter.onNavigation("home") }
+        verify(exactly = 1) { reporter.report("home") }
     }
 
     @Test
     fun `listener uses the latest screenName supplied at fire time`() {
         val controller = mockk<NavController>(relaxed = true)
         var name = "first"
-        val listener = controller.attachOpenTelemetry({ emitter }, { { _, _ -> name } })
+        val listener = controller.attachOpenTelemetry({ emitter }, { { _, _ -> name } }, reporter)
 
         val destination = mockk<NavDestination>()
         listener.onDestinationChanged(controller, destination, null)

--- a/instrumentation/compose/navigation/src/test/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationDestinationReporterTest.kt
+++ b/instrumentation/compose/navigation/src/test/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationDestinationReporterTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.compose.navigation
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.mockk
+import io.mockk.verify
+import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTracker
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class NavigationDestinationReporterTest {
+    private val visibleScreenTracker = mockk<VisibleScreenTracker>(relaxed = true)
+    private val reporter = NavigationDestinationReporter(visibleScreenTracker)
+
+    @Test
+    fun `clears using the last name it reported`() {
+        reporter.report("a")
+        reporter.report("b")
+        reporter.clear()
+
+        verify(exactly = 1) { visibleScreenTracker.navigationDestinationCleared("b") }
+        verify(exactly = 0) { visibleScreenTracker.navigationDestinationCleared("a") }
+    }
+
+    @Test
+    fun `clearing without having reported anything does not touch the tracker`() {
+        reporter.clear()
+
+        verify(exactly = 0) { visibleScreenTracker.navigationDestinationCleared(any()) }
+    }
+
+    @Test
+    fun `clearing twice only clears once`() {
+        reporter.report("a")
+        reporter.clear()
+        reporter.clear()
+
+        verify(exactly = 1) { visibleScreenTracker.navigationDestinationCleared("a") }
+    }
+}

--- a/instrumentation/compose/navigation/src/test/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationVisibleScreenComposeTest.kt
+++ b/instrumentation/compose/navigation/src/test/kotlin/io/opentelemetry/instrumentation/compose/navigation/NavigationVisibleScreenComposeTest.kt
@@ -1,0 +1,149 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.instrumentation.compose.navigation
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.internal.services.Services
+import io.opentelemetry.android.internal.services.visiblescreen.VisibleScreenTracker
+import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Covers the [VisibleScreenTracker] side of the instrumentation: the resolved screen name is
+ * reported on every destination change and cleared when the controller leaves the composition.
+ */
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@RunWith(AndroidJUnit4::class)
+class NavigationVisibleScreenComposeTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private lateinit var rum: OpenTelemetryRum
+    private lateinit var visibleScreenTracker: VisibleScreenTracker
+
+    @Before
+    fun setup() {
+        val otel = OpenTelemetryRule.create()
+        rum =
+            mockk<OpenTelemetryRum> {
+                every { openTelemetry } returns otel.openTelemetry
+            }
+        visibleScreenTracker = mockk(relaxed = true)
+        Services.set(
+            mockk<Services> {
+                every { this@mockk.visibleScreenTracker } returns this@NavigationVisibleScreenComposeTest.visibleScreenTracker
+            },
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Services.set(null)
+    }
+
+    @Test
+    fun `reports the resolved screen name on attach and on each navigation`() {
+        lateinit var navController: NavHostController
+        composeRule.setContent {
+            navController = rememberObservedNavController(rum)
+            NavHost(navController, startDestination = "a") {
+                composable("a") {}
+                composable("b") {}
+            }
+        }
+
+        composeRule.runOnIdle { navController.navigate("b") }
+        composeRule.waitForIdle()
+
+        verifyOrder {
+            visibleScreenTracker.navigationDestinationChanged("a")
+            visibleScreenTracker.navigationDestinationChanged("b")
+        }
+    }
+
+    @Test
+    fun `reports the route pattern rather than the filled in arguments`() {
+        lateinit var navController: NavHostController
+        composeRule.setContent {
+            navController = rememberObservedNavController(rum)
+            NavHost(navController, startDestination = "user/1") {
+                composable("user/{id}") {}
+            }
+        }
+
+        composeRule.runOnIdle { navController.navigate("user/2") }
+        composeRule.waitForIdle()
+
+        verify(exactly = 2) { visibleScreenTracker.navigationDestinationChanged("user/{id}") }
+        verify(exactly = 0) { visibleScreenTracker.navigationDestinationChanged("user/2") }
+    }
+
+    @Test
+    fun `clears the destination when the controller leaves the composition`() {
+        var instrumented by mutableStateOf(true)
+        composeRule.setContent {
+            val navController = rememberNavController()
+            if (instrumented) {
+                navController.withOpenTelemetry(rum)
+            }
+            NavHost(navController, startDestination = "a") {
+                composable("a") {}
+            }
+        }
+        composeRule.waitForIdle()
+
+        composeRule.runOnIdle { instrumented = false }
+        composeRule.waitForIdle()
+
+        verify(exactly = 1) { visibleScreenTracker.navigationDestinationCleared("a") }
+    }
+
+    @Test
+    fun `a dispose and re-attach cycle clears and then replays the destination`() {
+        var instrumented by mutableStateOf(true)
+        composeRule.setContent {
+            val navController = rememberNavController()
+            if (instrumented) {
+                navController.withOpenTelemetry(rum)
+            }
+            NavHost(navController, startDestination = "a") {
+                composable("a") {}
+            }
+        }
+        composeRule.waitForIdle()
+
+        // Approximates a configuration change: the effect is disposed and then re-registered,
+        // and registering replays the destination that is already showing.
+        composeRule.runOnIdle { instrumented = false }
+        composeRule.waitForIdle()
+        composeRule.runOnIdle { instrumented = true }
+        composeRule.waitForIdle()
+
+        verifyOrder {
+            visibleScreenTracker.navigationDestinationChanged("a")
+            visibleScreenTracker.navigationDestinationCleared("a")
+            visibleScreenTracker.navigationDestinationChanged("a")
+        }
+    }
+}

--- a/services/api/services.api
+++ b/services/api/services.api
@@ -73,6 +73,8 @@ public abstract interface class io/opentelemetry/android/internal/services/visib
 	public abstract fun fragmentResumed (Landroidx/fragment/app/Fragment;)V
 	public abstract fun getCurrentlyVisibleScreen ()Ljava/lang/String;
 	public abstract fun getPreviouslyVisibleScreen ()Ljava/lang/String;
+	public abstract fun navigationDestinationChanged (Ljava/lang/String;)V
+	public abstract fun navigationDestinationCleared (Ljava/lang/String;)V
 }
 
 public abstract interface class io/opentelemetry/android/internal/services/visiblescreen/activities/DefaultingActivityLifecycleCallbacks : android/app/Application$ActivityLifecycleCallbacks {

--- a/services/src/main/java/io/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTracker.kt
+++ b/services/src/main/java/io/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTracker.kt
@@ -13,10 +13,15 @@ import io.opentelemetry.android.internal.services.Service
  * Wherein we do our best to figure out what "screen" is visible and what was the previously visible
  * "screen".
  *
- * In general, we favor using the last fragment that was resumed, but fall back to the last
- * resumed activity in case we don't have a fragment.
+ * In general, we favor the most recently reported navigation destination, then the last fragment
+ * that was resumed, and fall back to the last resumed activity in case we have neither. While a
+ * destination is recorded it outranks both, including a DialogFragment shown over it.
  *
- * We always ignore NavHostFragment instances since they aren't ever visible to the user.
+ * Navigation destinations contribute only to the currently visible screen. The previously visible
+ * screen is still derived from fragments and activities alone.
+ *
+ * We always ignore NavHostFragment instances since they aren't ever visible to the user. That
+ * concerns the host fragment itself, not the destinations a navigation library reports to us.
  *
  * We have to treat DialogFragments slightly differently since they don't replace the launching
  * screen, and the launching screen never leaves visibility.
@@ -32,4 +37,20 @@ interface VisibleScreenTracker : Service {
     fun fragmentResumed(fragment: Fragment)
 
     fun fragmentPaused(fragment: Fragment)
+
+    /**
+     * Records the screen name of a navigation destination reached by a source that is neither an
+     * Activity nor a Fragment, such as a Compose Navigation NavController. The recorded name takes
+     * precedence over the last resumed fragment and activity until it is cleared.
+     */
+    fun navigationDestinationChanged(destinationName: String)
+
+    /**
+     * Clears the recorded navigation destination, so that the visible screen falls back to the last
+     * resumed fragment, then the last resumed activity.
+     *
+     * The clear only applies if [destinationName] is still the recorded destination. A source that
+     * has since been superseded by another one therefore cannot discard the newer destination.
+     */
+    fun navigationDestinationCleared(destinationName: String)
 }

--- a/services/src/main/java/io/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTrackerImpl.kt
+++ b/services/src/main/java/io/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTrackerImpl.kt
@@ -22,10 +22,15 @@ import java.util.concurrent.atomic.AtomicReference
  * Wherein we do our best to figure out what "screen" is visible and what was the previously visible
  * "screen".
  *
- * In general, we favor using the last fragment that was resumed, but fall back to the last
- * resumed activity in case we don't have a fragment.
+ * In general, we favor the most recently reported navigation destination, then the last fragment
+ * that was resumed, and fall back to the last resumed activity in case we have neither. While a
+ * destination is recorded it outranks both, including a DialogFragment shown over it.
  *
- * We always ignore NavHostFragment instances since they aren't ever visible to the user.
+ * Navigation destinations contribute only to the currently visible screen. The previously visible
+ * screen is still derived from fragments and activities alone.
+ *
+ * We always ignore NavHostFragment instances since they aren't ever visible to the user. That
+ * concerns the host fragment itself, not the destinations a navigation library reports to us.
  *
  * We have to treat DialogFragments slightly differently since they don't replace the launching
  * screen, and the launching screen never leaves visibility.
@@ -37,6 +42,7 @@ internal class VisibleScreenTrackerImpl internal constructor(
     private val previouslyLastResumedActivity = AtomicReference<String>()
     private val lastResumedFragment = AtomicReference<String>()
     private val previouslyLastResumedFragment = AtomicReference<String?>()
+    private val currentNavigationDestination = AtomicReference<String?>()
     private val activityLifecycleTracker by lazy { buildActivitiesTracker() }
     private val fragmentLifecycleTrackerRegisterer by lazy { buildFragmentsTrackerRegisterer() }
 
@@ -76,6 +82,10 @@ internal class VisibleScreenTrackerImpl internal constructor(
 
     override val currentlyVisibleScreen: String
         get() {
+            val destination = currentNavigationDestination.get()
+            if (destination != null) {
+                return destination
+            }
             val lastFragment = lastResumedFragment.get()
             if (lastFragment != null) {
                 return lastFragment
@@ -119,6 +129,14 @@ internal class VisibleScreenTrackerImpl internal constructor(
             lastResumedFragment.compareAndSet(fragment.javaClass.simpleName, null)
         }
         previouslyLastResumedFragment.set(fragment.javaClass.simpleName)
+    }
+
+    override fun navigationDestinationChanged(destinationName: String) {
+        currentNavigationDestination.set(destinationName)
+    }
+
+    override fun navigationDestinationCleared(destinationName: String) {
+        currentNavigationDestination.compareAndSet(destinationName, null)
     }
 
     override fun close() {

--- a/services/src/test/java/io/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTrackerTest.kt
+++ b/services/src/test/java/io/opentelemetry/android/internal/services/visiblescreen/VisibleScreenTrackerTest.kt
@@ -196,6 +196,104 @@ internal class VisibleScreenTrackerTest {
         )
     }
 
+    @Test
+    fun navigationDestinationWinsOverFragmentAndActivity() {
+        val visibleScreenTracker = this.visibleScreenService
+        val activity = mockk<Activity>()
+        val fragment = mockk<Fragment>()
+
+        visibleScreenTracker.activityResumed(activity)
+        visibleScreenTracker.fragmentResumed(fragment)
+        visibleScreenTracker.navigationDestinationChanged("user/{id}")
+
+        assertEquals("user/{id}", visibleScreenTracker.currentlyVisibleScreen)
+    }
+
+    @Test
+    fun navigationDestinationClearedFallsBackToFragment() {
+        val visibleScreenTracker = this.visibleScreenService
+        val activity = mockk<Activity>()
+        val fragment = mockk<Fragment>()
+
+        visibleScreenTracker.activityResumed(activity)
+        visibleScreenTracker.fragmentResumed(fragment)
+        visibleScreenTracker.navigationDestinationChanged("user/{id}")
+        visibleScreenTracker.navigationDestinationCleared("user/{id}")
+
+        assertEquals(
+            fragment.javaClass.simpleName,
+            visibleScreenTracker.currentlyVisibleScreen,
+        )
+    }
+
+    @Test
+    fun navigationDestinationClearedFallsBackToActivity() {
+        val visibleScreenTracker = this.visibleScreenService
+        val activity = mockk<Activity>()
+
+        visibleScreenTracker.activityResumed(activity)
+        visibleScreenTracker.navigationDestinationChanged("user/{id}")
+        visibleScreenTracker.navigationDestinationCleared("user/{id}")
+
+        assertEquals(
+            activity.javaClass.simpleName,
+            visibleScreenTracker.currentlyVisibleScreen,
+        )
+    }
+
+    @Test
+    fun navigationDestinationClearedWithNoOtherScreenIsUnknown() {
+        val visibleScreenTracker = this.visibleScreenService
+
+        visibleScreenTracker.navigationDestinationChanged("user/{id}")
+        visibleScreenTracker.navigationDestinationCleared("user/{id}")
+
+        assertEquals("unknown", visibleScreenTracker.currentlyVisibleScreen)
+    }
+
+    @Test
+    fun navigationDestinationReplayedWithTheSameNameIsIdempotent() {
+        val visibleScreenTracker = this.visibleScreenService
+        val activity = mockk<Activity>()
+
+        visibleScreenTracker.activityResumed(activity)
+        visibleScreenTracker.navigationDestinationChanged("home")
+        // A configuration change disposes the controller and re-registers the listener, which
+        // replays the destination that is already showing.
+        visibleScreenTracker.navigationDestinationCleared("home")
+        visibleScreenTracker.navigationDestinationChanged("home")
+
+        assertEquals("home", visibleScreenTracker.currentlyVisibleScreen)
+    }
+
+    @Test
+    fun navigationDestinationDoesNotAffectPreviouslyVisibleScreen() {
+        val visibleScreenTracker = this.visibleScreenService
+        val fragment = mockk<Fragment>()
+
+        visibleScreenTracker.fragmentResumed(fragment)
+        visibleScreenTracker.fragmentPaused(fragment)
+        visibleScreenTracker.navigationDestinationChanged("cart")
+
+        assertEquals(
+            fragment.javaClass.simpleName,
+            visibleScreenTracker.previouslyVisibleScreen,
+        )
+    }
+
+    @Test
+    fun navigationDestinationClearedByASupersededSourceIsIgnored() {
+        val visibleScreenTracker = this.visibleScreenService
+
+        // A parent controller records "a", then a nested controller records "b". The parent
+        // leaving the composition must not discard the nested controller's destination.
+        visibleScreenTracker.navigationDestinationChanged("a")
+        visibleScreenTracker.navigationDestinationChanged("b")
+        visibleScreenTracker.navigationDestinationCleared("a")
+
+        assertEquals("b", visibleScreenTracker.currentlyVisibleScreen)
+    }
+
     private val visibleScreenService: VisibleScreenTracker
         get() = VisibleScreenTrackerImpl(application)
 


### PR DESCRIPTION
## What this does

Gives `VisibleScreenTracker` a source-agnostic way to be told about a screen that is neither an
Activity nor a Fragment, and wires it up from the Compose Navigation instrumentation's
`NavController.OnDestinationChangedListener`.

- New `AtomicReference` slot on `VisibleScreenTrackerImpl` for a navigation destination name.
- Precedence for `currentlyVisibleScreen` becomes: **destination → fragment → activity → `"unknown"`**.
- `:instrumentation:compose:navigation` gains `implementation(project(":services"))`. This edge is
  precedented: `:instrumentation:compose:click` already depends on `:services`.
- The listener reports the resolved screen name through a new internal
  `NavigationDestinationReporter`, and the `DisposableEffect`'s `onDispose` clears it.

Clearing is **conditional**: `navigationDestinationCleared(name)` only clears when `name` is still
the recorded destination, via `compareAndSet`, matching the pattern already used by `activityPaused`
and `fragmentPaused`. Each attached controller owns its own reporter, so a nested or sibling
controller leaving the composition cannot discard a destination another controller has since
recorded. Without this, teardown ordering between nested controllers could blank a destination the
parent had just recorded and silently drop attribution back to the Activity name.

## What this deliberately does not do

- **No changes to `ScreenAttributesSpanProcessor` or `ScreenAttributesLogRecordProcessor`.**
- **No change to which attribute is stamped, and no new semantic convention entry.**
- **#1920 (navigation event generation) is untouched.** The `app.navigation.complete` event and its
  `app.navigation.destination.name` attribute behave exactly as before.
- `previouslyVisibleScreen` is untouched, so `last.screen.name` keeps its Activity/Fragment-only
  meaning. There is a test pinning this.

One consequence worth stating plainly, because it is the point of the change rather than a side
effect: no attribute *key* changes, but for apps that attach this instrumentation the *value* of
`app.screen.name` will now be the Compose destination name rather than the host Activity name. The
instrumentation is manual and opt-in — it is not auto-discovered — so only apps that call
`withOpenTelemetry` or `rememberObservedNavController` are affected.

## Public API delta — Tier 4

Two methods on `VisibleScreenTracker`, and nothing else:

```
public abstract fun navigationDestinationChanged (Ljava/lang/String;)V
public abstract fun navigationDestinationCleared (Ljava/lang/String;)V
```

`navigation.api` is unchanged — `attachOpenTelemetry` and `NavigationDestinationReporter` are
`internal`. Per CONTRIBUTING this is Tier 4: 2 approvals and a 2-day waiting period.

## Known consequence: DialogFragment

Under destination-first precedence, a `DialogFragment` shown over a Compose screen is no longer
reflected in `currentlyVisibleScreen` — the recorded destination outranks it. This follows directly
from the precedence order rather than from a defect in the implementation, and it is the tradeoff
against the alternative ordering, where a `NavHost` nested inside a Fragment would lose to its host
fragment instead.

This is documented in the class KDoc, and it relates to the staleness question still open on #1909.
Happy to reorder if maintainers prefer the other tradeoff.

## Nested-controller restore semantics

The destination slot **overwrites rather than stacks**. If a parent controller records `"a"` and a
nested controller then records `"b"`, `"a"` is already gone; disposing the child clears to the
fallback chain rather than restoring `"a"`.

I've left nested-controller restore semantics out of this PR since it needs owner/name pairs rather
than a single slot — a single displaced-value slot is not enough, because it would resurrect a stale
route from the *same* controller after an ordinary `a → b → c` navigation. That felt related to the
staleness question still open on the issue, but happy to fold it in if you'd rather.

## Tests

`:services` (JUnit 5 + MockK) — all 7 pre-existing `VisibleScreenTrackerTest` cases pass unchanged;
7 added:

- destination beats fragment and activity
- cleared falls back to fragment / to activity / to `"unknown"`
- a clear from a superseded source is ignored (the nested/sibling case above)
- the attach replay on a configuration change is idempotent
- a destination does not affect `previouslyVisibleScreen`

`:instrumentation:compose:navigation` (JUnit 4 + Robolectric) — 7 added across two new files:

- reports the resolved name on attach and on each navigation
- reports the route *pattern*, asserting `user/{id}` and never `user/2`, pinning the PII-safe default
- clears when the controller leaves the composition
- a dispose/re-attach cycle clears and then replays, in that order
- reporter unit tests: clears using only the last name reported, no-op when nothing was reported,
  idempotent on double-clear

`NavControllerExtensionsTest` was updated for the new `attachOpenTelemetry` parameter; that internal
function exists as a test seam, so its signature is pinned by that file.

## Verification

`./gradlew spotlessApply` and `./gradlew apiDump` both clean, with the updated `.api` file included
in the diff.

`./gradlew :services:check :instrumentation:compose:navigation:check :core:check` — BUILD SUCCESSFUL.
services 89 tests, compose-navigation 23 tests, core 118 tests; 0 failures. The single skipped core
test is a pre-existing `@Ignore`, and `core` is untouched by this PR.

See #1909
