### PR TITLE
feat(session): expire on meaningful activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 
 ### 📈 Enhancements
 
+- Sessions now expire after 15 minutes without meaningful activity. Foreground returns and
+  instrumented pointer input refresh the inactivity window, while passive telemetry does not. The
+  four-hour maximum lifetime remains unchanged.
+  ([#794](https://github.com/open-telemetry/opentelemetry-android/issues/794),
+  [#910](https://github.com/open-telemetry/opentelemetry-android/issues/910))
+
 - The Compose Navigation instrumentation, which shipped in 1.6.0 without emitting any telemetry,
   now records an `app.navigation.complete` event carrying the `app.navigation.destination.name`
   attribute whenever a navigation completes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### 📣 Migration notes
 
+- Foreground sessions now expire after the configured inactivity window; previously they remained
+  active until the four-hour maximum. Expired sessions rotate on the next access, including passive
+  telemetry attribution. Use `inactivityTimeout`; `backgroundInactivityTimeout` remains as a
+  deprecated alias.
+
 - Network change events now use `network.connection.type` instead of the deprecated
   `network.status`. To keep emitting `network.status` while migrating, configure
   `semanticConventions { useLatestExperimental = false }`.
@@ -12,8 +17,8 @@
 ### 📈 Enhancements
 
 - Sessions now expire after 15 minutes without meaningful activity. Foreground returns and
-  instrumented pointer input refresh the inactivity window, while passive telemetry does not. The
-  four-hour maximum lifetime remains unchanged.
+  touch, key, and scroll input refresh the inactivity window, while passive telemetry does not.
+  The four-hour maximum lifetime remains unchanged.
   ([#794](https://github.com/open-telemetry/opentelemetry-android/issues/794),
   [#910](https://github.com/open-telemetry/opentelemetry-android/issues/910))
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ private fun initOTel(context: Context): OpenTelemetryRum? =
                     }
                 }
                 session {
-                    backgroundInactivityTimeout = 5.minutes
+                    inactivityTimeout = 5.minutes
                     maxLifetime = 1.days
                 }
                 globalAttributes {

--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -82,9 +82,11 @@ public final class io/opentelemetry/android/agent/dsl/SemanticConventionsConfigu
 
 public final class io/opentelemetry/android/agent/dsl/SessionConfiguration {
 	public final fun getBackgroundInactivityTimeout-UwyO8pc ()J
+	public final fun getInactivityTimeout-UwyO8pc ()J
 	public final fun getMaxLifetime-UwyO8pc ()J
 	public final fun observers ([Lio/opentelemetry/android/session/SessionObserver;)V
 	public final fun setBackgroundInactivityTimeout-LRDsOJo (J)V
+	public final fun setInactivityTimeout-LRDsOJo (J)V
 	public final fun setMaxLifetime-LRDsOJo (J)V
 }
 

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
@@ -16,12 +16,11 @@ import io.opentelemetry.android.agent.connectivity.HttpEndpointConnectivity
 import io.opentelemetry.android.agent.dsl.OpenTelemetryConfiguration
 import io.opentelemetry.android.agent.session.SessionConfig
 import io.opentelemetry.android.agent.session.SessionIdTimeoutHandler
+import io.opentelemetry.android.agent.session.SessionInputActivityInstrumentation
 import io.opentelemetry.android.agent.session.SessionManager
-import io.opentelemetry.android.agent.session.registerSessionInputActivityTracker
 import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.internal.services.Services
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle
-import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
@@ -65,7 +64,9 @@ object OpenTelemetryRumInitializer {
                         instrumentationLoader = instrumentationLoader,
                     ).also(configuration)
 
-                setSessionProvider(createSessionProvider(ctx, Services.get(ctx).appLifecycle, cfg))
+                val sessionManager = createSessionManager(Services.get(ctx).appLifecycle, cfg)
+                setSessionProvider(sessionManager)
+                addInstrumentation(SessionInputActivityInstrumentation(sessionManager::recordActivity))
                 setResource(
                     AndroidResource
                         .createDefault(ctx)
@@ -145,11 +146,10 @@ object OpenTelemetryRumInitializer {
             else -> "none"
         }
 
-    private fun createSessionProvider(
-        context: Context,
+    private fun createSessionManager(
         appLifecycle: AppLifecycle,
         cfg: OpenTelemetryConfiguration,
-    ): SessionProvider {
+    ): SessionManager {
         val sessionConfig =
             SessionConfig(
                 cfg.sessionConfig.inactivityTimeout,
@@ -158,7 +158,6 @@ object OpenTelemetryRumInitializer {
         val clock = cfg.clock
         val timeoutHandler = SessionIdTimeoutHandler(sessionConfig, clock)
         val sessionManager = SessionManager.create(timeoutHandler, sessionConfig, clock)
-        registerSessionInputActivityTracker(context, sessionManager::recordActivity)
         appLifecycle.registerListener(sessionManager)
         cfg.sessionConfig.getObservers().forEach { sessionManager.addObserver(it) }
         return sessionManager

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
@@ -17,6 +17,7 @@ import io.opentelemetry.android.agent.dsl.OpenTelemetryConfiguration
 import io.opentelemetry.android.agent.session.SessionConfig
 import io.opentelemetry.android.agent.session.SessionIdTimeoutHandler
 import io.opentelemetry.android.agent.session.SessionManager
+import io.opentelemetry.android.agent.session.registerSessionInputActivityTracker
 import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.internal.services.Services
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle
@@ -64,7 +65,7 @@ object OpenTelemetryRumInitializer {
                         instrumentationLoader = instrumentationLoader,
                     ).also(configuration)
 
-                setSessionProvider(createSessionProvider(Services.get(ctx).appLifecycle, cfg))
+                setSessionProvider(createSessionProvider(ctx, Services.get(ctx).appLifecycle, cfg))
                 setResource(
                     AndroidResource
                         .createDefault(ctx)
@@ -145,17 +146,19 @@ object OpenTelemetryRumInitializer {
         }
 
     private fun createSessionProvider(
+        context: Context,
         appLifecycle: AppLifecycle,
         cfg: OpenTelemetryConfiguration,
     ): SessionProvider {
         val sessionConfig =
             SessionConfig(
-                cfg.sessionConfig.backgroundInactivityTimeout,
+                cfg.sessionConfig.inactivityTimeout,
                 cfg.sessionConfig.maxLifetime,
             )
         val clock = cfg.clock
         val timeoutHandler = SessionIdTimeoutHandler(sessionConfig, clock)
         val sessionManager = SessionManager.create(timeoutHandler, sessionConfig, clock)
+        registerSessionInputActivityTracker(context, sessionManager::recordActivity)
         appLifecycle.registerListener(sessionManager)
         cfg.sessionConfig.getObservers().forEach { sessionManager.addObserver(it) }
         return sessionManager

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
@@ -155,8 +155,8 @@ object OpenTelemetryRumInitializer {
             )
         val clock = cfg.clock
         val timeoutHandler = SessionIdTimeoutHandler(sessionConfig, clock)
-        appLifecycle.registerListener(timeoutHandler)
         val sessionManager = SessionManager.create(timeoutHandler, sessionConfig, clock)
+        appLifecycle.registerListener(sessionManager)
         cfg.sessionConfig.getObservers().forEach { sessionManager.addObserver(it) }
         return sessionManager
     }

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/SessionConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/SessionConfiguration.kt
@@ -19,7 +19,18 @@ class SessionConfiguration internal constructor() {
      * The maximum duration which a session can remain open without meaningful activity before it
      * automatically expires.
      */
-    var backgroundInactivityTimeout: Duration = 15.minutes
+    var inactivityTimeout: Duration = 15.minutes
+
+    /**
+     * The maximum duration which a session can remain open without meaningful activity before it
+     * automatically expires.
+     */
+    @Deprecated("Use inactivityTimeout", ReplaceWith("inactivityTimeout"))
+    var backgroundInactivityTimeout: Duration
+        get() = inactivityTimeout
+        set(value) {
+            inactivityTimeout = value
+        }
 
     /**
      * The maximum duration which a session can remain open before it automatically expires.

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/SessionConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/SessionConfiguration.kt
@@ -16,7 +16,7 @@ import kotlin.time.Duration.Companion.minutes
 @OpenTelemetryDslMarker
 class SessionConfiguration internal constructor() {
     /**
-     * The maximum duration which a session can remain open in the background before it
+     * The maximum duration which a session can remain open without meaningful activity before it
      * automatically expires.
      */
     var backgroundInactivityTimeout: Duration = 15.minutes

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionConfig.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionConfig.kt
@@ -10,7 +10,7 @@ import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 
 internal class SessionConfig(
-    val backgroundInactivityTimeout: Duration = 15.minutes,
+    val inactivityTimeout: Duration = 15.minutes,
     val maxLifetime: Duration = 4.hours,
 ) {
     companion object {

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionIdTimeoutHandler.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionIdTimeoutHandler.kt
@@ -6,33 +6,18 @@
 package io.opentelemetry.android.agent.session
 
 import io.opentelemetry.android.Incubating
-import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateListener
 import io.opentelemetry.sdk.common.Clock
 import kotlin.time.Duration
 
 /**
- * This class encapsulates the following criteria about the sessionId timeout:
- *
- *
- *  * If the app is in the foreground sessionId should never time out.
- *  * If the app is in the background and no activity (spans) happens for >15 minutes, sessionId
- * should time out.
- *  * If the app is in the background and some activity (spans) happens in <15 minute intervals,
- * sessionId should not time out.
- *
- *
- * Consequently, when the app spent >15 minutes without any activity (spans) in the background,
- * after moving to the foreground the first span should trigger the sessionId timeout.
+ * Tracks the elapsed time since the last meaningful session activity.
  */
 internal class SessionIdTimeoutHandler(
     private val clock: Clock,
-    private val sessionBackgroundInactivityTimeout: Duration,
-) : ApplicationStateListener {
+    private val sessionInactivityTimeout: Duration,
+) {
     @Volatile
-    private var timeoutStartNanos: Long = 0
-
-    @Volatile
-    private var state = State.FOREGROUND
+    private var timeoutStartNanos: Long = clock.nanoTime()
 
     // for testing
     @OptIn(Incubating::class)
@@ -41,37 +26,12 @@ internal class SessionIdTimeoutHandler(
         sessionConfig.backgroundInactivityTimeout,
     )
 
-    override fun onApplicationForegrounded() {
-        state = State.TRANSITIONING_TO_FOREGROUND
-    }
-
-    override fun onApplicationBackgrounded() {
-        state = State.BACKGROUND
-    }
-
     fun hasTimedOut(): Boolean {
-        // don't apply sessionId timeout to apps in the foreground
-        if (state == State.FOREGROUND) {
-            return false
-        }
         val elapsedTime = clock.nanoTime() - timeoutStartNanos
-        return elapsedTime >= sessionBackgroundInactivityTimeout.inWholeNanoseconds
+        return elapsedTime >= sessionInactivityTimeout.inWholeNanoseconds
     }
 
     fun bump() {
         timeoutStartNanos = clock.nanoTime()
-
-        // move from the temporary transition state to foreground after the first span
-        if (state == State.TRANSITIONING_TO_FOREGROUND) {
-            state = State.FOREGROUND
-        }
-    }
-
-    private enum class State {
-        FOREGROUND,
-        BACKGROUND,
-
-        /** A temporary state representing the first event after the app has been brought back.  */
-        TRANSITIONING_TO_FOREGROUND,
     }
 }

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionIdTimeoutHandler.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionIdTimeoutHandler.kt
@@ -23,7 +23,7 @@ internal class SessionIdTimeoutHandler(
     @OptIn(Incubating::class)
     internal constructor(sessionConfig: SessionConfig, clock: Clock) : this(
         clock,
-        sessionConfig.backgroundInactivityTimeout,
+        sessionConfig.inactivityTimeout,
     )
 
     fun hasTimedOut(): Boolean {

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionInputActivityTracker.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionInputActivityTracker.kt
@@ -70,9 +70,18 @@ internal class SessionInputActivityTracker(
         track(activity)
     }
 
+    override fun onActivityDestroyed(activity: Activity) {
+        synchronized(trackedWindows) {
+            untrack(activity.window, trackedWindows.remove(activity.window))
+        }
+    }
+
     private fun track(activity: Activity) {
         synchronized(trackedWindows) {
             val window = activity.window
+            if (trackedWindows.containsKey(window)) {
+                return
+            }
             val callback = window.callback
             if (callback !is SessionInputWindowCallback) {
                 SessionInputWindowCallback(callback, recordActivity).also {
@@ -86,19 +95,31 @@ internal class SessionInputActivityTracker(
     fun close() {
         synchronized(trackedWindows) {
             trackedWindows.forEach { (window, callback) ->
-                if (window.callback === callback) {
-                    window.callback = callback.unwrap()
-                }
+                untrack(window, callback)
             }
             trackedWindows.clear()
         }
+    }
+
+    private fun untrack(
+        window: Window,
+        callback: SessionInputWindowCallback?,
+    ) {
+        callback ?: return
+        if (window.callback === callback) {
+            window.callback = callback.unwrap()
+        }
+        callback.detach()
     }
 }
 
 internal class SessionInputWindowCallback(
     private val callback: Window.Callback,
-    private val recordActivity: () -> Unit,
+    recordActivity: () -> Unit,
 ) : Window.Callback by callback {
+    @Volatile
+    private var activityRecorder: (() -> Unit)? = recordActivity
+
     override fun dispatchTouchEvent(event: MotionEvent?): Boolean {
         if (event?.actionMasked == MotionEvent.ACTION_DOWN) {
             recordActivitySafely()
@@ -121,7 +142,7 @@ internal class SessionInputWindowCallback(
     }
 
     private fun recordActivitySafely() {
-        runCatching(recordActivity)
+        activityRecorder?.let { runCatching(it) }
     }
 
     @RequiresApi(api = VERSION_CODES.O)
@@ -146,4 +167,8 @@ internal class SessionInputWindowCallback(
     ): ActionMode? = this.callback.onWindowStartingActionMode(callback, type)
 
     fun unwrap(): Window.Callback = callback
+
+    fun detach() {
+        activityRecorder = null
+    }
 }

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionInputActivityTracker.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionInputActivityTracker.kt
@@ -18,28 +18,79 @@ import android.view.MotionEvent
 import android.view.SearchEvent
 import android.view.Window
 import androidx.annotation.RequiresApi
+import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.internal.services.visiblescreen.activities.DefaultingActivityLifecycleCallbacks
+import java.util.WeakHashMap
 
-internal fun registerSessionInputActivityTracker(
-    context: Context,
-    recordActivity: () -> Unit,
-) {
-    (context as? Application)?.registerActivityLifecycleCallbacks(
-        SessionInputActivityTracker(recordActivity),
-    )
+internal class SessionInputActivityInstrumentation(
+    private val recordActivity: () -> Unit,
+) : AndroidInstrumentation {
+    override val name: String = "session-input-activity"
+
+    private var tracker: SessionInputActivityTracker? = null
+
+    override fun install(
+        context: Context,
+        openTelemetryRum: OpenTelemetryRum,
+    ) {
+        val application = context as? Application ?: return
+        SessionInputActivityTracker(recordActivity).also {
+            tracker = it
+            application.registerActivityLifecycleCallbacks(it)
+        }
+    }
+
+    override fun uninstall(
+        context: Context,
+        openTelemetryRum: OpenTelemetryRum,
+    ) {
+        val application = context as? Application ?: return
+        tracker?.let {
+            application.unregisterActivityLifecycleCallbacks(it)
+            it.close()
+        }
+        tracker = null
+    }
 }
 
 internal class SessionInputActivityTracker(
     private val recordActivity: () -> Unit,
 ) : DefaultingActivityLifecycleCallbacks {
+    private val trackedWindows = WeakHashMap<Window, SessionInputWindowCallback>()
+
     override fun onActivityCreated(
         activity: Activity,
         savedInstanceState: Bundle?,
     ) {
-        val window = activity.window
-        val callback = window.callback
-        if (callback !is SessionInputWindowCallback) {
-            window.callback = SessionInputWindowCallback(callback, recordActivity)
+        track(activity)
+    }
+
+    override fun onActivityResumed(activity: Activity) {
+        track(activity)
+    }
+
+    private fun track(activity: Activity) {
+        synchronized(trackedWindows) {
+            val window = activity.window
+            val callback = window.callback
+            if (callback !is SessionInputWindowCallback) {
+                SessionInputWindowCallback(callback, recordActivity).also {
+                    window.callback = it
+                    trackedWindows[window] = it
+                }
+            }
+        }
+    }
+
+    fun close() {
+        synchronized(trackedWindows) {
+            trackedWindows.forEach { (window, callback) ->
+                if (window.callback === callback) {
+                    window.callback = callback.unwrap()
+                }
+            }
+            trackedWindows.clear()
         }
     }
 }
@@ -93,4 +144,6 @@ internal class SessionInputWindowCallback(
         callback: ActionMode.Callback?,
         type: Int,
     ): ActionMode? = this.callback.onWindowStartingActionMode(callback, type)
+
+    fun unwrap(): Window.Callback = callback
 }

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionInputActivityTracker.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionInputActivityTracker.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.session
+
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import android.os.Build.VERSION_CODES
+import android.os.Bundle
+import android.view.ActionMode
+import android.view.KeyEvent
+import android.view.KeyboardShortcutGroup
+import android.view.Menu
+import android.view.MotionEvent
+import android.view.SearchEvent
+import android.view.Window
+import androidx.annotation.RequiresApi
+import io.opentelemetry.android.internal.services.visiblescreen.activities.DefaultingActivityLifecycleCallbacks
+
+internal fun registerSessionInputActivityTracker(
+    context: Context,
+    recordActivity: () -> Unit,
+) {
+    (context as? Application)?.registerActivityLifecycleCallbacks(
+        SessionInputActivityTracker(recordActivity),
+    )
+}
+
+internal class SessionInputActivityTracker(
+    private val recordActivity: () -> Unit,
+) : DefaultingActivityLifecycleCallbacks {
+    override fun onActivityCreated(
+        activity: Activity,
+        savedInstanceState: Bundle?,
+    ) {
+        val window = activity.window
+        val callback = window.callback
+        if (callback !is SessionInputWindowCallback) {
+            window.callback = SessionInputWindowCallback(callback, recordActivity)
+        }
+    }
+}
+
+internal class SessionInputWindowCallback(
+    private val callback: Window.Callback,
+    private val recordActivity: () -> Unit,
+) : Window.Callback by callback {
+    override fun dispatchTouchEvent(event: MotionEvent?): Boolean {
+        if (event?.actionMasked == MotionEvent.ACTION_DOWN) {
+            recordActivitySafely()
+        }
+        return callback.dispatchTouchEvent(event)
+    }
+
+    override fun dispatchKeyEvent(event: KeyEvent?): Boolean {
+        if (event?.action == KeyEvent.ACTION_DOWN && event.repeatCount == 0) {
+            recordActivitySafely()
+        }
+        return callback.dispatchKeyEvent(event)
+    }
+
+    override fun dispatchGenericMotionEvent(event: MotionEvent?): Boolean {
+        if (event?.actionMasked == MotionEvent.ACTION_SCROLL) {
+            recordActivitySafely()
+        }
+        return callback.dispatchGenericMotionEvent(event)
+    }
+
+    private fun recordActivitySafely() {
+        runCatching(recordActivity)
+    }
+
+    @RequiresApi(api = VERSION_CODES.O)
+    override fun onPointerCaptureChanged(hasCapture: Boolean) {
+        callback.onPointerCaptureChanged(hasCapture)
+    }
+
+    @RequiresApi(api = VERSION_CODES.N)
+    override fun onProvideKeyboardShortcuts(
+        data: List<KeyboardShortcutGroup?>?,
+        menu: Menu?,
+        deviceId: Int,
+    ) {
+        callback.onProvideKeyboardShortcuts(data, menu, deviceId)
+    }
+
+    override fun onSearchRequested(searchEvent: SearchEvent?): Boolean = callback.onSearchRequested(searchEvent)
+
+    override fun onWindowStartingActionMode(
+        callback: ActionMode.Callback?,
+        type: Int,
+    ): ActionMode? = this.callback.onWindowStartingActionMode(callback, type)
+}

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionManager.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionManager.kt
@@ -6,6 +6,7 @@
 package io.opentelemetry.android.agent.session
 
 import io.opentelemetry.android.Incubating
+import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateListener
 import io.opentelemetry.android.session.Session
 import io.opentelemetry.android.session.SessionObserver
 import io.opentelemetry.android.session.SessionProvider
@@ -23,9 +24,11 @@ internal class SessionManager(
     private val idGenerator: SessionIdGenerator = DefaultSessionIdGenerator(Random.Default),
     private val maxSessionLifetime: Duration,
 ) : SessionProvider,
-    SessionPublisher {
+    SessionPublisher,
+    ApplicationStateListener {
     private val session: AtomicReference<Session> = AtomicReference(invalidSession)
     private val observers = CopyOnWriteArrayList<SessionObserver>()
+    private val accessLock = Any()
 
     init {
         sessionStorage.save(session.get())
@@ -35,33 +38,45 @@ internal class SessionManager(
         observers.add(observer)
     }
 
-    override fun getSessionId(): String {
-        val currentSession = session.get()
+    override fun getSessionId(): String = accessSession(recordActivity = true)
 
-        // Check if we need to create a new session.
-        return if (sessionHasExpired(currentSession) || timeoutHandler.hasTimedOut()) {
-            val newId = idGenerator.generateSessionId()
-            val newSession = SessionImpl(newId, clock.now())
+    override fun getSessionIdForAttribution(): String = accessSession(recordActivity = false)
 
-            // Atomically update the session only if it hasn't been changed by another thread.
-            if (session.compareAndSet(currentSession, newSession)) {
-                sessionStorage.save(newSession)
-                timeoutHandler.bump()
-                // Observers need to be called after bumping the timer because it may create a new
-                // span.
-                notifyObserversOfSessionUpdate(currentSession, newSession)
-                newSession.id
-            } else {
-                // Another thread accessed this function prior to creating a new session. Use the
-                // current session.
-                timeoutHandler.bump()
-                session.get().id
+    override fun recordActivity() {
+        accessSession(recordActivity = true)
+    }
+
+    override fun onApplicationForegrounded() {
+        recordActivity()
+    }
+
+    override fun onApplicationBackgrounded() = Unit
+
+    private fun accessSession(recordActivity: Boolean): String {
+        var transition: Pair<Session, Session>? = null
+        val sessionId =
+            synchronized(accessLock) {
+                val currentSession = session.get()
+                if (sessionHasExpired(currentSession) || timeoutHandler.hasTimedOut()) {
+                    val newSession = SessionImpl(idGenerator.generateSessionId(), clock.now())
+                    session.set(newSession)
+                    sessionStorage.save(newSession)
+                    // A new session starts a new inactivity window even for passive attribution.
+                    timeoutHandler.bump()
+                    transition = currentSession to newSession
+                    newSession.id
+                } else {
+                    if (recordActivity) {
+                        timeoutHandler.bump()
+                    }
+                    currentSession.id
+                }
             }
-        } else {
-            // No new session needed, just bump the timeout and return current session ID
-            timeoutHandler.bump()
-            currentSession.id
+
+        transition?.let { (previousSession, newSession) ->
+            notifyObserversOfSessionUpdate(previousSession, newSession)
         }
+        return sessionId
     }
 
     private fun notifyObserversOfSessionUpdate(

--- a/android-agent/src/test/java/io/opentelemetry/android/agent/session/SessionProviderCompatibilityTest.java
+++ b/android-agent/src/test/java/io/opentelemetry/android/agent/session/SessionProviderCompatibilityTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.android.session.SessionProvider;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class SessionProviderCompatibilityTest {
+    @Test
+    void existingJavaProvidersUseDefaultActivityMethods() {
+        AtomicInteger calls = new AtomicInteger();
+        SessionProvider provider =
+                () -> {
+                    calls.incrementAndGet();
+                    return "session-id";
+                };
+
+        assertThat(provider.getSessionIdForAttribution()).isEqualTo("session-id");
+        provider.recordActivity();
+
+        assertThat(calls).hasValue(2);
+    }
+}

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
@@ -12,7 +12,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import io.opentelemetry.android.Incubating
-import io.opentelemetry.android.agent.session.SessionIdTimeoutHandler
+import io.opentelemetry.android.agent.session.SessionManager
 import io.opentelemetry.android.internal.services.Services
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle
 import io.opentelemetry.android.session.SessionObserver
@@ -39,7 +39,7 @@ class OpenTelemetryRumInitializerTest {
     }
 
     @Test
-    fun `Verify timeoutHandler initialization 2`() {
+    fun `registers session manager for application lifecycle events`() {
         val rum =
             OpenTelemetryRumInitializer.initialize(
                 context = RuntimeEnvironment.getApplication(),
@@ -52,7 +52,7 @@ class OpenTelemetryRumInitializerTest {
         rum.shutdown()
 
         verify {
-            appLifecycle.registerListener(any<SessionIdTimeoutHandler>())
+            appLifecycle.registerListener(any<SessionManager>())
         }
     }
 

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.android.agent
 
+import android.app.Activity
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.Runs
 import io.mockk.every
@@ -12,14 +13,17 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import io.opentelemetry.android.Incubating
+import io.opentelemetry.android.agent.session.SessionInputWindowCallback
 import io.opentelemetry.android.agent.session.SessionManager
 import io.opentelemetry.android.internal.services.Services
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle
 import io.opentelemetry.android.session.SessionObserver
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric
 import org.robolectric.RuntimeEnvironment
 
 @OptIn(Incubating::class)
@@ -54,6 +58,26 @@ class OpenTelemetryRumInitializerTest {
         verify {
             appLifecycle.registerListener(any<SessionManager>())
         }
+    }
+
+    @Test
+    fun `tracks input for activities created after initialization`() {
+        val rum =
+            OpenTelemetryRumInitializer.initialize(
+                context = RuntimeEnvironment.getApplication(),
+                configuration = {
+                    httpExport {
+                        baseUrl = "http://127.0.0.1:4318"
+                    }
+                },
+            )
+        val activityController = Robolectric.buildActivity(Activity::class.java).create()
+
+        assertThat(activityController.get().window.callback)
+            .isInstanceOf(SessionInputWindowCallback::class.java)
+
+        activityController.destroy()
+        rum.shutdown()
     }
 
     @Test

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
@@ -6,6 +6,7 @@
 package io.opentelemetry.android.agent
 
 import android.app.Activity
+import android.view.MotionEvent
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.mockk.Runs
 import io.mockk.every
@@ -19,12 +20,14 @@ import io.opentelemetry.android.internal.services.Services
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle
 import io.opentelemetry.android.session.SessionObserver
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import io.opentelemetry.sdk.testing.time.TestClock
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.Robolectric
 import org.robolectric.RuntimeEnvironment
+import java.util.concurrent.TimeUnit
 
 @OptIn(Incubating::class)
 @RunWith(AndroidJUnit4::class)
@@ -76,8 +79,64 @@ class OpenTelemetryRumInitializerTest {
         assertThat(activityController.get().window.callback)
             .isInstanceOf(SessionInputWindowCallback::class.java)
 
-        activityController.destroy()
         rum.shutdown()
+        assertThat(activityController.get().window.callback)
+            .isNotInstanceOf(SessionInputWindowCallback::class.java)
+        activityController.destroy()
+    }
+
+    @Test
+    fun `tracks an activity initialized before its first resume`() {
+        val activityController = Robolectric.buildActivity(Activity::class.java).create()
+        val rum =
+            OpenTelemetryRumInitializer.initialize(
+                context = RuntimeEnvironment.getApplication(),
+                configuration = {
+                    httpExport {
+                        baseUrl = "http://127.0.0.1:4318"
+                    }
+                },
+            )
+
+        activityController.start().resume()
+
+        assertThat(activityController.get().window.callback)
+            .isInstanceOf(SessionInputWindowCallback::class.java)
+
+        rum.shutdown()
+        activityController.pause().stop().destroy()
+    }
+
+    @Test
+    fun `default input tracking keeps an active session alive`() {
+        val clock = TestClock.create()
+        val rum =
+            OpenTelemetryRumInitializer.initialize(
+                context = RuntimeEnvironment.getApplication(),
+                configuration = {
+                    this.clock = clock
+                    httpExport {
+                        baseUrl = "http://127.0.0.1:4318"
+                    }
+                },
+            )
+        val activityController = Robolectric.buildActivity(Activity::class.java).setup()
+        val initialSessionId = rum.sessionProvider.getSessionIdForAttribution()
+
+        repeat(4) {
+            clock.advance(10, TimeUnit.MINUTES)
+            val event = MotionEvent.obtain(0, 0, MotionEvent.ACTION_DOWN, 1f, 1f, 0)
+            activityController
+                .get()
+                .window.callback
+                .dispatchTouchEvent(event)
+            event.recycle()
+        }
+
+        assertThat(rum.sessionProvider.getSessionIdForAttribution()).isEqualTo(initialSessionId)
+
+        rum.shutdown()
+        activityController.pause().stop().destroy()
     }
 
     @Test

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/SessionConfigurationTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/SessionConfigurationTest.kt
@@ -30,7 +30,7 @@ internal class SessionConfigurationTest {
 
     @Test
     fun testDefaults() {
-        assertEquals(15.minutes, otelConfig.sessionConfig.backgroundInactivityTimeout)
+        assertEquals(15.minutes, otelConfig.sessionConfig.inactivityTimeout)
         assertEquals(4.hours, otelConfig.sessionConfig.maxLifetime)
     }
 
@@ -41,12 +41,21 @@ internal class SessionConfigurationTest {
         val otelConfig =
             otelConfig.apply {
                 session {
-                    backgroundInactivityTimeout = customTimeout
+                    inactivityTimeout = customTimeout
                     maxLifetime = customLifetime
                 }
             }
-        assertEquals(customTimeout, otelConfig.sessionConfig.backgroundInactivityTimeout)
+        assertEquals(customTimeout, otelConfig.sessionConfig.inactivityTimeout)
         assertEquals(customLifetime, otelConfig.sessionConfig.maxLifetime)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `background timeout remains a compatible alias`() {
+        otelConfig.sessionConfig.backgroundInactivityTimeout = 30.minutes
+
+        assertEquals(30.minutes, otelConfig.sessionConfig.inactivityTimeout)
+        assertEquals(30.minutes, otelConfig.sessionConfig.backgroundInactivityTimeout)
     }
 
     @Test

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionIdTimeoutHandlerTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionIdTimeoutHandlerTest.kt
@@ -9,94 +9,49 @@ import io.opentelemetry.sdk.testing.time.TestClock
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
-import java.time.Duration
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration.Companion.nanoseconds
 
 class SessionIdTimeoutHandlerTest {
     @Test
-    fun shouldNeverTimeOutInForeground() {
-        val clock: TestClock = TestClock.create()
+    fun `times out at the default inactivity boundary`() {
+        val clock = TestClock.create()
         val timeoutHandler =
             SessionIdTimeoutHandler(clock, SessionConfig.withDefaults().backgroundInactivityTimeout)
 
-        assertFalse(timeoutHandler.hasTimedOut())
-        timeoutHandler.bump()
-
-        // never time out in foreground
-        clock.advance(Duration.ofHours(4))
-        assertFalse(timeoutHandler.hasTimedOut())
-    }
-
-    @Test
-    fun shouldApply15MinutesTimeoutToAppsInBackground() {
-        val clock: TestClock = TestClock.create()
-        val timeoutHandler =
-            SessionIdTimeoutHandler(clock, SessionConfig.withDefaults().backgroundInactivityTimeout)
-
-        timeoutHandler.onApplicationBackgrounded()
-        timeoutHandler.bump()
-
-        assertFalse(timeoutHandler.hasTimedOut())
-        timeoutHandler.bump()
-
-        // do not timeout if <15 minutes have passed
         clock.advance(14, TimeUnit.MINUTES)
         clock.advance(59, TimeUnit.SECONDS)
         assertFalse(timeoutHandler.hasTimedOut())
-        timeoutHandler.bump()
 
-        // restart the timeout counter after bump()
-        clock.advance(1, TimeUnit.MINUTES)
-        assertFalse(timeoutHandler.hasTimedOut())
-        timeoutHandler.bump()
-
-        // timeout after 15 minutes
-        clock.advance(15, TimeUnit.MINUTES)
+        clock.advance(1, TimeUnit.SECONDS)
         assertTrue(timeoutHandler.hasTimedOut())
-
-        // bump() resets the counter
-        timeoutHandler.bump()
-        assertFalse(timeoutHandler.hasTimedOut())
     }
 
     @Test
-    fun shouldApplyTimeoutToFirstSpanAfterAppBeingMovedToForeground() {
-        val clock: TestClock = TestClock.create()
+    fun `meaningful activity restarts the inactivity window`() {
+        val clock = TestClock.create()
         val timeoutHandler =
             SessionIdTimeoutHandler(clock, SessionConfig.withDefaults().backgroundInactivityTimeout)
 
-        timeoutHandler.onApplicationBackgrounded()
+        clock.advance(10, TimeUnit.MINUTES)
         timeoutHandler.bump()
-
-        // the first span after app is moved to the foreground gets timed out
-        timeoutHandler.onApplicationForegrounded()
-        clock.advance(20, TimeUnit.MINUTES)
-        assertTrue(timeoutHandler.hasTimedOut())
-        timeoutHandler.bump()
-
-        // after the initial span it's the same as the usual foreground scenario
-        clock.advance(Duration.ofHours(4))
+        clock.advance(10, TimeUnit.MINUTES)
         assertFalse(timeoutHandler.hasTimedOut())
+
+        clock.advance(5, TimeUnit.MINUTES)
+        assertTrue(timeoutHandler.hasTimedOut())
     }
 
     @Test
-    fun shouldApplyCustomTimeoutToFirstSpanAfterAppBeingMovedToForeground() {
-        val clock: TestClock = TestClock.create()
+    fun `custom inactivity timeout uses exact boundary`() {
+        val clock = TestClock.create()
         val timeoutHandler =
             SessionIdTimeoutHandler(clock, 5.nanoseconds)
 
-        timeoutHandler.onApplicationBackgrounded()
-        timeoutHandler.bump()
-
-        // the first span after app is moved to the foreground gets timed out
-        timeoutHandler.onApplicationForegrounded()
-        clock.advance(6, TimeUnit.MINUTES)
-        assertTrue(timeoutHandler.hasTimedOut())
-        timeoutHandler.bump()
-
-        // after the initial span it's the same as the usual foreground scenario
-        clock.advance(Duration.ofHours(4))
+        clock.advance(4, TimeUnit.NANOSECONDS)
         assertFalse(timeoutHandler.hasTimedOut())
+
+        clock.advance(1, TimeUnit.NANOSECONDS)
+        assertTrue(timeoutHandler.hasTimedOut())
     }
 }

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionIdTimeoutHandlerTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionIdTimeoutHandlerTest.kt
@@ -17,7 +17,7 @@ class SessionIdTimeoutHandlerTest {
     fun `times out at the default inactivity boundary`() {
         val clock = TestClock.create()
         val timeoutHandler =
-            SessionIdTimeoutHandler(clock, SessionConfig.withDefaults().backgroundInactivityTimeout)
+            SessionIdTimeoutHandler(clock, SessionConfig.withDefaults().inactivityTimeout)
 
         clock.advance(14, TimeUnit.MINUTES)
         clock.advance(59, TimeUnit.SECONDS)
@@ -31,7 +31,7 @@ class SessionIdTimeoutHandlerTest {
     fun `meaningful activity restarts the inactivity window`() {
         val clock = TestClock.create()
         val timeoutHandler =
-            SessionIdTimeoutHandler(clock, SessionConfig.withDefaults().backgroundInactivityTimeout)
+            SessionIdTimeoutHandler(clock, SessionConfig.withDefaults().inactivityTimeout)
 
         clock.advance(10, TimeUnit.MINUTES)
         timeoutHandler.bump()

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionInputActivityTrackerTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionInputActivityTrackerTest.kt
@@ -18,6 +18,7 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
+import io.opentelemetry.android.OpenTelemetryRum
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -27,20 +28,32 @@ internal class SessionInputActivityTrackerTest {
     @Test
     fun `registers tracker for application contexts`() {
         val application = mockk<Application>()
+        val openTelemetryRum = mockk<OpenTelemetryRum>()
+        val callback = slot<Application.ActivityLifecycleCallbacks>()
         every { application.registerActivityLifecycleCallbacks(any()) } just Runs
+        every { application.unregisterActivityLifecycleCallbacks(any()) } just Runs
+        val instrumentation = SessionInputActivityInstrumentation {}
 
-        registerSessionInputActivityTracker(application) {}
+        instrumentation.install(application, openTelemetryRum)
+        verify(exactly = 1) {
+            application.registerActivityLifecycleCallbacks(capture(callback))
+        }
+
+        instrumentation.uninstall(application, openTelemetryRum)
 
         verify(exactly = 1) {
-            application.registerActivityLifecycleCallbacks(any<SessionInputActivityTracker>())
+            application.unregisterActivityLifecycleCallbacks(callback.captured)
         }
     }
 
     @Test
     fun `does not register tracker for non-application contexts`() {
         val context = mockk<Context>(relaxed = true)
+        val openTelemetryRum = mockk<OpenTelemetryRum>()
+        val instrumentation = SessionInputActivityInstrumentation {}
 
-        registerSessionInputActivityTracker(context) {}
+        instrumentation.install(context, openTelemetryRum)
+        instrumentation.uninstall(context, openTelemetryRum)
 
         verify(exactly = 0) { context.applicationContext }
     }
@@ -50,15 +63,90 @@ internal class SessionInputActivityTrackerTest {
         val activity = mockk<Activity>()
         val window = mockk<Window>()
         val callback = mockk<Window.Callback>()
-        val installedCallback = slot<Window.Callback>()
+        var installedCallback: Window.Callback = callback
         every { activity.window } returns window
-        every { window.callback } returns callback
-        every { window.callback = capture(installedCallback) } just Runs
+        every { window.callback } answers { installedCallback }
+        every { window.callback = any() } answers { installedCallback = firstArg() }
         val tracker = SessionInputActivityTracker {}
 
         tracker.onActivityCreated(activity, null)
+        val createdCallback = installedCallback
+        tracker.onActivityResumed(activity)
 
-        assertThat(installedCallback.captured).isInstanceOf(SessionInputWindowCallback::class.java)
+        assertThat(createdCallback).isInstanceOf(SessionInputWindowCallback::class.java)
+        assertThat(installedCallback).isSameAs(createdCallback)
+    }
+
+    @Test
+    fun `wraps an activity first seen when it resumes`() {
+        val activity = mockk<Activity>()
+        val window = mockk<Window>()
+        val callback = mockk<Window.Callback>()
+        var installedCallback: Window.Callback = callback
+        every { activity.window } returns window
+        every { window.callback } answers { installedCallback }
+        every { window.callback = any() } answers { installedCallback = firstArg() }
+        val tracker = SessionInputActivityTracker {}
+
+        tracker.onActivityResumed(activity)
+
+        assertThat(installedCallback).isInstanceOf(SessionInputWindowCallback::class.java)
+    }
+
+    @Test
+    fun `resume wraps a callback replaced after activity creation`() {
+        val activity = mockk<Activity>()
+        val window = mockk<Window>()
+        val originalCallback = mockk<Window.Callback>()
+        val replacementCallback = mockk<Window.Callback>()
+        var installedCallback: Window.Callback = originalCallback
+        every { activity.window } returns window
+        every { window.callback } answers { installedCallback }
+        every { window.callback = any() } answers { installedCallback = firstArg() }
+        val tracker = SessionInputActivityTracker {}
+
+        tracker.onActivityCreated(activity, null)
+        installedCallback = replacementCallback
+        tracker.onActivityResumed(activity)
+
+        val wrapper = installedCallback as SessionInputWindowCallback
+        assertThat(wrapper.unwrap()).isSameAs(replacementCallback)
+    }
+
+    @Test
+    fun `close restores a callback installed by the tracker`() {
+        val activity = mockk<Activity>()
+        val window = mockk<Window>()
+        val callback = mockk<Window.Callback>()
+        var installedCallback: Window.Callback = callback
+        every { activity.window } returns window
+        every { window.callback } answers { installedCallback }
+        every { window.callback = any() } answers { installedCallback = firstArg() }
+        val tracker = SessionInputActivityTracker {}
+
+        tracker.onActivityCreated(activity, null)
+        tracker.close()
+
+        assertThat(installedCallback).isSameAs(callback)
+    }
+
+    @Test
+    fun `close does not replace a callback installed later`() {
+        val activity = mockk<Activity>()
+        val window = mockk<Window>()
+        val callback = mockk<Window.Callback>()
+        val replacementCallback = mockk<Window.Callback>()
+        var installedCallback: Window.Callback = callback
+        every { activity.window } returns window
+        every { window.callback } answers { installedCallback }
+        every { window.callback = any() } answers { installedCallback = firstArg() }
+        val tracker = SessionInputActivityTracker {}
+
+        tracker.onActivityCreated(activity, null)
+        installedCallback = replacementCallback
+        tracker.close()
+
+        assertThat(installedCallback).isSameAs(replacementCallback)
     }
 
     @Test

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionInputActivityTrackerTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionInputActivityTrackerTest.kt
@@ -94,7 +94,7 @@ internal class SessionInputActivityTrackerTest {
     }
 
     @Test
-    fun `resume wraps a callback replaced after activity creation`() {
+    fun `resume leaves a callback replaced after activity creation in place`() {
         val activity = mockk<Activity>()
         val window = mockk<Window>()
         val originalCallback = mockk<Window.Callback>()
@@ -109,8 +109,29 @@ internal class SessionInputActivityTrackerTest {
         installedCallback = replacementCallback
         tracker.onActivityResumed(activity)
 
-        val wrapper = installedCallback as SessionInputWindowCallback
-        assertThat(wrapper.unwrap()).isSameAs(replacementCallback)
+        assertThat(installedCallback).isSameAs(replacementCallback)
+    }
+
+    @Test
+    fun `foreign wrapper does not cause another session wrapper on resume`() {
+        val activity = mockk<Activity>()
+        val window = mockk<Window>()
+        val callback = mockk<Window.Callback>()
+        var installedCallback: Window.Callback = callback
+        every { activity.window } returns window
+        every { window.callback } answers { installedCallback }
+        every { window.callback = any() } answers { installedCallback = firstArg() }
+        val tracker = SessionInputActivityTracker {}
+
+        tracker.onActivityCreated(activity, null)
+        val sessionCallback = installedCallback
+        val foreignCallback = DelegatingWindowCallback(sessionCallback)
+        installedCallback = foreignCallback
+
+        repeat(5) { tracker.onActivityResumed(activity) }
+
+        assertThat(installedCallback).isSameAs(foreignCallback)
+        assertThat(foreignCallback.unwrap()).isSameAs(sessionCallback)
     }
 
     @Test
@@ -147,6 +168,53 @@ internal class SessionInputActivityTrackerTest {
         tracker.close()
 
         assertThat(installedCallback).isSameAs(replacementCallback)
+    }
+
+    @Test
+    fun `destroy restores and detaches the activity callback`() {
+        val activity = mockk<Activity>()
+        val window = mockk<Window>()
+        val callback = mockk<Window.Callback>()
+        val recordActivity = mockk<() -> Unit>(relaxed = true)
+        val event = MotionEvent.obtain(0, 0, MotionEvent.ACTION_DOWN, 1f, 1f, 0)
+        var installedCallback: Window.Callback = callback
+        every { activity.window } returns window
+        every { window.callback } answers { installedCallback }
+        every { window.callback = any() } answers { installedCallback = firstArg() }
+        every { callback.dispatchTouchEvent(event) } returns false
+        val tracker = SessionInputActivityTracker(recordActivity)
+
+        tracker.onActivityCreated(activity, null)
+        val sessionCallback = installedCallback
+        tracker.onActivityDestroyed(activity)
+        sessionCallback.dispatchTouchEvent(event)
+
+        assertThat(installedCallback).isSameAs(callback)
+        verify(exactly = 0) { recordActivity() }
+        event.recycle()
+    }
+
+    @Test
+    fun `close detaches a session callback nested below a foreign wrapper`() {
+        val activity = mockk<Activity>()
+        val window = mockk<Window>()
+        val callback = mockk<Window.Callback>()
+        val recordActivity = mockk<() -> Unit>(relaxed = true)
+        val event = MotionEvent.obtain(0, 0, MotionEvent.ACTION_DOWN, 1f, 1f, 0)
+        var installedCallback: Window.Callback = callback
+        every { activity.window } returns window
+        every { window.callback } answers { installedCallback }
+        every { window.callback = any() } answers { installedCallback = firstArg() }
+        every { callback.dispatchTouchEvent(event) } returns false
+        val tracker = SessionInputActivityTracker(recordActivity)
+
+        tracker.onActivityCreated(activity, null)
+        installedCallback = DelegatingWindowCallback(installedCallback)
+        tracker.close()
+        installedCallback.dispatchTouchEvent(event)
+
+        verify(exactly = 0) { recordActivity() }
+        event.recycle()
     }
 
     @Test
@@ -222,5 +290,11 @@ internal class SessionInputActivityTrackerTest {
         assertThat(wrapper.dispatchTouchEvent(event)).isTrue()
         verify(exactly = 1) { callback.dispatchTouchEvent(event) }
         event.recycle()
+    }
+
+    private class DelegatingWindowCallback(
+        private val callback: Window.Callback,
+    ) : Window.Callback by callback {
+        fun unwrap(): Window.Callback = callback
     }
 }

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionInputActivityTrackerTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionInputActivityTrackerTest.kt
@@ -1,0 +1,138 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.session
+
+import android.app.Activity
+import android.app.Application
+import android.content.Context
+import android.view.KeyEvent
+import android.view.MotionEvent
+import android.view.Window
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+internal class SessionInputActivityTrackerTest {
+    @Test
+    fun `registers tracker for application contexts`() {
+        val application = mockk<Application>()
+        every { application.registerActivityLifecycleCallbacks(any()) } just Runs
+
+        registerSessionInputActivityTracker(application) {}
+
+        verify(exactly = 1) {
+            application.registerActivityLifecycleCallbacks(any<SessionInputActivityTracker>())
+        }
+    }
+
+    @Test
+    fun `does not register tracker for non-application contexts`() {
+        val context = mockk<Context>(relaxed = true)
+
+        registerSessionInputActivityTracker(context) {}
+
+        verify(exactly = 0) { context.applicationContext }
+    }
+
+    @Test
+    fun `wraps each activity window once`() {
+        val activity = mockk<Activity>()
+        val window = mockk<Window>()
+        val callback = mockk<Window.Callback>()
+        val installedCallback = slot<Window.Callback>()
+        every { activity.window } returns window
+        every { window.callback } returns callback
+        every { window.callback = capture(installedCallback) } just Runs
+        val tracker = SessionInputActivityTracker {}
+
+        tracker.onActivityCreated(activity, null)
+
+        assertThat(installedCallback.captured).isInstanceOf(SessionInputWindowCallback::class.java)
+    }
+
+    @Test
+    fun `touch down records activity before delegating`() {
+        val calls = mutableListOf<String>()
+        val callback = mockk<Window.Callback>()
+        val event = MotionEvent.obtain(0, 0, MotionEvent.ACTION_DOWN, 1f, 1f, 0)
+        every { callback.dispatchTouchEvent(event) } answers {
+            calls += "delegate"
+            true
+        }
+        val wrapper = SessionInputWindowCallback(callback) { calls += "activity" }
+
+        val handled = wrapper.dispatchTouchEvent(event)
+
+        assertThat(handled).isTrue()
+        assertThat(calls).containsExactly("activity", "delegate")
+        event.recycle()
+    }
+
+    @Test
+    fun `touch up does not record activity`() {
+        val callback = mockk<Window.Callback>()
+        val recordActivity = mockk<() -> Unit>(relaxed = true)
+        val event = MotionEvent.obtain(0, 0, MotionEvent.ACTION_UP, 1f, 1f, 0)
+        every { callback.dispatchTouchEvent(event) } returns false
+        val wrapper = SessionInputWindowCallback(callback, recordActivity)
+
+        wrapper.dispatchTouchEvent(event)
+
+        verify(exactly = 0) { recordActivity() }
+        event.recycle()
+    }
+
+    @Test
+    fun `initial key down records activity but repeats and key up do not`() {
+        val callback = mockk<Window.Callback>()
+        val recordActivity = mockk<() -> Unit>(relaxed = true)
+        every { callback.dispatchKeyEvent(any()) } returns false
+        val wrapper = SessionInputWindowCallback(callback, recordActivity)
+
+        wrapper.dispatchKeyEvent(KeyEvent(0, 0, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_CENTER, 0))
+        wrapper.dispatchKeyEvent(KeyEvent(0, 1, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_DPAD_CENTER, 1))
+        wrapper.dispatchKeyEvent(KeyEvent(0, 2, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_DPAD_CENTER, 0))
+
+        verify(exactly = 1) { recordActivity() }
+    }
+
+    @Test
+    fun `scroll records activity but other generic motion does not`() {
+        val callback = mockk<Window.Callback>()
+        val recordActivity = mockk<() -> Unit>(relaxed = true)
+        val scrollEvent = MotionEvent.obtain(0, 0, MotionEvent.ACTION_SCROLL, 1f, 1f, 0)
+        val hoverEvent = MotionEvent.obtain(0, 1, MotionEvent.ACTION_HOVER_MOVE, 1f, 1f, 0)
+        every { callback.dispatchGenericMotionEvent(any()) } returns false
+        val wrapper = SessionInputWindowCallback(callback, recordActivity)
+
+        wrapper.dispatchGenericMotionEvent(scrollEvent)
+        wrapper.dispatchGenericMotionEvent(hoverEvent)
+
+        verify(exactly = 1) { recordActivity() }
+        scrollEvent.recycle()
+        hoverEvent.recycle()
+    }
+
+    @Test
+    fun `activity failure does not prevent input delegation`() {
+        val callback = mockk<Window.Callback>()
+        val event = MotionEvent.obtain(0, 0, MotionEvent.ACTION_DOWN, 1f, 1f, 0)
+        every { callback.dispatchTouchEvent(event) } returns true
+        val wrapper = SessionInputWindowCallback(callback) { error("observer failed") }
+
+        assertThat(wrapper.dispatchTouchEvent(event)).isTrue()
+        verify(exactly = 1) { callback.dispatchTouchEvent(event) }
+        event.recycle()
+    }
+}

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionManagerTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionManagerTest.kt
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.regex.Pattern
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
 
 private const val SESSION_AWAIT_SECONDS: Long = 5
 private const val SESSION_ID_LENGTH = 32
@@ -233,6 +234,91 @@ internal class SessionManagerTest {
     }
 
     @Test
+    fun `passive attribution does not extend inactivity`() {
+        val clock = TestClock.create()
+        val sessionManager = createSessionManager(clock)
+        val initialSessionId = sessionManager.getSessionId()
+
+        clock.advance(10, TimeUnit.MINUTES)
+        assertThat(sessionManager.getSessionIdForAttribution()).isEqualTo(initialSessionId)
+
+        clock.advance(5, TimeUnit.MINUTES)
+        assertThat(sessionManager.getSessionIdForAttribution()).isNotEqualTo(initialSessionId)
+    }
+
+    @Test
+    fun `meaningful activity extends inactivity`() {
+        val clock = TestClock.create()
+        val sessionManager = createSessionManager(clock)
+        val initialSessionId = sessionManager.getSessionId()
+
+        clock.advance(10, TimeUnit.MINUTES)
+        sessionManager.recordActivity()
+        clock.advance(10, TimeUnit.MINUTES)
+        assertThat(sessionManager.getSessionIdForAttribution()).isEqualTo(initialSessionId)
+
+        clock.advance(5, TimeUnit.MINUTES)
+        assertThat(sessionManager.getSessionIdForAttribution()).isNotEqualTo(initialSessionId)
+    }
+
+    @Test
+    fun `foreground return checks expiry before recording activity`() {
+        val clock = TestClock.create()
+        val sessionManager = createSessionManager(clock)
+        val initialSessionId = sessionManager.getSessionId()
+
+        sessionManager.onApplicationBackgrounded()
+        clock.advance(15, TimeUnit.MINUTES)
+        sessionManager.onApplicationForegrounded()
+
+        assertThat(sessionManager.getSessionIdForAttribution()).isNotEqualTo(initialSessionId)
+    }
+
+    @Test
+    fun `foreground return refreshes an unexpired session`() {
+        val clock = TestClock.create()
+        val sessionManager = createSessionManager(clock)
+        val initialSessionId = sessionManager.getSessionId()
+
+        sessionManager.onApplicationBackgrounded()
+        clock.advance(10, TimeUnit.MINUTES)
+        sessionManager.onApplicationForegrounded()
+        clock.advance(10, TimeUnit.MINUTES)
+
+        assertThat(sessionManager.getSessionIdForAttribution()).isEqualTo(initialSessionId)
+    }
+
+    @Test
+    fun `background transition alone does not extend inactivity`() {
+        val clock = TestClock.create()
+        val sessionManager = createSessionManager(clock)
+        val initialSessionId = sessionManager.getSessionId()
+
+        clock.advance(10, TimeUnit.MINUTES)
+        sessionManager.onApplicationBackgrounded()
+        clock.advance(5, TimeUnit.MINUTES)
+
+        assertThat(sessionManager.getSessionIdForAttribution()).isNotEqualTo(initialSessionId)
+    }
+
+    @Test
+    fun `meaningful activity cannot extend the four hour maximum lifetime`() {
+        val clock = TestClock.create()
+        val sessionManager = createSessionManager(clock)
+        val initialSessionId = sessionManager.getSessionId()
+
+        repeat(23) {
+            clock.advance(10, TimeUnit.MINUTES)
+            sessionManager.recordActivity()
+        }
+        assertThat(sessionManager.getSessionIdForAttribution()).isEqualTo(initialSessionId)
+
+        clock.advance(10, TimeUnit.MINUTES)
+        sessionManager.recordActivity()
+        assertThat(sessionManager.getSessionIdForAttribution()).isNotEqualTo(initialSessionId)
+    }
+
+    @Test
     fun `concurrent access during timeout should create only one new session`() {
         // Given
         val clock = TestClock.create()
@@ -276,6 +362,39 @@ internal class SessionManagerTest {
         // Then - verify that only one new session was created
         assertThat(sessionIds).hasSize(1)
         assertThat(sessionIds.first()).isNotEqualTo(initialSessionId)
+        assertThat(sessionIdCount.get()).isEqualTo(numThreads)
+    }
+
+    @Test
+    fun `concurrent passive attribution after inactivity creates one session`() {
+        val clock = TestClock.create()
+        val sessionManager = createSessionManager(clock)
+        val initialSessionId = sessionManager.getSessionId()
+        clock.advance(15, TimeUnit.MINUTES)
+
+        val numThreads = 10
+        val executor = Executors.newFixedThreadPool(numThreads)
+        val firstLatch = CountDownLatch(numThreads)
+        val lastLatch = CountDownLatch(numThreads)
+        val sessionIds = mutableSetOf<String>()
+        val sessionIdCount = AtomicInteger(0)
+        val params =
+            AddSessionIdsParameters(
+                numThreads,
+                executor,
+                firstLatch,
+                lastLatch,
+                sessionManager,
+                sessionIds,
+                sessionIdCount,
+            )
+
+        addSessionIdsAcrossThreads(params, passive = true)
+
+        assertThat(lastLatch.await(SESSION_AWAIT_SECONDS, TimeUnit.SECONDS)).isTrue()
+        executor.shutdown()
+        assertThat(sessionIds).hasSize(1)
+        assertThat(sessionIds.single()).isNotEqualTo(initialSessionId)
         assertThat(sessionIdCount.get()).isEqualTo(numThreads)
     }
 
@@ -411,14 +530,22 @@ internal class SessionManagerTest {
         assertThat(thirdSessionId).isNotEqualTo(secondSessionId)
     }
 
-    private fun addSessionIdsAcrossThreads(params: AddSessionIdsParameters) {
+    private fun addSessionIdsAcrossThreads(
+        params: AddSessionIdsParameters,
+        passive: Boolean = false,
+    ) {
         repeat(params.numThreads) {
             params.executor.submit {
                 try {
                     params.firstLatch.countDown()
                     params.firstLatch.await(SESSION_AWAIT_SECONDS, TimeUnit.SECONDS)
 
-                    val sessionId = params.sessionManager.getSessionId()
+                    val sessionId =
+                        if (passive) {
+                            params.sessionManager.getSessionIdForAttribution()
+                        } else {
+                            params.sessionManager.getSessionId()
+                        }
                     synchronized(params.sessionIds) {
                         params.sessionIds.add(sessionId)
                         params.sessionIdCount.incrementAndGet()
@@ -429,6 +556,13 @@ internal class SessionManagerTest {
             }
         }
     }
+
+    private fun createSessionManager(clock: TestClock): SessionManager =
+        SessionManager(
+            clock = clock,
+            timeoutHandler = SessionIdTimeoutHandler(clock, 15.minutes),
+            maxSessionLifetime = MAX_SESSION_LIFETIME.hours,
+        )
 
     private data class AddSessionIdsParameters(
         val numThreads: Int,

--- a/core/src/main/java/io/opentelemetry/android/SessionIdRatioBasedSampler.kt
+++ b/core/src/main/java/io/opentelemetry/android/SessionIdRatioBasedSampler.kt
@@ -36,7 +36,7 @@ class SessionIdRatioBasedSampler(
         // Replace traceId with sessionId
         return ratioBasedSampler.shouldSample(
             parentContext,
-            sessionProvider.getSessionId(),
+            sessionProvider.getSessionIdForAttribution(),
             name,
             spanKind,
             attributes,

--- a/core/src/main/java/io/opentelemetry/android/SessionIdSpanAppender.kt
+++ b/core/src/main/java/io/opentelemetry/android/SessionIdSpanAppender.kt
@@ -28,7 +28,7 @@ internal class SessionIdSpanAppender(
         parentContext: Context,
         span: ReadWriteSpan,
     ) {
-        span.setAttribute(sessionId, sessionProvider.getSessionId())
+        span.setAttribute(sessionId, sessionProvider.getSessionIdForAttribution())
     }
 
     override fun isStartRequired(): Boolean = true

--- a/core/src/main/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppender.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppender.kt
@@ -26,7 +26,7 @@ internal class SessionIdLogRecordAppender(
     ) {
         // Recovered crashes and session-end events can describe a session that is no longer current.
         if (logRecord.getAttribute(sessionIdKey) == null) {
-            logRecord.setAttribute(sessionIdKey, sessionProvider.getSessionId())
+            logRecord.setAttribute(sessionIdKey, sessionProvider.getSessionIdForAttribution())
         }
     }
 }

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumNoopTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumNoopTest.kt
@@ -15,6 +15,8 @@ internal class OpenTelemetryRumNoopTest {
         val noop = RumBuilder.noop()
         assertEquals(OpenTelemetry.noop(), noop.openTelemetry)
         assertEquals("", noop.sessionProvider.getSessionId())
+        assertEquals("", noop.sessionProvider.getSessionIdForAttribution())
+        noop.sessionProvider.recordActivity()
 
         // assert no exceptions thrown
         noop.emitEvent("event")

--- a/core/src/test/java/io/opentelemetry/android/SessionIdRatioBasedSamplerTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/SessionIdRatioBasedSamplerTest.kt
@@ -8,6 +8,7 @@ package io.opentelemetry.android
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.verify
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
@@ -36,18 +37,19 @@ internal class SessionIdRatioBasedSamplerTest {
 
     @Test
     fun samplerDropsHigh() {
-        every { sessionProvider.getSessionId() } returns HIGH_ID
+        every { sessionProvider.getSessionIdForAttribution() } returns HIGH_ID
 
         val sampler = SessionIdRatioBasedSampler(0.5, sessionProvider)
 
         // Sampler drops if TraceIdRatioBasedSampler would drop this sessionId
         assertThat(shouldSample(sampler)).isEqualTo(SamplingDecision.DROP)
+        verify(exactly = 0) { sessionProvider.getSessionId() }
     }
 
     @Test
     fun samplerKeepsLowestId() {
         // Sampler accepts if TraceIdRatioBasedSampler would accept this sessionId
-        every { sessionProvider.getSessionId() } returns LOW_ID
+        every { sessionProvider.getSessionIdForAttribution() } returns LOW_ID
 
         val sampler = SessionIdRatioBasedSampler(0.5, sessionProvider)
         assertThat(shouldSample(sampler)).isEqualTo(SamplingDecision.RECORD_AND_SAMPLE)
@@ -55,13 +57,13 @@ internal class SessionIdRatioBasedSamplerTest {
 
     @Test
     fun zeroRatioDropsAll() {
-        every { sessionProvider.getSessionId() } returns HIGH_ID
+        every { sessionProvider.getSessionIdForAttribution() } returns HIGH_ID
 
         val samplerHigh =
             SessionIdRatioBasedSampler(0.0, sessionProvider)
         assertThat(shouldSample(samplerHigh)).isEqualTo(SamplingDecision.DROP)
 
-        every { sessionProvider.getSessionId() } returns LOW_ID
+        every { sessionProvider.getSessionIdForAttribution() } returns LOW_ID
 
         val samplerLow =
             SessionIdRatioBasedSampler(0.0, sessionProvider)
@@ -70,13 +72,13 @@ internal class SessionIdRatioBasedSamplerTest {
 
     @Test
     fun oneRatioAcceptsAll() {
-        every { sessionProvider.getSessionId() } returns HIGH_ID
+        every { sessionProvider.getSessionIdForAttribution() } returns HIGH_ID
 
         val samplerHigh =
             SessionIdRatioBasedSampler(1.0, sessionProvider)
         assertThat(shouldSample(samplerHigh)).isEqualTo(SamplingDecision.RECORD_AND_SAMPLE)
 
-        every { sessionProvider.getSessionId() } returns LOW_ID
+        every { sessionProvider.getSessionIdForAttribution() } returns LOW_ID
 
         val samplerLow =
             SessionIdRatioBasedSampler(1.0, sessionProvider)

--- a/core/src/test/java/io/opentelemetry/android/SessionIdSpanAppenderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/SessionIdSpanAppenderTest.kt
@@ -32,7 +32,7 @@ internal class SessionIdSpanAppenderTest {
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
-        every { sessionProvider.getSessionId() }.returns("42")
+        every { sessionProvider.getSessionIdForAttribution() }.returns("42")
         every { span.setAttribute(any<AttributeKey<String>>(), any<String>()) } returns span
     }
 
@@ -44,6 +44,7 @@ internal class SessionIdSpanAppenderTest {
         underTest.onStart(Context.root(), span)
 
         verify { span.setAttribute(stringKey(SESSION_ID), "42") }
+        verify(exactly = 0) { sessionProvider.getSessionId() }
 
         assertFalse(underTest.isEndRequired)
     }

--- a/core/src/test/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppenderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppenderTest.kt
@@ -32,7 +32,7 @@ class SessionIdLogRecordAppenderTest {
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
-        every { sessionProvider.getSessionId() }.returns(SESSION_ID_VALUE)
+        every { sessionProvider.getSessionIdForAttribution() }.returns(SESSION_ID_VALUE)
         every { log.getAttribute(any<AttributeKey<String>>()) } returns null
         every { log.setAttribute(any<AttributeKey<String>>(), any<String>()) } returns log
     }
@@ -44,6 +44,7 @@ class SessionIdLogRecordAppenderTest {
         underTest.onEmit(Context.root(), log)
 
         verify { log.setAttribute(stringKey(SESSION_ID), SESSION_ID_VALUE) }
+        verify(exactly = 0) { sessionProvider.getSessionId() }
     }
 
     @Test
@@ -54,5 +55,6 @@ class SessionIdLogRecordAppenderTest {
         underTest.onEmit(Context.root(), log)
 
         verify(exactly = 0) { log.setAttribute(any<AttributeKey<String>>(), any<String>()) }
+        verify(exactly = 0) { sessionProvider.getSessionIdForAttribution() }
     }
 }

--- a/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGenerator.kt
+++ b/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGenerator.kt
@@ -20,6 +20,7 @@ internal class ComposeClickEventGenerator(
     private val eventLogger: Logger,
     private val composeLayoutNodeUtil: ComposeLayoutNodeUtil = ComposeLayoutNodeUtil(),
     private val composeTapTargetDetector: ComposeTapTargetDetector = ComposeTapTargetDetector(composeLayoutNodeUtil),
+    private val recordActivity: () -> Unit = {},
 ) {
     private var windowRef: WeakReference<Window>? = null
 
@@ -31,7 +32,9 @@ internal class ComposeClickEventGenerator(
 
     fun generateClick(motionEvent: MotionEvent?) {
         windowRef?.get()?.let { window ->
-            if (motionEvent != null && motionEvent.actionMasked == MotionEvent.ACTION_UP) {
+            if (motionEvent?.actionMasked == MotionEvent.ACTION_DOWN) {
+                recordActivity()
+            } else if (motionEvent != null && motionEvent.actionMasked == MotionEvent.ACTION_UP) {
                 AppScreenClickEvent(
                     appScreenCoordinateX = motionEvent.x.toLong(),
                     appScreenCoordinateY = motionEvent.y.toLong(),

--- a/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickInstrumentation.kt
+++ b/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickInstrumentation.kt
@@ -26,6 +26,7 @@ class ComposeClickInstrumentation : AndroidInstrumentation {
                         .logsBridge
                         .loggerBuilder("io.opentelemetry.android.instrumentation.compose.click")
                         .build(),
+                    recordActivity = openTelemetryRum.sessionProvider::recordActivity,
                 ),
             ),
         )

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
@@ -100,10 +100,14 @@ internal class ComposeInstrumentationTest {
 
     @Test
     fun capture_compose_click() {
+        val activitySessionProvider = mockk<SessionProvider>(relaxUnitFun = true)
+        every { activitySessionProvider.recordActivity() } answers {
+            assertThat(openTelemetryRule.logRecords).isEmpty()
+        }
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns activitySessionProvider
                 every { clock } returns Clock.getDefault()
             }
 
@@ -124,8 +128,8 @@ internal class ComposeInstrumentationTest {
         val wrapperCapturingSlot = slot<WindowCallbackWrapper>()
         every { window.callback = any() } returns Unit
 
-        val motionEvent =
-            MotionEvent.obtain(0L, SystemClock.uptimeMillis(), MotionEvent.ACTION_UP, 250f, 50f, 0)
+        val downEvent = createMotionEvent(MotionEvent.ACTION_DOWN)
+        val motionEvent = createMotionEvent(MotionEvent.ACTION_UP)
         every { window.decorView } returns composeView
         every { composeView.childCount } returns 0
 
@@ -144,9 +148,8 @@ internal class ComposeInstrumentationTest {
             window.callback = capture(wrapperCapturingSlot)
         }
 
-        wrapperCapturingSlot.captured.dispatchTouchEvent(
-            motionEvent,
-        )
+        listOf(downEvent, motionEvent).forEach { wrapperCapturingSlot.captured.dispatchTouchEvent(it) }
+        verify(exactly = 1) { activitySessionProvider.recordActivity() }
 
         val events = openTelemetryRule.logRecords
         assertThat(events).hasSize(2)
@@ -167,6 +170,8 @@ internal class ComposeInstrumentationTest {
                 equalTo(APP_WIDGET_NAME_KEY, "clickMe"),
             )
     }
+
+    private fun createMotionEvent(action: Int): MotionEvent = MotionEvent.obtain(0L, SystemClock.uptimeMillis(), action, 250f, 50f, 0)
 
     private fun createMockLayoutNode(
         targetX: Float = 0f,

--- a/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
+++ b/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
@@ -325,7 +325,7 @@ internal data class NativeCrashContext(
 private fun Context.currentCrashContext(openTelemetryRum: OpenTelemetryRum): NativeCrashContext {
     val packageInfo = runCatching { packageManager.getPackageInfo(packageName, 0) }.getOrNull()
     return NativeCrashContext(
-        sessionId = openTelemetryRum.sessionProvider.getSessionId().takeIf { it.isNotBlank() },
+        sessionId = openTelemetryRum.sessionProvider.getSessionIdForAttribution().takeIf { it.isNotBlank() },
         serviceVersion = packageInfo?.versionName,
         osName = "Android",
         osVersion = Build.VERSION.RELEASE,

--- a/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
+++ b/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
@@ -273,6 +273,8 @@ class NativeCrashReporterTest {
                 ),
             )
         assertThat(sessionProvider.observer).isNotNull()
+        assertThat(sessionProvider.attributionAccesses).isEqualTo(1)
+        assertThat(sessionProvider.activityAccesses).isZero()
         assertThat(installedMarkerPath).isEqualTo(store.crashRecordPath)
     }
 
@@ -555,8 +557,18 @@ class NativeCrashReporterTest {
     ) : SessionProvider,
         SessionPublisher {
         var observer: SessionObserver? = null
+        var activityAccesses = 0
+        var attributionAccesses = 0
 
-        override fun getSessionId(): String = sessionId
+        override fun getSessionId(): String {
+            activityAccesses++
+            return sessionId
+        }
+
+        override fun getSessionIdForAttribution(): String {
+            attributionAccesses++
+            return sessionId
+        }
 
         override fun addObserver(observer: SessionObserver) {
             this.observer = observer

--- a/instrumentation/sessions/README.md
+++ b/instrumentation/sessions/README.md
@@ -21,7 +21,7 @@ You can customize session behavior using the configuration DSL:
 OpenTelemetryRumInitializer.initialize(context) {
     session {
         // Session expires after 15 minutes without meaningful activity (default)
-        backgroundInactivityTimeout = 15.minutes
+        inactivityTimeout = 15.minutes
 
         // Session expires after 4 hours regardless of activity (default)
         maxLifetime = 4.hours
@@ -29,10 +29,10 @@ OpenTelemetryRumInitializer.initialize(context) {
 }
 ```
 
-Returning to the foreground and pointer input captured by the View or Compose click
-instrumentation record meaningful activity. The agent checks whether the current session has
-expired before it records that activity. Passive telemetry, including spans and logs, does not
-extend the inactivity window.
+Returning to the foreground, pointer input, hardware key input, and mouse or trackpad scrolling
+record meaningful activity. The agent checks whether the current session has expired before it
+records that activity. Passive telemetry, including spans and logs, does not extend the inactivity
+window.
 
 Custom integrations can record other meaningful activity explicitly:
 

--- a/instrumentation/sessions/README.md
+++ b/instrumentation/sessions/README.md
@@ -20,7 +20,7 @@ You can customize session behavior using the configuration DSL:
 ```kotlin
 OpenTelemetryRumInitializer.initialize(context) {
     session {
-        // Session expires after 15 minutes in background (default)
+        // Session expires after 15 minutes without meaningful activity (default)
         backgroundInactivityTimeout = 15.minutes
 
         // Session expires after 4 hours regardless of activity (default)
@@ -28,6 +28,22 @@ OpenTelemetryRumInitializer.initialize(context) {
     }
 }
 ```
+
+Returning to the foreground and pointer input captured by the View or Compose click
+instrumentation record meaningful activity. The agent checks whether the current session has
+expired before it records that activity. Passive telemetry, including spans and logs, does not
+extend the inactivity window.
+
+Custom integrations can record other meaningful activity explicitly:
+
+```kotlin
+openTelemetryRum.sessionProvider.recordActivity()
+```
+
+With the agent's built-in provider, calling `getSessionId()` directly also records activity for
+compatibility with existing integrations. Telemetry processors should use
+`getSessionIdForAttribution()` when retrieving the ID must not extend the session. Custom providers
+that track inactivity should override `getSessionIdForAttribution()` and `recordActivity()`.
 
 If not using the agent, you can create a `SessionManager` directly with a custom `SessionConfig`.
 

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
@@ -32,6 +32,7 @@ import java.util.LinkedList
 
 internal class ViewClickEventGenerator(
     private val eventLogger: Logger,
+    private val recordActivity: () -> Unit = {},
 ) {
     private var windowRef: WeakReference<Window>? = null
 
@@ -148,6 +149,9 @@ internal class ViewClickEventGenerator(
 
     fun generateClick(motionEvent: MotionEvent?) {
         if (motionEvent != null) {
+            if (motionEvent.actionMasked == MotionEvent.ACTION_DOWN && windowRef?.get() != null) {
+                recordActivity()
+            }
             gestureDetector.onTouchEvent(motionEvent)
         }
     }

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentation.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentation.kt
@@ -26,6 +26,7 @@ class ViewClickInstrumentation : AndroidInstrumentation {
                         .logsBridge
                         .loggerBuilder("io.opentelemetry.android.instrumentation.view.click")
                         .build(),
+                    openTelemetryRum.sessionProvider::recordActivity,
                 ),
             ),
         )

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
@@ -80,10 +80,14 @@ class ViewClickInstrumentationTest {
 
     @Test
     fun capture_view_click() {
+        val activitySessionProvider = mockk<SessionProvider>(relaxUnitFun = true)
+        every { activitySessionProvider.recordActivity() } answers {
+            assertThat(openTelemetryRule.logRecords).isEmpty()
+        }
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns activitySessionProvider
                 every { clock } returns Clock.getDefault()
             }
 
@@ -115,13 +119,9 @@ class ViewClickInstrumentationTest {
             window.callback = capture(wrapperCapturingSlot)
         }
 
-        wrapperCapturingSlot.captured.dispatchTouchEvent(
-            singleTapSequence[0],
-        )
-        wrapperCapturingSlot.captured.dispatchTouchEvent(
-            singleTapSequence[1],
-        )
+        singleTapSequence.forEach { wrapperCapturingSlot.captured.dispatchTouchEvent(it) }
         fastForwardDoubleTapTimeout()
+        verify(exactly = 1) { activitySessionProvider.recordActivity() }
 
         val events = openTelemetryRule.logRecords
         assertThat(events).hasSize(2)
@@ -154,7 +154,7 @@ class ViewClickInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -226,7 +226,7 @@ class ViewClickInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -289,7 +289,7 @@ class ViewClickInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -330,7 +330,7 @@ class ViewClickInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -399,7 +399,7 @@ class ViewClickInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -470,7 +470,7 @@ class ViewClickInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -539,7 +539,7 @@ class ViewClickInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -609,7 +609,7 @@ class ViewClickInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -671,7 +671,7 @@ class ViewClickInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewLongPressInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewLongPressInstrumentationTest.kt
@@ -75,7 +75,7 @@ class ViewLongPressInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -144,7 +144,7 @@ class ViewLongPressInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -210,7 +210,7 @@ class ViewLongPressInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewScrollInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewScrollInstrumentationTest.kt
@@ -81,7 +81,7 @@ class ViewScrollInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -154,7 +154,7 @@ class ViewScrollInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -206,7 +206,7 @@ class ViewScrollInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -282,7 +282,7 @@ class ViewScrollInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 

--- a/session/api/session.api
+++ b/session/api/session.api
@@ -12,6 +12,8 @@ public abstract interface class io/opentelemetry/android/session/SessionProvider
 	public static final field Companion Lio/opentelemetry/android/session/SessionProvider$Companion;
 	public static fun getNoop ()Lio/opentelemetry/android/session/SessionProvider;
 	public abstract fun getSessionId ()Ljava/lang/String;
+	public fun getSessionIdForAttribution ()Ljava/lang/String;
+	public fun recordActivity ()V
 }
 
 public final class io/opentelemetry/android/session/SessionProvider$Companion {

--- a/session/src/main/kotlin/io/opentelemetry/android/session/SessionProvider.kt
+++ b/session/src/main/kotlin/io/opentelemetry/android/session/SessionProvider.kt
@@ -11,8 +11,29 @@ package io.opentelemetry.android.session
 fun interface SessionProvider {
     /**
      * Retrieves the current session ID.
+     *
+     * The agent's built-in provider also records meaningful activity when this method is called.
      */
     fun getSessionId(): String
+
+    /**
+     * Retrieves the current session ID for passive telemetry attribution.
+     *
+     * Implementations that track activity in [getSessionId] should override this method so passive
+     * telemetry cannot keep a session alive. The default delegates to [getSessionId] for
+     * compatibility with existing custom providers.
+     */
+    fun getSessionIdForAttribution(): String = getSessionId()
+
+    /**
+     * Records meaningful activity for the current session.
+     *
+     * Implementations that maintain an inactivity window should override this method. The default
+     * preserves existing custom-provider behavior by retrieving the current session ID.
+     */
+    fun recordActivity() {
+        getSessionId()
+    }
 
     companion object {
         /**


### PR DESCRIPTION
Resolves #910
Resolves #794

- separate meaningful activity from passive session attribution
- expire sessions after configurable inactivity while keeping the four-hour maximum lifetime
- record touch, keyboard, and scroll input in the default agent without emitting extra telemetry
- keep processors, sampling, and recovered crashes from extending a session
- preserve compatibility for existing `SessionProvider` implementations and the deprecated background timeout setting

The input tracker owns one callback wrapper per activity window, leaves later replacements alone, and detaches on shutdown or activity destruction.

Validation:
- `./gradlew spotlessCheck check apiCheck`
- debug and release builds for the Android agent, View click, and Compose click modules
- focused lifecycle, callback-coexistence, and compatibility tests
- mutation checks for input wiring, pre-init activity resume, cleanup, detachment, and destruction

No screenshot or video applies to this SDK lifecycle change.

Draft note: the behavior is complete, but the current diff is over the repository's preferred review size. I will split the default input tracker before marking it ready if maintainers prefer that boundary.

Merge tier: Tier 4