### PR TITLE
feat(native-crash): parse stack snapshots

### DIFF
--- a/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashSnapshot.kt
+++ b/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashSnapshot.kt
@@ -1,0 +1,261 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.nativecrash
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.charset.CodingErrorAction
+
+// Mirrors native_crash_snapshot.h, which remains the binary layout source of truth.
+internal object NativeCrashSnapshotLayout {
+    const val MAGIC_SIZE = 8
+    const val VERSION_OFFSET = 8
+    const val ARCHITECTURE_OFFSET = 12
+    const val RECORD_SIZE_OFFSET = 16
+    const val SIGNAL_NUMBER_OFFSET = 20
+    const val TIMESTAMP_OFFSET = 24
+    const val PROGRAM_COUNTER_OFFSET = 32
+    const val STACK_POINTER_OFFSET = 40
+    const val FRAME_POINTER_OFFSET = 48
+    const val LINK_REGISTER_OFFSET = 56
+    const val MODULE_COUNT_OFFSET = 64
+    const val STACK_SIZE_OFFSET = 68
+    const val STACK_START_OFFSET = 72
+    const val MODULES_OFFSET = 80
+
+    const val MAX_MODULES = 128
+    const val MODULE_ENTRY_SIZE = 128
+    const val MODULE_LOAD_BIAS_OFFSET = 0
+    const val MODULE_EXECUTABLE_START_OFFSET = 8
+    const val MODULE_EXECUTABLE_END_OFFSET = 16
+    const val MODULE_NAME_OFFSET = 24
+    const val MODULE_NAME_SIZE = 64
+    const val MODULE_BUILD_ID_SIZE_OFFSET = 88
+    const val MODULE_BUILD_ID_OFFSET = 92
+    const val MODULE_BUILD_ID_CAPACITY = 32
+    const val MODULE_RESERVED_OFFSET = 124
+
+    const val STACK_OFFSET = MODULES_OFFSET + MAX_MODULES * MODULE_ENTRY_SIZE
+    const val STACK_CAPACITY = 4_096
+    const val RESERVED_OFFSET = STACK_OFFSET + STACK_CAPACITY
+    const val CHECKSUM_OFFSET = RESERVED_OFFSET + Int.SIZE_BYTES
+    const val RECORD_SIZE = CHECKSUM_OFFSET + Int.SIZE_BYTES
+}
+
+internal enum class NativeCrashArchitecture(
+    val id: Int,
+    val pointerSize: Int,
+    val hasLinkRegister: Boolean,
+) {
+    ARM(1, Int.SIZE_BYTES, true),
+    ARM64(2, Long.SIZE_BYTES, true),
+    X86(3, Int.SIZE_BYTES, false),
+    X86_64(4, Long.SIZE_BYTES, false),
+    ;
+
+    companion object {
+        fun fromId(id: Int): NativeCrashArchitecture? = entries.firstOrNull { it.id == id }
+    }
+}
+
+internal class NativeCrashSnapshot(
+    val architecture: NativeCrashArchitecture,
+    val programCounter: ULong,
+    val stackPointer: ULong,
+    val framePointer: ULong,
+    val linkRegister: ULong,
+    val modules: List<NativeCrashModule>,
+    val stackStart: ULong,
+    val stack: ByteArray,
+)
+
+internal data class NativeCrashModule(
+    val loadBias: ULong,
+    val executableStart: ULong,
+    val executableEnd: ULong,
+    val name: String,
+    val buildId: String?,
+)
+
+internal object NativeCrashSnapshotParser {
+    private const val VERSION = 1
+    private const val FNV_OFFSET_BASIS = 0x811c9dc5u
+    private const val FNV_PRIME = 0x01000193u
+    private const val NANOS_PER_SECOND = 1_000_000_000L
+    private const val HEX_DIGITS = "0123456789abcdef"
+
+    private val magic = "OTELNCS\u0000".toByteArray(Charsets.US_ASCII)
+
+    fun parse(
+        bytes: ByteArray,
+        crashRecord: NativeCrashRecord,
+    ): NativeCrashSnapshot? {
+        if (!hasValidEnvelope(bytes)) return null
+
+        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+        val architecture = readValidatedArchitecture(bytes, buffer, crashRecord) ?: return null
+
+        val programCounter = buffer.addressAt(NativeCrashSnapshotLayout.PROGRAM_COUNTER_OFFSET, architecture) ?: return null
+        val stackPointer = buffer.addressAt(NativeCrashSnapshotLayout.STACK_POINTER_OFFSET, architecture) ?: return null
+        val framePointer = buffer.addressAt(NativeCrashSnapshotLayout.FRAME_POINTER_OFFSET, architecture) ?: return null
+        val linkRegister = buffer.linkRegister(architecture) ?: return null
+        val stackStart = buffer.addressAt(NativeCrashSnapshotLayout.STACK_START_OFFSET, architecture) ?: return null
+        val moduleCount = buffer.getInt(NativeCrashSnapshotLayout.MODULE_COUNT_OFFSET)
+        val stackSize = buffer.getInt(NativeCrashSnapshotLayout.STACK_SIZE_OFFSET)
+
+        if (stackPointer == 0UL || stackStart != stackPointer) return null
+        if (stackStart % architecture.pointerSize.toULong() != 0UL) return null
+        if (moduleCount !in 1..NativeCrashSnapshotLayout.MAX_MODULES) return null
+        if (stackSize !in 0..NativeCrashSnapshotLayout.STACK_CAPACITY) return null
+        if (buffer.getInt(NativeCrashSnapshotLayout.RESERVED_OFFSET) != 0) return null
+
+        val modules =
+            (0 until moduleCount).mapNotNull { index ->
+                readModule(bytes, buffer, index, architecture)
+            }
+        val stack =
+            bytes.copyOfRange(
+                NativeCrashSnapshotLayout.STACK_OFFSET,
+                NativeCrashSnapshotLayout.STACK_OFFSET + stackSize,
+            )
+        return NativeCrashSnapshot(
+            architecture = architecture,
+            programCounter = programCounter,
+            stackPointer = stackPointer,
+            framePointer = framePointer,
+            linkRegister = linkRegister,
+            modules = modules,
+            stackStart = stackStart,
+            stack = stack,
+        )
+    }
+
+    internal fun checksum(bytes: ByteArray): UInt {
+        require(bytes.size >= NativeCrashSnapshotLayout.CHECKSUM_OFFSET)
+        var checksum = FNV_OFFSET_BASIS
+        for (index in 0 until NativeCrashSnapshotLayout.CHECKSUM_OFFSET) {
+            checksum = (checksum xor bytes[index].toUByte().toUInt()) * FNV_PRIME
+        }
+        return checksum
+    }
+
+    private fun hasValidEnvelope(bytes: ByteArray): Boolean =
+        bytes.size == NativeCrashSnapshotLayout.RECORD_SIZE &&
+            checksum(bytes) == bytes.uintAt(NativeCrashSnapshotLayout.CHECKSUM_OFFSET)
+
+    private fun readValidatedArchitecture(
+        bytes: ByteArray,
+        buffer: ByteBuffer,
+        crashRecord: NativeCrashRecord,
+    ): NativeCrashArchitecture? {
+        if (!bytes.copyOfRange(0, NativeCrashSnapshotLayout.MAGIC_SIZE).contentEquals(magic)) return null
+        if (buffer.getInt(NativeCrashSnapshotLayout.VERSION_OFFSET) != VERSION) return null
+        val architecture =
+            NativeCrashArchitecture.fromId(buffer.getInt(NativeCrashSnapshotLayout.ARCHITECTURE_OFFSET))
+                ?: return null
+        if (buffer.getInt(NativeCrashSnapshotLayout.RECORD_SIZE_OFFSET) != NativeCrashSnapshotLayout.RECORD_SIZE) return null
+        return architecture.takeIf { matchesCrashRecord(buffer, crashRecord) }
+    }
+
+    private fun matchesCrashRecord(
+        buffer: ByteBuffer,
+        crashRecord: NativeCrashRecord,
+    ): Boolean {
+        if (buffer.getInt(NativeCrashSnapshotLayout.SIGNAL_NUMBER_OFFSET) != crashRecord.signalNumber) return false
+        val timestampNanos = buffer.getLong(NativeCrashSnapshotLayout.TIMESTAMP_OFFSET)
+        val epochSecond = crashRecord.timestamp.epochSecond
+        val nano = crashRecord.timestamp.nano.toLong()
+        if (timestampNanos <= 0 || epochSecond < 0 || epochSecond > (Long.MAX_VALUE - nano) / NANOS_PER_SECOND) return false
+        return timestampNanos == epochSecond * NANOS_PER_SECOND + nano
+    }
+
+    private fun readModule(
+        bytes: ByteArray,
+        buffer: ByteBuffer,
+        index: Int,
+        architecture: NativeCrashArchitecture,
+    ): NativeCrashModule? {
+        val base = NativeCrashSnapshotLayout.MODULES_OFFSET + index * NativeCrashSnapshotLayout.MODULE_ENTRY_SIZE
+        val loadBias = buffer.addressAt(base + NativeCrashSnapshotLayout.MODULE_LOAD_BIAS_OFFSET, architecture) ?: return null
+        val executableStart = buffer.addressAt(base + NativeCrashSnapshotLayout.MODULE_EXECUTABLE_START_OFFSET, architecture) ?: return null
+        val executableEnd = buffer.addressAt(base + NativeCrashSnapshotLayout.MODULE_EXECUTABLE_END_OFFSET, architecture) ?: return null
+        if (loadBias > executableStart || executableStart >= executableEnd) return null
+        if (buffer.getInt(base + NativeCrashSnapshotLayout.MODULE_RESERVED_OFFSET) != 0) return null
+
+        val name =
+            decodeName(
+                bytes,
+                base + NativeCrashSnapshotLayout.MODULE_NAME_OFFSET,
+                NativeCrashSnapshotLayout.MODULE_NAME_SIZE,
+            ) ?: return null
+        val buildIdSize = buffer.getInt(base + NativeCrashSnapshotLayout.MODULE_BUILD_ID_SIZE_OFFSET)
+        if (buildIdSize !in 0..NativeCrashSnapshotLayout.MODULE_BUILD_ID_CAPACITY) return null
+        val buildIdOffset = base + NativeCrashSnapshotLayout.MODULE_BUILD_ID_OFFSET
+        if (bytes.hasNonZeroBytes(
+                buildIdOffset + buildIdSize,
+                buildIdOffset + NativeCrashSnapshotLayout.MODULE_BUILD_ID_CAPACITY,
+            )
+        ) {
+            return null
+        }
+        val buildId = buildIdSize.takeIf { it > 0 }?.let { bytes.toHex(buildIdOffset, it) }
+        return NativeCrashModule(loadBias, executableStart, executableEnd, name, buildId)
+    }
+
+    private fun decodeName(
+        bytes: ByteArray,
+        offset: Int,
+        size: Int,
+    ): String? {
+        val terminator = (offset until offset + size).firstOrNull { bytes[it] == 0.toByte() } ?: return null
+        if (terminator == offset || bytes.hasNonZeroBytes(terminator + 1, offset + size)) return null
+        val name =
+            runCatching {
+                Charsets.UTF_8
+                    .newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(bytes, offset, terminator - offset))
+                    .toString()
+            }.getOrNull() ?: return null
+        return name.takeUnless { it.isBlank() || it.contains('/') || it.any(Char::isISOControl) }
+    }
+
+    private fun ByteBuffer.addressAt(
+        offset: Int,
+        architecture: NativeCrashArchitecture,
+    ): ULong? {
+        val address = getLong(offset).toULong()
+        return address.takeIf { architecture.pointerSize == Long.SIZE_BYTES || it <= UInt.MAX_VALUE.toULong() }
+    }
+
+    private fun ByteBuffer.linkRegister(architecture: NativeCrashArchitecture): ULong? =
+        if (architecture.hasLinkRegister) addressAt(NativeCrashSnapshotLayout.LINK_REGISTER_OFFSET, architecture) else 0UL
+
+    private fun ByteArray.uintAt(offset: Int): UInt =
+        ByteBuffer
+            .wrap(this, offset, Int.SIZE_BYTES)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .int
+            .toUInt()
+
+    private fun ByteArray.hasNonZeroBytes(
+        start: Int,
+        end: Int,
+    ): Boolean = (start until end).any { this[it] != 0.toByte() }
+
+    private fun ByteArray.toHex(
+        offset: Int,
+        size: Int,
+    ): String =
+        buildString(size * 2) {
+            repeat(size) { index ->
+                val value = this@toHex[offset + index].toInt() and 0xff
+                append(HEX_DIGITS[value ushr 4])
+                append(HEX_DIGITS[value and 0xf])
+            }
+        }
+}

