### PR TITLE
Obsolete bespoke network.status in favor of network.connection.type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### 📣 Migration notes
+
+- Network change events now use `network.connection.type` instead of the deprecated
+  `network.status`. To keep emitting `network.status` while migrating, configure
+  `semanticConventions { useLatestExperimental = false }`.
+  ([#2014](https://github.com/open-telemetry/opentelemetry-android/pull/2014))
+
 ### 📈 Enhancements
 
 - The Compose Navigation instrumentation, which shipped in 1.6.0 without emitting any telemetry,

--- a/instrumentation/network/README.md
+++ b/instrumentation/network/README.md
@@ -22,8 +22,10 @@ This instrumentation produces the following telemetry:
 * Name: `network.change`
 * Description: This event is emitted when a network change is detected.
 * Attributes:
-    * `network.status`: One of `lost` or `available`.
     * `network.connection.type` (semconv) one of `cell`, `wifi`, `wired`, `unavailable`, `unknown`, `vpn`.
+    * `network.status`: Deprecated. It is emitted only when
+      `semanticConventions { useLatestExperimental = false }` is configured, with a value of
+      `lost` or `available`.
 
 Note: This instrumentation supports additional user-configurable `AttributeExtractors` that
 may set additional attributes when given a `CurrentNetwork` instance.

--- a/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeAttributesExtractor.kt
+++ b/instrumentation/network/src/main/java/io/opentelemetry/android/instrumentation/network/NetworkChangeAttributesExtractor.kt
@@ -9,6 +9,7 @@ import io.opentelemetry.android.common.internal.features.networkattributes.Curre
 import io.opentelemetry.android.common.internal.features.networkattributes.data.CurrentNetwork
 import io.opentelemetry.android.common.internal.features.networkattributes.data.NetworkState
 import io.opentelemetry.android.semconv.NetworkAttributes.NETWORK_STATUS_KEY
+import io.opentelemetry.android.semconv.internal.SemconvCompat
 import io.opentelemetry.api.common.AttributesBuilder
 import io.opentelemetry.kotlin.semconv.IncubatingApi
 import io.opentelemetry.kotlin.semconv.NetworkAttributes
@@ -17,17 +18,20 @@ internal class NetworkChangeAttributesExtractor : NetworkAttributesExtractor {
     private val networkAttributesExtractor = CurrentNetworkAttributesExtractor()
 
     @OptIn(IncubatingApi::class)
+    @Suppress("DEPRECATION")
     override fun invoke(
         attributesBuilder: AttributesBuilder,
         currentNetwork: CurrentNetwork,
     ) {
-        val status =
-            if (currentNetwork.state == NetworkState.NO_NETWORK_AVAILABLE) {
-                "lost"
-            } else {
-                "available"
-            }
-        attributesBuilder.put(NETWORK_STATUS_KEY, status)
+        if (!SemconvCompat.useLatestExperimental) {
+            val status =
+                if (currentNetwork.state == NetworkState.NO_NETWORK_AVAILABLE) {
+                    "lost"
+                } else {
+                    "available"
+                }
+            attributesBuilder.put(NETWORK_STATUS_KEY, status)
+        }
         if (currentNetwork.state == NetworkState.NO_NETWORK_AVAILABLE) {
             attributesBuilder.put(
                 NetworkAttributes.NETWORK_CONNECTION_TYPE,

--- a/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentationTest.kt
+++ b/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentationTest.kt
@@ -29,6 +29,7 @@ import io.opentelemetry.android.internal.services.network.NetworkChangeListener
 import io.opentelemetry.android.internal.services.network.NetworkProviderHolder
 import io.opentelemetry.android.semconv.NetworkAttributes.NETWORK_STATUS_KEY
 import io.opentelemetry.android.semconv.events.NetworkChangeEvent.Companion.NETWORK_CHANGE_EVENT_NAME
+import io.opentelemetry.android.semconv.internal.SemconvCompat
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.common.AttributeKey.stringKey
 import io.opentelemetry.kotlin.semconv.IncubatingApi
@@ -71,6 +72,7 @@ class NetworkChangeInstrumentationTest {
     fun tearDown() {
         NetworkProviderHolder.set(null)
         Services.set(null)
+        SemconvCompat.useLatestExperimental = true
     }
 
     @Test
@@ -92,7 +94,6 @@ class NetworkChangeInstrumentationTest {
         assertThat(event)
             .hasEventName(NETWORK_CHANGE_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(NETWORK_STATUS_KEY, "available"),
                 equalTo(stringKey(NETWORK_CONNECTION_TYPE), "wifi"),
             )
     }
@@ -123,7 +124,6 @@ class NetworkChangeInstrumentationTest {
         assertThat(event)
             .hasEventName(NETWORK_CHANGE_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(NETWORK_STATUS_KEY, "available"),
                 equalTo(stringKey(NETWORK_CONNECTION_TYPE), "cell"),
                 equalTo(stringKey(NETWORK_CONNECTION_SUBTYPE), "LTE"),
                 equalTo(stringKey(NETWORK_CARRIER_NAME), "ShadyTel"),
@@ -152,7 +152,6 @@ class NetworkChangeInstrumentationTest {
         assertThat(event)
             .hasEventName(NETWORK_CHANGE_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
-                equalTo(NETWORK_STATUS_KEY, "lost"),
                 equalTo(stringKey(NETWORK_CONNECTION_TYPE), "unavailable"),
             )
     }
@@ -190,6 +189,29 @@ class NetworkChangeInstrumentationTest {
         assertThat(otelTesting.logRecords).hasSize(1)
         val event = otelTesting.logRecords[0]
         assertThat(event)
+            .hasEventName(NETWORK_CHANGE_EVENT_NAME)
+            .hasAttributesSatisfyingExactly(
+                equalTo(stringKey(NETWORK_CONNECTION_TYPE), "unavailable"),
+            )
+    }
+
+    @Test
+    @Suppress("DEPRECATION")
+    fun legacySemconv_networkLost() {
+        SemconvCompat.useLatestExperimental = false
+        val networkChangeListenerSlot = slot<NetworkChangeListener>()
+        val (context, openTelemetryRum) = createTestDependencies()
+        NetworkChangeInstrumentation().install(context, openTelemetryRum)
+
+        verify {
+            currentNetworkProvider.addNetworkChangeListener(capture(networkChangeListenerSlot))
+        }
+
+        networkChangeListenerSlot.captured.onNetworkChange(
+            CurrentNetwork(NetworkState.NO_NETWORK_AVAILABLE),
+        )
+
+        assertThat(otelTesting.logRecords.single())
             .hasEventName(NETWORK_CHANGE_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(NETWORK_STATUS_KEY, "lost"),

--- a/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentationTest.kt
+++ b/instrumentation/network/src/test/java/io/opentelemetry/android/instrumentation/network/NetworkChangeInstrumentationTest.kt
@@ -220,6 +220,30 @@ class NetworkChangeInstrumentationTest {
     }
 
     @Test
+    @Suppress("DEPRECATION")
+    fun legacySemconv_networkAvailable() {
+        SemconvCompat.useLatestExperimental = false
+        val networkChangeListenerSlot = slot<NetworkChangeListener>()
+        val (context, openTelemetryRum) = createTestDependencies()
+        NetworkChangeInstrumentation().install(context, openTelemetryRum)
+
+        verify {
+            currentNetworkProvider.addNetworkChangeListener(capture(networkChangeListenerSlot))
+        }
+
+        networkChangeListenerSlot.captured.onNetworkChange(
+            CurrentNetwork(NetworkState.TRANSPORT_WIFI),
+        )
+
+        assertThat(otelTesting.logRecords.single())
+            .hasEventName(NETWORK_CHANGE_EVENT_NAME)
+            .hasAttributesSatisfyingExactly(
+                equalTo(NETWORK_STATUS_KEY, "available"),
+                equalTo(stringKey(NETWORK_CONNECTION_TYPE), "wifi"),
+            )
+    }
+
+    @Test
     fun uninstall() {
         val networkChangeListenerSlot = slot<NetworkChangeListener>()
         val appStateListenerSlot = slot<ApplicationStateListener>()

--- a/semconv/model/android/events.yaml
+++ b/semconv/model/android/events.yaml
@@ -190,7 +190,7 @@ groups:
     brief: >
       This event indicates that Android network connectivity changed.
     attributes:
-      - ref: network.status
+      - ref: network.connection.type
         requirement_level: recommended
   - id: event.rum.sdk.init.started
     type: event

--- a/semconv/model/android/events.yaml
+++ b/semconv/model/android/events.yaml
@@ -190,6 +190,8 @@ groups:
     brief: >
       This event indicates that Android network connectivity changed.
     attributes:
+      - ref: network.status
+        requirement_level: recommended
       - ref: network.connection.type
         requirement_level: recommended
   - id: event.rum.sdk.init.started

--- a/semconv/model/android/registry.yaml
+++ b/semconv/model/android/registry.yaml
@@ -126,9 +126,14 @@ groups:
       - id: network.status
         type: string
         stability: development
+        deprecated:
+          reason: obsoleted
+          note: >
+            Use `network.connection.type` instead. A value of `unavailable` indicates that no
+            network connection is available.
         brief: >
-          The Android network status after a network change.
-        examples: ["TRANSPORT_WIFI", "TRANSPORT_CELLULAR", "NO_NETWORK_AVAILABLE"]
+          Deprecated. Use `network.connection.type` instead.
+        examples: ["available", "lost"]
       - id: screen.name
         type: string
         stability: development


### PR DESCRIPTION
`network.connection.type` comes from [upstream](https://github.com/open-telemetry/semantic-conventions/blob/3c3ffc3b01cdda4cabbc82e9584696ec1e63306a/model/network/registry.yaml#L118) and we should use it instead of bespoke/custom conventions.

This is a breaking change, so we use the `SemconvCompat` opt-in to keep the attribute for users who still need it.

The semantics of "available" or "lost" were previously specified in the `network.status` attribute, which is redundant with the other values of `network.connection.type`. That is, a type of `unavailable` means `lost`, whereas every other value means "available".

So this makes things simpler while also aligning better with upstream.