### PR TITLE
Add the os.build_id resource attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   attribute whenever a navigation completes.
   ([#1920](https://github.com/open-telemetry/opentelemetry-android/issues/1920))
 
+- Add the `os.build_id` resource attribute, reporting the OS build identifier from `Build.ID`.
+  ([#1089](https://github.com/open-telemetry/opentelemetry-android/issues/1089))
+
 ### 🛠️ Bug fixes
 
 - Fix R8 failures caused by optional Error Prone annotations in minified applications.

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/ResourceConfigTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/ResourceConfigTest.kt
@@ -16,6 +16,7 @@ import io.opentelemetry.kotlin.semconv.DeviceAttributes.DEVICE_MANUFACTURER
 import io.opentelemetry.kotlin.semconv.DeviceAttributes.DEVICE_MODEL_IDENTIFIER
 import io.opentelemetry.kotlin.semconv.DeviceAttributes.DEVICE_MODEL_NAME
 import io.opentelemetry.kotlin.semconv.IncubatingApi
+import io.opentelemetry.kotlin.semconv.OsAttributes.OS_BUILD_ID
 import io.opentelemetry.kotlin.semconv.OsAttributes.OS_DESCRIPTION
 import io.opentelemetry.kotlin.semconv.OsAttributes.OS_NAME
 import io.opentelemetry.kotlin.semconv.OsAttributes.OS_TYPE
@@ -80,6 +81,7 @@ class ResourceConfigTest {
         assertEquals("Android", attrs[stringKey(OS_NAME)])
         assertEquals("linux", attrs[stringKey(OS_TYPE)])
         assertEquals("6.0.1", attrs[stringKey(OS_VERSION)])
+        assertEquals("MMB29M", attrs[stringKey(OS_BUILD_ID)])
         assertEquals("Android Version 6.0.1 (Build MMB29M API level 23)", attrs[stringKey(OS_DESCRIPTION)])
         assertEquals("java", attrs[stringKey(TELEMETRY_SDK_LANGUAGE)])
         assertEquals("opentelemetry", attrs[stringKey(TELEMETRY_SDK_NAME)])

--- a/core/src/main/java/io/opentelemetry/android/AndroidResource.kt
+++ b/core/src/main/java/io/opentelemetry/android/AndroidResource.kt
@@ -14,6 +14,7 @@ import io.opentelemetry.kotlin.semconv.DeviceAttributes.DEVICE_MANUFACTURER
 import io.opentelemetry.kotlin.semconv.DeviceAttributes.DEVICE_MODEL_IDENTIFIER
 import io.opentelemetry.kotlin.semconv.DeviceAttributes.DEVICE_MODEL_NAME
 import io.opentelemetry.kotlin.semconv.IncubatingApi
+import io.opentelemetry.kotlin.semconv.OsAttributes.OS_BUILD_ID
 import io.opentelemetry.kotlin.semconv.OsAttributes.OS_DESCRIPTION
 import io.opentelemetry.kotlin.semconv.OsAttributes.OS_NAME
 import io.opentelemetry.kotlin.semconv.OsAttributes.OS_TYPE
@@ -46,6 +47,7 @@ object AndroidResource {
             .put(ANDROID_OS_API_LEVEL, Build.VERSION.SDK_INT.toString())
             .put(OS_TYPE, "linux")
             .put(OS_VERSION, Build.VERSION.RELEASE)
+            .put(OS_BUILD_ID, Build.ID)
             .put(OS_DESCRIPTION, oSDescription)
             .put(APP_INSTALLATION_ID, readInstallId(context))
             .build()

--- a/core/src/test/java/io/opentelemetry/android/AndroidResourceTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/AndroidResourceTest.kt
@@ -86,8 +86,7 @@ internal class AndroidResourceTest {
                 .put(
                     AndroidAttributes.ANDROID_OS_API_LEVEL,
                     Build.VERSION.SDK_INT.toString(),
-                )
-                .put(OsAttributes.OS_BUILD_ID, Build.ID)
+                ).put(OsAttributes.OS_BUILD_ID, Build.ID)
                 .put(OsAttributes.OS_DESCRIPTION, osDescription)
                 .put(APP_INSTALLATION_ID, installId)
     }

--- a/core/src/test/java/io/opentelemetry/android/AndroidResourceTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/AndroidResourceTest.kt
@@ -86,7 +86,8 @@ internal class AndroidResourceTest {
                 .put(
                     AndroidAttributes.ANDROID_OS_API_LEVEL,
                     Build.VERSION.SDK_INT.toString(),
-                ).put(OsAttributes.OS_BUILD_ID, Build.ID)
+                )
+                .put(OsAttributes.OS_BUILD_ID, Build.ID)
                 .put(OsAttributes.OS_DESCRIPTION, osDescription)
                 .put(APP_INSTALLATION_ID, installId)
     }

--- a/core/src/test/java/io/opentelemetry/android/AndroidResourceTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/AndroidResourceTest.kt
@@ -86,7 +86,8 @@ internal class AndroidResourceTest {
                 .put(
                     AndroidAttributes.ANDROID_OS_API_LEVEL,
                     Build.VERSION.SDK_INT.toString(),
-                ).put(OsAttributes.OS_DESCRIPTION, osDescription)
+                ).put(OsAttributes.OS_BUILD_ID, Build.ID)
+                .put(OsAttributes.OS_DESCRIPTION, osDescription)
                 .put(APP_INSTALLATION_ID, installId)
     }
 


### PR DESCRIPTION
## What

Adds the `os.build_id` resource attribute, sourced from `Build.ID`.

Semconv defines `os.build_id` as "Unique identifier for a particular build or
compilation of the operating system," and one of the registry's examples,
`TQ3C.230805.001.B2`, is an Android build ID. `AndroidResource` doesn't emit it
today.

Refs #1089.

## Scope

#1089 lists five items. Two are already fixed on main (`android.os.api_level`
in #1455, `TELEMETRY_SDK_VERSION` in #1365). Of the remaining three, this PR
takes only `os.build_id` — the one with unambiguous spec backing and no change
to any value consumers already receive.

The `device.model.identifier` and `os.description` items both looked less
clear-cut than the issue suggests once I read the registry entries; I've left
that reasoning on #1089 rather than here, since it concerns attributes this PR
doesn't touch.

## Testing

`AndroidResourceTest` asserts the new attribute, and `ResourceConfigTest`'s
`assertCommonResources` includes it alongside the rest of the common set.
Full `./gradlew check` passes.
