### PR TITLE
Fix lychee toml escapes

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -12,5 +12,5 @@ exclude = [
   '^https://github.com/open-telemetry/opentelemetry-android/(issues|pull)/\d+$',
   "^https://maven-badges.sml.io/maven-central/io.opentelemetry.android/.*$",
   "^https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/.*$",
-  "^https://cloud-native\.slack\.com/archives/C05J0T9K27Q$",
+  "^https://cloud-native.slack.com/archives/C05J0T9K27Q$",
 ]


### PR DESCRIPTION
Bah, I [broke the build](https://github.com/open-telemetry/opentelemetry-android/actions/runs/32884381003/job/97921251494) because I didn't realize the escaping needed extra backslashes or whatever. Let's just remove them, even if it's slightly incorrect.

I really should have listened to @benjoseph-grafana over [here](https://github.com/open-telemetry/opentelemetry-android/pull/1995#discussion_r3826378790). Sorry sorry.