### PR TITLE
fix: flush telemetry before delegating on crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 ### 🛠️ Bug fixes
 
+- Flush telemetry on crash before delegating to the previous uncaught exception handler, so the
+  process is not terminated before the flush completes.
+  ([#1997](https://github.com/open-telemetry/opentelemetry-android/issues/1997))
+
 - Fix R8 failures caused by optional Error Prone annotations in minified applications.
   ([#1972](https://github.com/open-telemetry/opentelemetry-android/pull/1972))
 

--- a/core/src/main/java/io/opentelemetry/android/CrashFlushHandler.kt
+++ b/core/src/main/java/io/opentelemetry/android/CrashFlushHandler.kt
@@ -49,10 +49,6 @@ internal class CrashFlushHandler(
             thread: Thread,
             throwable: Throwable,
         ) {
-            // Let any previously installed handler run first (e.g. the crash
-            // instrumentation emits the crash log record in its handler).
-            previousHandler?.uncaughtException(thread, throwable)
-
             try {
                 awaitCompletion(
                     flushTimeout,
@@ -62,6 +58,11 @@ internal class CrashFlushHandler(
                 )
             } catch (e: Exception) {
                 Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to flush telemetry on crash", e)
+            } finally {
+                // Delegate after flushing. The previous handler is often the
+                // platform default, which terminates the process and would
+                // otherwise prevent the flush from completing.
+                previousHandler?.uncaughtException(thread, throwable)
             }
         }
 

--- a/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
@@ -88,18 +88,19 @@ class SdkPreconfiguredRumBuilder internal constructor(
                 onShutdown.run()
             }
 
+        // Install the crash flush handler before instrumentations so that any
+        // UncaughtExceptionHandler set by an instrumentation (e.g. the crash reporter)
+        // wraps it. The instrumentation then records its crash telemetry, this handler
+        // flushes it, and only afterwards is the platform handler - which terminates the
+        // process - invoked.
+        CrashFlushHandler(sdk).install()
+
         val configurator = InstrumentationConfigurators.create()
         // Install instrumentations
         for (instrumentation in enabledInstrumentations) {
             configurator.configure(instrumentation)
             instrumentation.install(context, openTelemetryRum)
         }
-
-        // Install crash flush handler after instrumentations so it wraps any
-        // UncaughtExceptionHandler set by instrumentations (e.g. crash reporter).
-        // This ensures all telemetry (including crash events) is flushed before
-        // the process terminates.
-        CrashFlushHandler(sdk).install()
 
         return openTelemetryRum
     }

--- a/core/src/test/java/io/opentelemetry/android/CrashFlushHandlerTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/CrashFlushHandlerTest.kt
@@ -19,6 +19,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.time.Duration.Companion.seconds
 
 class CrashFlushHandlerTest {
     private var previousHandler: Thread.UncaughtExceptionHandler? = null
@@ -99,7 +101,26 @@ class CrashFlushHandlerTest {
     }
 
     @Test
-    fun `previous handler runs before flush`() {
+    fun `still delegates to previous handler when flush fails`() {
+        val existingHandler = mockk<Thread.UncaughtExceptionHandler>(relaxed = true)
+        Thread.setDefaultUncaughtExceptionHandler(existingHandler)
+
+        val loggerProvider = mockk<SdkLoggerProvider>()
+        val sdk = mockSdk(loggerProvider = loggerProvider)
+        every { loggerProvider.forceFlush() } throws RuntimeException("flush failed")
+
+        CrashFlushHandler(sdk).install()
+
+        val handler = Thread.getDefaultUncaughtExceptionHandler()!!
+        val thread = Thread.currentThread()
+        val exception = RuntimeException("test")
+        handler.uncaughtException(thread, exception)
+
+        verify { existingHandler.uncaughtException(thread, exception) }
+    }
+
+    @Test
+    fun `flush completes before previous handler runs`() {
         val existingHandler = mockk<Thread.UncaughtExceptionHandler>(relaxed = true)
         Thread.setDefaultUncaughtExceptionHandler(existingHandler)
 
@@ -119,9 +140,49 @@ class CrashFlushHandlerTest {
         handler.uncaughtException(thread, RuntimeException("test"))
 
         verifyOrder {
-            existingHandler.uncaughtException(thread, any())
+            loggerProvider.forceFlush()
             tracerProvider.forceFlush()
+            meterProvider.forceFlush()
+            existingHandler.uncaughtException(thread, any())
         }
+    }
+
+    @Test
+    fun `flush is awaited before previous handler runs`() {
+        val flushResult = CompletableResultCode()
+        val flushObservedIncomplete = AtomicBoolean(false)
+        val existingHandler =
+            Thread.UncaughtExceptionHandler { _, _ ->
+                flushObservedIncomplete.set(!flushResult.isDone)
+            }
+        Thread.setDefaultUncaughtExceptionHandler(existingHandler)
+
+        val tracerProvider = mockk<SdkTracerProvider>()
+        val loggerProvider = mockk<SdkLoggerProvider>()
+        val meterProvider = mockk<SdkMeterProvider>()
+        val sdk = mockSdk(tracerProvider, loggerProvider, meterProvider)
+
+        every { loggerProvider.forceFlush() } returns flushResult
+        every { tracerProvider.forceFlush() } returns CompletableResultCode.ofSuccess()
+        every { meterProvider.forceFlush() } returns CompletableResultCode.ofSuccess()
+
+        CrashFlushHandler(sdk, flushTimeout = 10.seconds).install()
+
+        val handler = Thread.getDefaultUncaughtExceptionHandler()!!
+        val crashThread =
+            Thread {
+                handler.uncaughtException(Thread.currentThread(), RuntimeException("test"))
+            }
+        crashThread.start()
+
+        // The handler must still be blocked on the incomplete flush.
+        crashThread.join(500)
+        assertThat(crashThread.isAlive).isTrue()
+
+        flushResult.succeed()
+        crashThread.join(5_000)
+        assertThat(crashThread.isAlive).isFalse()
+        assertThat(flushObservedIncomplete).isFalse()
     }
 
     private fun mockSdk(

--- a/core/src/test/java/io/opentelemetry/android/CrashFlushHandlerTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/CrashFlushHandlerTest.kt
@@ -16,6 +16,7 @@ import io.opentelemetry.sdk.logs.SdkLoggerProvider
 import io.opentelemetry.sdk.metrics.SdkMeterProvider
 import io.opentelemetry.sdk.trace.SdkTracerProvider
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -58,22 +59,6 @@ class CrashFlushHandlerTest {
         handler.uncaughtException(thread, exception)
 
         verify { existingHandler.uncaughtException(thread, exception) }
-    }
-
-    @Test
-    fun `flushes without delegating when there is no previous handler`() {
-        Thread.setDefaultUncaughtExceptionHandler(null)
-
-        val loggerProvider = mockk<SdkLoggerProvider>()
-        val sdk = mockSdk(loggerProvider = loggerProvider)
-        every { loggerProvider.forceFlush() } returns CompletableResultCode.ofSuccess()
-
-        CrashFlushHandler(sdk).install()
-
-        val handler = Thread.getDefaultUncaughtExceptionHandler()!!
-        handler.uncaughtException(Thread.currentThread(), RuntimeException("test"))
-
-        verify { loggerProvider.forceFlush() }
     }
 
     @Test
@@ -133,6 +118,45 @@ class CrashFlushHandlerTest {
         handler.uncaughtException(thread, exception)
 
         verify { existingHandler.uncaughtException(thread, exception) }
+    }
+
+    @Test
+    fun `still delegates to previous handler when flush throws an error`() {
+        val existingHandler = mockk<Thread.UncaughtExceptionHandler>(relaxed = true)
+        Thread.setDefaultUncaughtExceptionHandler(existingHandler)
+
+        val loggerProvider = mockk<SdkLoggerProvider>()
+        val sdk = mockSdk(loggerProvider = loggerProvider)
+        // Errors are not caught, so the handler exits by propagating; the
+        // finally block must still delegate on the way out.
+        every { loggerProvider.forceFlush() } throws StackOverflowError("flush failed")
+
+        CrashFlushHandler(sdk).install()
+
+        val handler = Thread.getDefaultUncaughtExceptionHandler()!!
+        val thread = Thread.currentThread()
+        val exception = RuntimeException("test")
+
+        assertThatThrownBy { handler.uncaughtException(thread, exception) }
+            .isInstanceOf(StackOverflowError::class.java)
+
+        verify { existingHandler.uncaughtException(thread, exception) }
+    }
+
+    @Test
+    fun `propagates flush error when there is no previous handler`() {
+        Thread.setDefaultUncaughtExceptionHandler(null)
+
+        val loggerProvider = mockk<SdkLoggerProvider>()
+        val sdk = mockSdk(loggerProvider = loggerProvider)
+        every { loggerProvider.forceFlush() } throws StackOverflowError("flush failed")
+
+        CrashFlushHandler(sdk).install()
+
+        val handler = Thread.getDefaultUncaughtExceptionHandler()!!
+
+        assertThatThrownBy { handler.uncaughtException(Thread.currentThread(), RuntimeException("test")) }
+            .isInstanceOf(StackOverflowError::class.java)
     }
 
     @Test

--- a/core/src/test/java/io/opentelemetry/android/CrashFlushHandlerTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/CrashFlushHandlerTest.kt
@@ -61,6 +61,22 @@ class CrashFlushHandlerTest {
     }
 
     @Test
+    fun `flushes without delegating when there is no previous handler`() {
+        Thread.setDefaultUncaughtExceptionHandler(null)
+
+        val loggerProvider = mockk<SdkLoggerProvider>()
+        val sdk = mockSdk(loggerProvider = loggerProvider)
+        every { loggerProvider.forceFlush() } returns CompletableResultCode.ofSuccess()
+
+        CrashFlushHandler(sdk).install()
+
+        val handler = Thread.getDefaultUncaughtExceptionHandler()!!
+        handler.uncaughtException(Thread.currentThread(), RuntimeException("test"))
+
+        verify { loggerProvider.forceFlush() }
+    }
+
+    @Test
     fun `flushes all signal providers on crash`() {
         val tracerProvider = mockk<SdkTracerProvider>()
         val loggerProvider = mockk<SdkLoggerProvider>()


### PR DESCRIPTION
CrashFlushHandler invoked the previous uncaught exception handler
before force-flushing. The handler chain reaches the platform default,
which terminates the process, so the flush never ran.

Flush first, then delegate. Install the handler before instrumentations
so crash reporting wraps it and crash events are included in the flush.

Resolves https://github.com/open-telemetry/opentelemetry-android/issues/1997