--- a/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashSnapshot.kt
+++ b/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashSnapshot.kt
@@ -133,6 +133,11 @@ internal object NativeCrashSnapshotParser {
         )
     }
 
+    /**
+     * Calculates the checksum over the fixed prefix covered by the snapshot format.
+     *
+     * @throws IllegalArgumentException if [bytes] does not contain the complete prefix.
+     */
     internal fun checksum(bytes: ByteArray): UInt {
         require(bytes.size >= NativeCrashSnapshotLayout.CHECKSUM_OFFSET)
         var checksum = FNV_OFFSET_BASIS

--- a/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashSnapshot.kt
+++ b/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashSnapshot.kt
@@ -89,6 +89,10 @@ internal object NativeCrashSnapshotParser {
 
     private val magic = "OTELNCS\u0000".toByteArray(Charsets.US_ASCII)
 
+    /**
+     * Parses a complete snapshot record, returning `null` when the record is malformed or does not
+     * match [crashRecord].
+     */
     fun parse(
         bytes: ByteArray,
         crashRecord: NativeCrashRecord,
@@ -106,11 +110,7 @@ internal object NativeCrashSnapshotParser {
         val moduleCount = buffer.getInt(NativeCrashSnapshotLayout.MODULE_COUNT_OFFSET)
         val stackSize = buffer.getInt(NativeCrashSnapshotLayout.STACK_SIZE_OFFSET)
 
-        if (stackPointer == 0UL || stackStart != stackPointer) return null
-        if (stackStart % architecture.pointerSize.toULong() != 0UL) return null
-        if (moduleCount !in 1..NativeCrashSnapshotLayout.MAX_MODULES) return null
-        if (stackSize !in 0..NativeCrashSnapshotLayout.STACK_CAPACITY) return null
-        if (buffer.getInt(NativeCrashSnapshotLayout.RESERVED_OFFSET) != 0) return null
+        if (!buffer.hasValidPayloadMetadata(architecture, stackPointer, stackStart, moduleCount, stackSize)) return null
 
         val modules =
             (0 until moduleCount).mapNotNull { index ->
@@ -135,6 +135,8 @@ internal object NativeCrashSnapshotParser {
 
     /**
      * Calculates the checksum over the fixed prefix covered by the snapshot format.
+     *
+     * [parse] checks the complete record length before calling this helper.
      *
      * @throws IllegalArgumentException if [bytes] does not contain the complete prefix.
      */
@@ -176,6 +178,22 @@ internal object NativeCrashSnapshotParser {
         if (timestampNanos <= 0 || epochSecond < 0 || epochSecond > (Long.MAX_VALUE - nano) / NANOS_PER_SECOND) return false
         return timestampNanos == epochSecond * NANOS_PER_SECOND + nano
     }
+
+    private fun ByteBuffer.hasValidPayloadMetadata(
+        architecture: NativeCrashArchitecture,
+        stackPointer: ULong,
+        stackStart: ULong,
+        moduleCount: Int,
+        stackSize: Int,
+    ): Boolean =
+        with(NativeCrashSnapshotLayout) {
+            stackPointer != 0UL &&
+                stackStart == stackPointer &&
+                stackStart % architecture.pointerSize.toULong() == 0UL &&
+                moduleCount in 1..MAX_MODULES &&
+                stackSize in 0..STACK_CAPACITY &&
+                getInt(RESERVED_OFFSET) == 0
+        }
 
     private fun readModule(
         bytes: ByteArray,

--- a/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashSnapshotParserTest.kt
+++ b/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashSnapshotParserTest.kt
@@ -31,7 +31,7 @@ class NativeCrashSnapshotParserTest {
         val snapshot =
             requireNotNull(
                 parse { buffer ->
-                    buffer.putInt(NativeCrashSnapshotLayout.MODULE_COUNT_OFFSET, 128)
+                    buffer.writeMaximumModuleTable()
                     buffer.putInt(NativeCrashSnapshotLayout.STACK_SIZE_OFFSET, 4096)
                     buffer.fill(MODULE_OFFSET + 24, 64, 0)
                     buffer.fill(MODULE_OFFSET + 24, 63, 'a'.code.toByte())
@@ -48,8 +48,9 @@ class NativeCrashSnapshotParserTest {
         assertThat(snapshot.linkRegister).isEqualTo(0x1130UL)
         assertThat(snapshot.stack).hasSize(4096)
         assertThat(snapshot.stack.copyOf(4)).containsExactly(1, 2, 3, 4)
-        assertThat(snapshot.modules)
-            .containsExactly(
+        assertThat(snapshot.modules).hasSize(NativeCrashSnapshotLayout.MAX_MODULES)
+        assertThat(snapshot.modules.first())
+            .isEqualTo(
                 NativeCrashModule(
                     0x1000UL,
                     0x1100UL,
@@ -58,6 +59,8 @@ class NativeCrashSnapshotParserTest {
                     "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
                 ),
             )
+        assertThat(snapshot.modules.last())
+            .isEqualTo(NativeCrashModule(0xaef0UL, 0xaf00UL, 0xaf80UL, "lib127.so", null))
     }
 
     @TestFactory
@@ -80,6 +83,7 @@ class NativeCrashSnapshotParserTest {
                 assertThat(snapshot.architecture).isEqualTo(architecture)
                 assertThat(snapshot.linkRegister)
                     .isEqualTo(if (architecture.hasLinkRegister) encodedLinkRegister.toULong() else 0UL)
+                assertThat(snapshot.stack).containsExactly(1, 2, 3, 4)
             }
         }
 
@@ -113,9 +117,18 @@ class NativeCrashSnapshotParserTest {
     @Test
     fun `never throws for checksum-valid mutations`() {
         val random = Random(1940)
-        repeat(500) {
-            val bytes = SnapshotBuilder().build()
-            bytes[random.nextInt(NativeCrashSnapshotLayout.CHECKSUM_OFFSET)] = random.nextInt().toByte()
+        val interpretedRanges =
+            listOf(
+                0 until NativeCrashSnapshotLayout.MODULES_OFFSET,
+                NativeCrashSnapshotLayout.MODULES_OFFSET until MODULE_OFFSET + NativeCrashSnapshotLayout.MODULE_ENTRY_SIZE,
+                NativeCrashSnapshotLayout.RESERVED_OFFSET until NativeCrashSnapshotLayout.CHECKSUM_OFFSET,
+            )
+        repeat(500) { iteration ->
+            val architecture = NativeCrashArchitecture.entries[iteration % NativeCrashArchitecture.entries.size]
+            val bytes = SnapshotBuilder(architecture).build()
+            val range = interpretedRanges[iteration % interpretedRanges.size]
+            val index = random.nextInt(range.first, range.last + 1)
+            bytes[index] = (bytes[index].toInt() xor (1 shl random.nextInt(8))).toByte()
             ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).putInt(
                 NativeCrashSnapshotLayout.CHECKSUM_OFFSET,
                 NativeCrashSnapshotParser.checksum(bytes).toInt(),
@@ -168,6 +181,7 @@ class NativeCrashSnapshotParserTest {
 
     @TestFactory
     fun `skips malformed module entries`() =
+        // Raw relative offsets intentionally cross-check the mirrored binary layout constants.
         listOf<Pair<String, (ByteBuffer) -> Unit>>(
             "load bias after start" to { it.putLong(MODULE_OFFSET, 0x1200) },
             "empty executable range" to { it.putLong(MODULE_OFFSET + 16, 0x1100) },
@@ -232,6 +246,7 @@ class NativeCrashSnapshotParserTest {
             buffer.writeModule(MODULE_OFFSET, 0x1000, 0x1100, 0x2000, "libapp.so", byteArrayOf(1, 0x23, 0xfe.toByte()))
             buffer.position(NativeCrashSnapshotLayout.STACK_OFFSET)
             buffer.put(byteArrayOf(1, 2, 3, 4))
+            buffer.put(NativeCrashSnapshotLayout.STACK_OFFSET + 100, 9)
             mutate(buffer)
             buffer.putInt(NativeCrashSnapshotLayout.CHECKSUM_OFFSET, NativeCrashSnapshotParser.checksum(bytes).toInt())
             return bytes
@@ -254,6 +269,20 @@ class NativeCrashSnapshotParserTest {
         putInt(offset + 88, buildId.size)
         position(offset + 92)
         put(buildId)
+    }
+
+    private fun ByteBuffer.writeMaximumModuleTable() {
+        putInt(NativeCrashSnapshotLayout.MODULE_COUNT_OFFSET, NativeCrashSnapshotLayout.MAX_MODULES)
+        for (index in 1 until NativeCrashSnapshotLayout.MAX_MODULES) {
+            val executableStart = 0x3000L + index * 0x100L
+            writeModule(
+                MODULE_OFFSET + index * NativeCrashSnapshotLayout.MODULE_ENTRY_SIZE,
+                executableStart - 0x10,
+                executableStart,
+                executableStart + 0x80,
+                "lib$index.so",
+            )
+        }
     }
 
     private fun ByteBuffer.fill(

--- a/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashSnapshotParserTest.kt
+++ b/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashSnapshotParserTest.kt
@@ -6,6 +6,7 @@
 package io.opentelemetry.android.instrumentation.nativecrash
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.DynamicTest.dynamicTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestFactory
@@ -24,6 +25,13 @@ class NativeCrashSnapshotParserTest {
         bytes[NativeCrashSnapshotLayout.CHECKSUM_OFFSET - 1] = 0xff.toByte()
 
         assertThat(NativeCrashSnapshotParser.checksum(bytes)).isEqualTo(0x974ee9fcu)
+    }
+
+    @Test
+    fun `checksum rejects a truncated prefix`() {
+        assertThatThrownBy {
+            NativeCrashSnapshotParser.checksum(ByteArray(NativeCrashSnapshotLayout.CHECKSUM_OFFSET - 1))
+        }.isInstanceOf(IllegalArgumentException::class.java)
     }
 
     @Test

--- a/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashSnapshotParserTest.kt
+++ b/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashSnapshotParserTest.kt
@@ -1,0 +1,271 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.instrumentation.nativecrash
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestFactory
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.time.Instant
+import kotlin.random.Random
+
+class NativeCrashSnapshotParserTest {
+    @Test
+    fun `uses the contract checksum constants`() {
+        val bytes = ByteArray(NativeCrashSnapshotLayout.RECORD_SIZE)
+        bytes[0] = 1
+        bytes[1] = 2
+        bytes[2] = 3
+        bytes[NativeCrashSnapshotLayout.CHECKSUM_OFFSET - 1] = 0xff.toByte()
+
+        assertThat(NativeCrashSnapshotParser.checksum(bytes)).isEqualTo(0x974ee9fcu)
+    }
+
+    @Test
+    fun `parses a complete snapshot at maximum bounds`() {
+        val snapshot =
+            requireNotNull(
+                parse { buffer ->
+                    buffer.putInt(NativeCrashSnapshotLayout.MODULE_COUNT_OFFSET, 128)
+                    buffer.putInt(NativeCrashSnapshotLayout.STACK_SIZE_OFFSET, 4096)
+                    buffer.fill(MODULE_OFFSET + 24, 64, 0)
+                    buffer.fill(MODULE_OFFSET + 24, 63, 'a'.code.toByte())
+                    buffer.putInt(MODULE_OFFSET + 88, 32)
+                    buffer.position(MODULE_OFFSET + 92)
+                    buffer.put(ByteArray(32) { it.toByte() })
+                },
+            )
+
+        assertThat(snapshot.architecture).isEqualTo(NativeCrashArchitecture.ARM64)
+        assertThat(snapshot.programCounter).isEqualTo(0x1120UL)
+        assertThat(snapshot.stackPointer).isEqualTo(STACK_START.toULong())
+        assertThat(snapshot.framePointer).isEqualTo((STACK_START + 16).toULong())
+        assertThat(snapshot.linkRegister).isEqualTo(0x1130UL)
+        assertThat(snapshot.stack).hasSize(4096)
+        assertThat(snapshot.stack.copyOf(4)).containsExactly(1, 2, 3, 4)
+        assertThat(snapshot.modules)
+            .containsExactly(
+                NativeCrashModule(
+                    0x1000UL,
+                    0x1100UL,
+                    0x2000UL,
+                    "a".repeat(63),
+                    "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+                ),
+            )
+    }
+
+    @TestFactory
+    fun `supports each contract architecture`() =
+        NativeCrashArchitecture.entries.map { architecture ->
+            dynamicTest(architecture.name) {
+                val encodedLinkRegister =
+                    if (architecture == NativeCrashArchitecture.ARM) {
+                        UInt.MAX_VALUE.toLong()
+                    } else {
+                        -1L
+                    }
+                val snapshot =
+                    requireNotNull(
+                        parse(architecture) { buffer ->
+                            buffer.putLong(NativeCrashSnapshotLayout.LINK_REGISTER_OFFSET, encodedLinkRegister)
+                        },
+                    )
+
+                assertThat(snapshot.architecture).isEqualTo(architecture)
+                assertThat(snapshot.linkRegister)
+                    .isEqualTo(if (architecture.hasLinkRegister) encodedLinkRegister.toULong() else 0UL)
+            }
+        }
+
+    @Test
+    fun `accepts an empty stack and zero program counter`() {
+        val snapshot =
+            requireNotNull(
+                parse { buffer ->
+                    buffer.putLong(NativeCrashSnapshotLayout.PROGRAM_COUNTER_OFFSET, 0)
+                    buffer.putInt(NativeCrashSnapshotLayout.STACK_SIZE_OFFSET, 0)
+                },
+            )
+
+        assertThat(snapshot.programCounter).isEqualTo(0UL)
+        assertThat(snapshot.stack).isEmpty()
+    }
+
+    @Test
+    fun `rejects size checksum signal and timestamp mismatches`() {
+        val valid = SnapshotBuilder().build()
+        val corrupt = valid.copyOf().apply { this[NativeCrashSnapshotLayout.STACK_OFFSET] = 9 }
+
+        assertThat(NativeCrashSnapshotParser.parse(valid.copyOf(valid.size - 1), crashRecord)).isNull()
+        assertThat(NativeCrashSnapshotParser.parse(valid + byteArrayOf(0), crashRecord)).isNull()
+        assertThat(NativeCrashSnapshotParser.parse(corrupt, crashRecord)).isNull()
+        assertThat(NativeCrashSnapshotParser.parse(valid, crashRecord.copy(signalNumber = 6))).isNull()
+        assertThat(NativeCrashSnapshotParser.parse(valid, crashRecord.copy(timestamp = crashRecord.timestamp.plusNanos(1)))).isNull()
+        assertThat(NativeCrashSnapshotParser.parse(valid, crashRecord.copy(timestamp = Instant.MAX))).isNull()
+    }
+
+    @Test
+    fun `never throws for checksum-valid mutations`() {
+        val random = Random(1940)
+        repeat(500) {
+            val bytes = SnapshotBuilder().build()
+            bytes[random.nextInt(NativeCrashSnapshotLayout.CHECKSUM_OFFSET)] = random.nextInt().toByte()
+            ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).putInt(
+                NativeCrashSnapshotLayout.CHECKSUM_OFFSET,
+                NativeCrashSnapshotParser.checksum(bytes).toInt(),
+            )
+
+            assertThat(runCatching { NativeCrashSnapshotParser.parse(bytes, crashRecord) }.exceptionOrNull()).isNull()
+        }
+    }
+
+    @TestFactory
+    fun `rejects structurally invalid snapshots`() =
+        listOf<Pair<String, (ByteBuffer) -> Unit>>(
+            "magic" to { it.put(0, 'X'.code.toByte()) },
+            "version" to { it.putInt(NativeCrashSnapshotLayout.VERSION_OFFSET, 2) },
+            "architecture" to { it.putInt(NativeCrashSnapshotLayout.ARCHITECTURE_OFFSET, 99) },
+            "record size" to { it.putInt(NativeCrashSnapshotLayout.RECORD_SIZE_OFFSET, 1) },
+            "zero timestamp" to { it.putLong(NativeCrashSnapshotLayout.TIMESTAMP_OFFSET, 0) },
+            "zero stack pointer" to { it.putLong(NativeCrashSnapshotLayout.STACK_POINTER_OFFSET, 0) },
+            "different stack start" to { it.putLong(NativeCrashSnapshotLayout.STACK_START_OFFSET, STACK_START + 8) },
+            "unaligned stack" to {
+                it.putLong(NativeCrashSnapshotLayout.STACK_POINTER_OFFSET, STACK_START + 1)
+                it.putLong(NativeCrashSnapshotLayout.STACK_START_OFFSET, STACK_START + 1)
+            },
+            "zero modules" to { it.putInt(NativeCrashSnapshotLayout.MODULE_COUNT_OFFSET, 0) },
+            "too many modules" to { it.putInt(NativeCrashSnapshotLayout.MODULE_COUNT_OFFSET, 129) },
+            "negative stack size" to { it.putInt(NativeCrashSnapshotLayout.STACK_SIZE_OFFSET, -1) },
+            "oversized stack" to { it.putInt(NativeCrashSnapshotLayout.STACK_SIZE_OFFSET, 4097) },
+            "reserved header" to { it.putInt(NativeCrashSnapshotLayout.RESERVED_OFFSET, 1) },
+        ).map { (name, mutation) ->
+            dynamicTest(name) {
+                assertThat(parse(mutate = mutation)).isNull()
+            }
+        }
+
+    @TestFactory
+    fun `rejects non-zero upper bits in 32 bit registers`() =
+        listOf<Pair<String, (ByteBuffer) -> Unit>>(
+            "program counter" to { it.putLong(NativeCrashSnapshotLayout.PROGRAM_COUNTER_OFFSET, 0x1_0000_1120) },
+            "frame pointer" to { it.putLong(NativeCrashSnapshotLayout.FRAME_POINTER_OFFSET, 0x1_0000_7010) },
+            "link register" to { it.putLong(NativeCrashSnapshotLayout.LINK_REGISTER_OFFSET, 0x1_0000_1130) },
+            "stack pointer" to {
+                it.putLong(NativeCrashSnapshotLayout.STACK_POINTER_OFFSET, 0x1_0000_7000)
+                it.putLong(NativeCrashSnapshotLayout.STACK_START_OFFSET, 0x1_0000_7000)
+            },
+        ).map { (name, mutation) ->
+            dynamicTest(name) {
+                assertThat(parse(NativeCrashArchitecture.ARM, mutation)).isNull()
+            }
+        }
+
+    @TestFactory
+    fun `skips malformed module entries`() =
+        listOf<Pair<String, (ByteBuffer) -> Unit>>(
+            "load bias after start" to { it.putLong(MODULE_OFFSET, 0x1200) },
+            "empty executable range" to { it.putLong(MODULE_OFFSET + 16, 0x1100) },
+            "missing name terminator" to { it.fill(MODULE_OFFSET + 24, 64, 'a'.code.toByte()) },
+            "empty name" to { it.fill(MODULE_OFFSET + 24, 64, 0) },
+            "name padding" to { it.put(MODULE_OFFSET + 24 + 20, 1) },
+            "malformed utf8" to {
+                it.put(MODULE_OFFSET + 24, 0xc3.toByte())
+                it.put(MODULE_OFFSET + 25, 0x28)
+            },
+            "control character" to { it.put(MODULE_OFFSET + 27, '\n'.code.toByte()) },
+            "path instead of basename" to { it.put(MODULE_OFFSET + 27, '/'.code.toByte()) },
+            "negative build id length" to { it.putInt(MODULE_OFFSET + 88, -1) },
+            "oversized build id" to { it.putInt(MODULE_OFFSET + 88, 33) },
+            "build id padding" to { it.put(MODULE_OFFSET + 102, 1) },
+            "reserved module" to { it.putInt(MODULE_OFFSET + 124, 1) },
+        ).map { (name, mutation) ->
+            dynamicTest(name) {
+                assertThat(requireNotNull(parse(mutate = mutation)).modules).isEmpty()
+            }
+        }
+
+    @Test
+    fun `keeps valid modules after a malformed entry`() {
+        val snapshot =
+            requireNotNull(
+                parse(NativeCrashArchitecture.X86) { buffer ->
+                    buffer.putInt(NativeCrashSnapshotLayout.MODULE_COUNT_OFFSET, 2)
+                    buffer.putLong(MODULE_OFFSET, 0x1_0000_1000)
+                    buffer.writeModule(MODULE_OFFSET + 128, 0x3000, 0x3100, 0x4000, "libsecond.so")
+                },
+            )
+
+        assertThat(snapshot.modules)
+            .containsExactly(NativeCrashModule(0x3000UL, 0x3100UL, 0x4000UL, "libsecond.so", null))
+    }
+
+    private fun parse(
+        architecture: NativeCrashArchitecture = NativeCrashArchitecture.ARM64,
+        mutate: (ByteBuffer) -> Unit = {},
+    ): NativeCrashSnapshot? = NativeCrashSnapshotParser.parse(SnapshotBuilder(architecture).build(mutate), crashRecord)
+
+    private inner class SnapshotBuilder(
+        private val architecture: NativeCrashArchitecture = NativeCrashArchitecture.ARM64,
+    ) {
+        fun build(mutate: (ByteBuffer) -> Unit = {}): ByteArray {
+            val bytes = ByteArray(NativeCrashSnapshotLayout.RECORD_SIZE)
+            val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+            buffer.put("OTELNCS\u0000".toByteArray())
+            buffer.putInt(1)
+            buffer.putInt(architecture.id)
+            buffer.putInt(bytes.size)
+            buffer.putInt(crashRecord.signalNumber)
+            buffer.putLong(TIMESTAMP_NANOS)
+            buffer.putLong(0x1120)
+            buffer.putLong(STACK_START)
+            buffer.putLong(STACK_START + 16)
+            buffer.putLong(if (architecture.hasLinkRegister) 0x1130 else 0)
+            buffer.putInt(1)
+            buffer.putInt(4)
+            buffer.putLong(STACK_START)
+            buffer.writeModule(MODULE_OFFSET, 0x1000, 0x1100, 0x2000, "libapp.so", byteArrayOf(1, 0x23, 0xfe.toByte()))
+            buffer.position(NativeCrashSnapshotLayout.STACK_OFFSET)
+            buffer.put(byteArrayOf(1, 2, 3, 4))
+            mutate(buffer)
+            buffer.putInt(NativeCrashSnapshotLayout.CHECKSUM_OFFSET, NativeCrashSnapshotParser.checksum(bytes).toInt())
+            return bytes
+        }
+    }
+
+    private fun ByteBuffer.writeModule(
+        offset: Int,
+        loadBias: Long,
+        start: Long,
+        end: Long,
+        name: String,
+        buildId: ByteArray = byteArrayOf(),
+    ) {
+        putLong(offset, loadBias)
+        putLong(offset + 8, start)
+        putLong(offset + 16, end)
+        position(offset + 24)
+        put(name.toByteArray())
+        putInt(offset + 88, buildId.size)
+        position(offset + 92)
+        put(buildId)
+    }
+
+    private fun ByteBuffer.fill(
+        offset: Int,
+        size: Int,
+        value: Byte,
+    ) = repeat(size) { put(offset + it, value) }
+
+    private companion object {
+        const val STACK_START = 0x7000L
+        const val MODULE_OFFSET = NativeCrashSnapshotLayout.MODULES_OFFSET
+        const val TIMESTAMP_NANOS = 1_783_598_400_123_456_789L
+        val crashRecord = NativeCrashRecord(11, Instant.ofEpochSecond(1_783_598_400, 123_456_789))
+    }
+}

--- a/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashSnapshotParserTest.kt
+++ b/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashSnapshotParserTest.kt
@@ -35,6 +35,20 @@ class NativeCrashSnapshotParserTest {
     }
 
     @Test
+    fun `parser rejects a truncated record without throwing`() {
+        val result =
+            runCatching {
+                NativeCrashSnapshotParser.parse(
+                    ByteArray(NativeCrashSnapshotLayout.RECORD_SIZE - 1),
+                    crashRecord,
+                )
+            }
+
+        assertThat(result.exceptionOrNull()).isNull()
+        assertThat(result.getOrNull()).isNull()
+    }
+
+    @Test
     fun `parses a complete snapshot at maximum bounds`() {
         val snapshot =
             requireNotNull(
@@ -114,7 +128,6 @@ class NativeCrashSnapshotParserTest {
         val valid = SnapshotBuilder().build()
         val corrupt = valid.copyOf().apply { this[NativeCrashSnapshotLayout.STACK_OFFSET] = 9 }
 
-        assertThat(NativeCrashSnapshotParser.parse(valid.copyOf(valid.size - 1), crashRecord)).isNull()
         assertThat(NativeCrashSnapshotParser.parse(valid + byteArrayOf(0), crashRecord)).isNull()
         assertThat(NativeCrashSnapshotParser.parse(corrupt, crashRecord)).isNull()
         assertThat(NativeCrashSnapshotParser.parse(valid, crashRecord.copy(signalNumber = 6))).isNull()


### PR DESCRIPTION
This PR adds the internal parser and data model for the version 1 native crash snapshot defined in #1999.

- validates the exact size, magic, version, checksum, architecture, and marker pairing
- enforces ABI address widths, stack bounds, alignment, reserved fields, module ranges, names, and build IDs
- supports ARM, ARM64, x86, and x86_64
- skips malformed module entries while preserving valid entries
- includes boundary, corruption, and mutation coverage

This PR is intentionally limited to parsing and validation. It does not change the signal handler or emit native frames yet.

## Follow-up work

The remaining work for #1940 will be split into focused follow-ups:

1. Recover module-relative frames and build IDs from validated snapshots.
2. Integrate snapshots with restart-time crash replay, bounded retries, and cleanup.
3. Add async-signal-safe register, module, and bounded-stack capture to the native handler.
4. Run end-to-end device validation across the supported Android ABIs and malformed or partial data cases.

Symbolication and backend rendering remain separate work.

Merge tier: Tier 3

