### PR TITLE
Move thread utils

### DIFF
--- a/common/api/common.api
+++ b/common/api/common.api
@@ -66,7 +66,3 @@ public final class io/opentelemetry/android/common/internal/features/networkattr
 	public static fun values ()[Lio/opentelemetry/android/common/internal/features/networkattributes/data/NetworkState;
 }
 
-public final class io/opentelemetry/android/common/internal/utils/AndroidUtilsKt {
-	public static final fun getThreadIdCompat (Ljava/lang/Thread;)J
-}
-

--- a/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrWatcher.kt
+++ b/instrumentation/anr/src/main/java/io/opentelemetry/android/instrumentation/anr/AnrWatcher.kt
@@ -6,8 +6,8 @@
 package io.opentelemetry.android.instrumentation.anr
 
 import android.os.Handler
-import io.opentelemetry.android.common.internal.utils.threadIdCompat
 import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor
+import io.opentelemetry.android.instrumentation.utils.threadIdCompat
 import io.opentelemetry.android.semconv.events.DeviceAnrEvent
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.logs.Logger

--- a/instrumentation/common-api/api/common-api.api
+++ b/instrumentation/common-api/api/common-api.api
@@ -29,3 +29,7 @@ public abstract interface class io/opentelemetry/android/instrumentation/common/
 	public abstract fun extract (Ljava/lang/Object;)Ljava/lang/String;
 }
 
+public final class io/opentelemetry/android/instrumentation/utils/AndroidUtilsKt {
+	public static final fun getThreadIdCompat (Ljava/lang/Thread;)J
+}
+

--- a/instrumentation/common-api/src/main/java/io/opentelemetry/android/instrumentation/utils/AndroidUtils.kt
+++ b/instrumentation/common-api/src/main/java/io/opentelemetry/android/instrumentation/utils/AndroidUtils.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package io.opentelemetry.android.common.internal.utils
+package io.opentelemetry.android.instrumentation.utils
 
 import android.os.Build
 import androidx.annotation.RequiresApi

--- a/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.kt
+++ b/instrumentation/crash/src/main/java/io/opentelemetry/android/instrumentation/crash/CrashReporter.kt
@@ -5,8 +5,8 @@
 
 package io.opentelemetry.android.instrumentation.crash
 
-import io.opentelemetry.android.common.internal.utils.threadIdCompat
 import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor
+import io.opentelemetry.android.instrumentation.utils.threadIdCompat
 import io.opentelemetry.android.semconv.internal.SemconvCompat.Companion.map
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes

--- a/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReportIntegrationTest.kt
+++ b/instrumentation/crash/src/test/java/io/opentelemetry/android/instrumentation/crash/CrashReportIntegrationTest.kt
@@ -11,8 +11,8 @@ import android.app.Application
 import io.mockk.every
 import io.mockk.mockk
 import io.opentelemetry.android.OpenTelemetryRum
-import io.opentelemetry.android.common.internal.utils.threadIdCompat
 import io.opentelemetry.android.instrumentation.common.EventAttributesExtractor
+import io.opentelemetry.android.instrumentation.utils.threadIdCompat
 import io.opentelemetry.android.semconv.HeapAttributes.HEAP_FREE_KEY
 import io.opentelemetry.android.semconv.StorageAttributes.STORAGE_FREE_KEY
 import io.opentelemetry.api.common.AttributeKey


### PR DESCRIPTION
Moves `threadIdCompat` to the more specific `instrumentation/common-api` module which is a better fit than `core` given that the symbol is only used from instrumentation.