### PR TITLE
feat(session): separate activity from attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
 
 ### 📈 Enhancements
 
+- Session providers can now separate explicit activity from passive telemetry attribution through
+  `recordActivity()` and `getSessionIdForAttribution()`. Existing providers retain their previous
+  behavior by default.
+  ([#910](https://github.com/open-telemetry/opentelemetry-android/issues/910))
+
 - The Compose Navigation instrumentation, which shipped in 1.6.0 without emitting any telemetry,
   now records an `app.navigation.complete` event carrying the `app.navigation.destination.name`
   attribute whenever a navigation completes.

--- a/android-agent/src/test/java/io/opentelemetry/android/agent/session/SessionProviderCompatibilityTest.java
+++ b/android-agent/src/test/java/io/opentelemetry/android/agent/session/SessionProviderCompatibilityTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.session;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentelemetry.android.session.SessionProvider;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class SessionProviderCompatibilityTest {
+    @Test
+    void existingJavaProvidersUseDefaultActivityMethods() {
+        AtomicInteger calls = new AtomicInteger();
+        SessionProvider provider =
+                () -> {
+                    calls.incrementAndGet();
+                    return "session-id";
+                };
+
+        assertThat(provider.getSessionIdForAttribution()).isEqualTo("session-id");
+        provider.recordActivity();
+
+        assertThat(calls).hasValue(2);
+    }
+}

--- a/core/src/main/java/io/opentelemetry/android/SessionIdRatioBasedSampler.kt
+++ b/core/src/main/java/io/opentelemetry/android/SessionIdRatioBasedSampler.kt
@@ -36,7 +36,7 @@ class SessionIdRatioBasedSampler(
         // Replace traceId with sessionId
         return ratioBasedSampler.shouldSample(
             parentContext,
-            sessionProvider.getSessionId(),
+            sessionProvider.getSessionIdForAttribution(),
             name,
             spanKind,
             attributes,

--- a/core/src/main/java/io/opentelemetry/android/SessionIdSpanAppender.kt
+++ b/core/src/main/java/io/opentelemetry/android/SessionIdSpanAppender.kt
@@ -28,7 +28,7 @@ internal class SessionIdSpanAppender(
         parentContext: Context,
         span: ReadWriteSpan,
     ) {
-        span.setAttribute(sessionId, sessionProvider.getSessionId())
+        span.setAttribute(sessionId, sessionProvider.getSessionIdForAttribution())
     }
 
     override fun isStartRequired(): Boolean = true

--- a/core/src/main/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppender.kt
+++ b/core/src/main/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppender.kt
@@ -26,7 +26,7 @@ internal class SessionIdLogRecordAppender(
     ) {
         // Recovered crashes and session-end events can describe a session that is no longer current.
         if (logRecord.getAttribute(sessionIdKey) == null) {
-            logRecord.setAttribute(sessionIdKey, sessionProvider.getSessionId())
+            logRecord.setAttribute(sessionIdKey, sessionProvider.getSessionIdForAttribution())
         }
     }
 }

--- a/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumNoopTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/OpenTelemetryRumNoopTest.kt
@@ -15,6 +15,8 @@ internal class OpenTelemetryRumNoopTest {
         val noop = RumBuilder.noop()
         assertEquals(OpenTelemetry.noop(), noop.openTelemetry)
         assertEquals("", noop.sessionProvider.getSessionId())
+        assertEquals("", noop.sessionProvider.getSessionIdForAttribution())
+        noop.sessionProvider.recordActivity()
 
         // assert no exceptions thrown
         noop.emitEvent("event")

--- a/core/src/test/java/io/opentelemetry/android/SessionIdRatioBasedSamplerTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/SessionIdRatioBasedSamplerTest.kt
@@ -8,6 +8,7 @@ package io.opentelemetry.android
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
+import io.mockk.verify
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
@@ -36,18 +37,19 @@ internal class SessionIdRatioBasedSamplerTest {
 
     @Test
     fun samplerDropsHigh() {
-        every { sessionProvider.getSessionId() } returns HIGH_ID
+        every { sessionProvider.getSessionIdForAttribution() } returns HIGH_ID
 
         val sampler = SessionIdRatioBasedSampler(0.5, sessionProvider)
 
         // Sampler drops if TraceIdRatioBasedSampler would drop this sessionId
         assertThat(shouldSample(sampler)).isEqualTo(SamplingDecision.DROP)
+        verify(exactly = 0) { sessionProvider.getSessionId() }
     }
 
     @Test
     fun samplerKeepsLowestId() {
         // Sampler accepts if TraceIdRatioBasedSampler would accept this sessionId
-        every { sessionProvider.getSessionId() } returns LOW_ID
+        every { sessionProvider.getSessionIdForAttribution() } returns LOW_ID
 
         val sampler = SessionIdRatioBasedSampler(0.5, sessionProvider)
         assertThat(shouldSample(sampler)).isEqualTo(SamplingDecision.RECORD_AND_SAMPLE)
@@ -55,13 +57,13 @@ internal class SessionIdRatioBasedSamplerTest {
 
     @Test
     fun zeroRatioDropsAll() {
-        every { sessionProvider.getSessionId() } returns HIGH_ID
+        every { sessionProvider.getSessionIdForAttribution() } returns HIGH_ID
 
         val samplerHigh =
             SessionIdRatioBasedSampler(0.0, sessionProvider)
         assertThat(shouldSample(samplerHigh)).isEqualTo(SamplingDecision.DROP)
 
-        every { sessionProvider.getSessionId() } returns LOW_ID
+        every { sessionProvider.getSessionIdForAttribution() } returns LOW_ID
 
         val samplerLow =
             SessionIdRatioBasedSampler(0.0, sessionProvider)
@@ -70,13 +72,13 @@ internal class SessionIdRatioBasedSamplerTest {
 
     @Test
     fun oneRatioAcceptsAll() {
-        every { sessionProvider.getSessionId() } returns HIGH_ID
+        every { sessionProvider.getSessionIdForAttribution() } returns HIGH_ID
 
         val samplerHigh =
             SessionIdRatioBasedSampler(1.0, sessionProvider)
         assertThat(shouldSample(samplerHigh)).isEqualTo(SamplingDecision.RECORD_AND_SAMPLE)
 
-        every { sessionProvider.getSessionId() } returns LOW_ID
+        every { sessionProvider.getSessionIdForAttribution() } returns LOW_ID
 
         val samplerLow =
             SessionIdRatioBasedSampler(1.0, sessionProvider)

--- a/core/src/test/java/io/opentelemetry/android/SessionIdSpanAppenderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/SessionIdSpanAppenderTest.kt
@@ -32,7 +32,7 @@ internal class SessionIdSpanAppenderTest {
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
-        every { sessionProvider.getSessionId() }.returns("42")
+        every { sessionProvider.getSessionIdForAttribution() }.returns("42")
         every { span.setAttribute(any<AttributeKey<String>>(), any<String>()) } returns span
     }
 
@@ -44,6 +44,7 @@ internal class SessionIdSpanAppenderTest {
         underTest.onStart(Context.root(), span)
 
         verify { span.setAttribute(stringKey(SESSION_ID), "42") }
+        verify(exactly = 0) { sessionProvider.getSessionId() }
 
         assertFalse(underTest.isEndRequired)
     }

--- a/core/src/test/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppenderTest.kt
+++ b/core/src/test/java/io/opentelemetry/android/internal/processors/SessionIdLogRecordAppenderTest.kt
@@ -32,7 +32,7 @@ class SessionIdLogRecordAppenderTest {
     @BeforeEach
     fun setUp() {
         MockKAnnotations.init(this)
-        every { sessionProvider.getSessionId() }.returns(SESSION_ID_VALUE)
+        every { sessionProvider.getSessionIdForAttribution() }.returns(SESSION_ID_VALUE)
         every { log.getAttribute(any<AttributeKey<String>>()) } returns null
         every { log.setAttribute(any<AttributeKey<String>>(), any<String>()) } returns log
     }
@@ -44,6 +44,7 @@ class SessionIdLogRecordAppenderTest {
         underTest.onEmit(Context.root(), log)
 
         verify { log.setAttribute(stringKey(SESSION_ID), SESSION_ID_VALUE) }
+        verify(exactly = 0) { sessionProvider.getSessionId() }
     }
 
     @Test
@@ -54,5 +55,6 @@ class SessionIdLogRecordAppenderTest {
         underTest.onEmit(Context.root(), log)
 
         verify(exactly = 0) { log.setAttribute(any<AttributeKey<String>>(), any<String>()) }
+        verify(exactly = 0) { sessionProvider.getSessionIdForAttribution() }
     }
 }

--- a/instrumentation/compose/click/build.gradle.kts
+++ b/instrumentation/compose/click/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
 
     implementation(project(":agent-api"))
+    implementation(project(":common"))
     implementation(project(":instrumentation:android-instrumentation"))
     implementation(project(":semconv"))
     implementation(project(":services"))

--- a/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGenerator.kt
+++ b/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGenerator.kt
@@ -7,9 +7,11 @@
 
 package io.opentelemetry.instrumentation.compose.click
 
+import android.util.Log
 import android.view.MotionEvent
 import android.view.Window
 import androidx.compose.ui.node.LayoutNode
+import io.opentelemetry.android.common.RumConstants
 import io.opentelemetry.android.semconv.events.AppScreenClickEvent
 import io.opentelemetry.android.semconv.events.AppWidgetClickEvent
 import io.opentelemetry.api.logs.Logger
@@ -33,7 +35,7 @@ internal class ComposeClickEventGenerator(
     fun generateClick(motionEvent: MotionEvent?) {
         windowRef?.get()?.let { window ->
             if (motionEvent?.actionMasked == MotionEvent.ACTION_DOWN) {
-                recordActivity()
+                recordActivitySafely()
             } else if (motionEvent != null && motionEvent.actionMasked == MotionEvent.ACTION_UP) {
                 AppScreenClickEvent(
                     appScreenCoordinateX = motionEvent.x.toLong(),
@@ -51,6 +53,14 @@ internal class ComposeClickEventGenerator(
                     ).emit(eventLogger)
                 }
             }
+        }
+    }
+
+    private fun recordActivitySafely() {
+        try {
+            recordActivity()
+        } catch (error: Throwable) {
+            Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to record session activity", error)
         }
     }
 

--- a/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGenerator.kt
+++ b/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGenerator.kt
@@ -59,7 +59,7 @@ internal class ComposeClickEventGenerator(
     private fun recordActivitySafely() {
         try {
             recordActivity()
-        } catch (error: Throwable) {
+        } catch (error: Exception) {
             Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to record session activity", error)
         }
     }

--- a/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGenerator.kt
+++ b/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickEventGenerator.kt
@@ -20,6 +20,7 @@ internal class ComposeClickEventGenerator(
     private val eventLogger: Logger,
     private val composeLayoutNodeUtil: ComposeLayoutNodeUtil = ComposeLayoutNodeUtil(),
     private val composeTapTargetDetector: ComposeTapTargetDetector = ComposeTapTargetDetector(composeLayoutNodeUtil),
+    private val recordActivity: () -> Unit = {},
 ) {
     private var windowRef: WeakReference<Window>? = null
 
@@ -31,7 +32,9 @@ internal class ComposeClickEventGenerator(
 
     fun generateClick(motionEvent: MotionEvent?) {
         windowRef?.get()?.let { window ->
-            if (motionEvent != null && motionEvent.actionMasked == MotionEvent.ACTION_UP) {
+            if (motionEvent?.actionMasked == MotionEvent.ACTION_DOWN) {
+                recordActivity()
+            } else if (motionEvent != null && motionEvent.actionMasked == MotionEvent.ACTION_UP) {
                 AppScreenClickEvent(
                     appScreenCoordinateX = motionEvent.x.toLong(),
                     appScreenCoordinateY = motionEvent.y.toLong(),

--- a/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickInstrumentation.kt
+++ b/instrumentation/compose/click/src/main/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeClickInstrumentation.kt
@@ -26,6 +26,7 @@ class ComposeClickInstrumentation : AndroidInstrumentation {
                         .logsBridge
                         .loggerBuilder("io.opentelemetry.android.instrumentation.compose.click")
                         .build(),
+                    recordActivity = openTelemetryRum.sessionProvider::recordActivity,
                 ),
             ),
         )

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
@@ -99,6 +99,30 @@ internal class ComposeInstrumentationTest {
     }
 
     @Test
+    fun `activity failure does not block touch dispatch`() {
+        val recordActivity = mockk<() -> Unit>()
+        every { recordActivity() } throws IllegalStateException("activity failed")
+        every { window.callback } returns callback
+        every { callback.dispatchTouchEvent(any()) } returns true
+
+        val generator =
+            ComposeClickEventGenerator(
+                eventLogger = mockk(relaxed = true),
+                recordActivity = recordActivity,
+            )
+        val wrapper = slot<WindowCallbackWrapper>()
+        every { window.callback = capture(wrapper) } returns Unit
+        generator.startTracking(window)
+
+        val event = MotionEvent.obtain(0L, SystemClock.uptimeMillis(), MotionEvent.ACTION_DOWN, 0f, 0f, 0)
+        wrapper.captured.dispatchTouchEvent(event)
+
+        verify(exactly = 1) { recordActivity() }
+        verify(exactly = 1) { callback.dispatchTouchEvent(event) }
+        event.recycle()
+    }
+
+    @Test
     fun capture_compose_click() {
         val activitySessionProvider = mockk<SessionProvider>(relaxUnitFun = true)
         every { activitySessionProvider.recordActivity() } answers {

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
@@ -100,10 +100,14 @@ internal class ComposeInstrumentationTest {
 
     @Test
     fun capture_compose_click() {
+        val activitySessionProvider = mockk<SessionProvider>(relaxUnitFun = true)
+        every { activitySessionProvider.recordActivity() } answers {
+            assertThat(openTelemetryRule.logRecords).isEmpty()
+        }
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns activitySessionProvider
                 every { clock } returns Clock.getDefault()
             }
 
@@ -124,8 +128,8 @@ internal class ComposeInstrumentationTest {
         val wrapperCapturingSlot = slot<WindowCallbackWrapper>()
         every { window.callback = any() } returns Unit
 
-        val motionEvent =
-            MotionEvent.obtain(0L, SystemClock.uptimeMillis(), MotionEvent.ACTION_UP, 250f, 50f, 0)
+        val downEvent = createMotionEvent(MotionEvent.ACTION_DOWN)
+        val motionEvent = createMotionEvent(MotionEvent.ACTION_UP)
         every { window.decorView } returns composeView
         every { composeView.childCount } returns 0
 
@@ -144,9 +148,8 @@ internal class ComposeInstrumentationTest {
             window.callback = capture(wrapperCapturingSlot)
         }
 
-        wrapperCapturingSlot.captured.dispatchTouchEvent(
-            motionEvent,
-        )
+        listOf(downEvent, motionEvent).forEach { wrapperCapturingSlot.captured.dispatchTouchEvent(it) }
+        verify(exactly = 1) { activitySessionProvider.recordActivity() }
 
         val events = openTelemetryRule.logRecords
         assertThat(events).hasSize(2)
@@ -167,6 +170,8 @@ internal class ComposeInstrumentationTest {
                 equalTo(APP_WIDGET_NAME_KEY, "clickMe"),
             )
     }
+
+    private fun createMotionEvent(action: Int): MotionEvent = MotionEvent.obtain(0L, SystemClock.uptimeMillis(), action, 250f, 50f, 0)
 
     private fun createMockLayoutNode(
         targetX: Float = 0f,

--- a/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
+++ b/instrumentation/compose/click/src/test/kotlin/io/opentelemetry/instrumentation/compose/click/ComposeInstrumentationTest.kt
@@ -115,11 +115,14 @@ internal class ComposeInstrumentationTest {
         generator.startTracking(window)
 
         val event = MotionEvent.obtain(0L, SystemClock.uptimeMillis(), MotionEvent.ACTION_DOWN, 0f, 0f, 0)
-        wrapper.captured.dispatchTouchEvent(event)
+        try {
+            wrapper.captured.dispatchTouchEvent(event)
 
-        verify(exactly = 1) { recordActivity() }
-        verify(exactly = 1) { callback.dispatchTouchEvent(event) }
-        event.recycle()
+            verify(exactly = 1) { recordActivity() }
+            verify(exactly = 1) { callback.dispatchTouchEvent(event) }
+        } finally {
+            event.recycle()
+        }
     }
 
     @Test
@@ -172,22 +175,31 @@ internal class ComposeInstrumentationTest {
             window.callback = capture(wrapperCapturingSlot)
         }
 
-        listOf(downEvent, motionEvent).forEach { wrapperCapturingSlot.captured.dispatchTouchEvent(it) }
-        verify(exactly = 1) { activitySessionProvider.recordActivity() }
+        try {
+            listOf(downEvent, motionEvent).forEach { wrapperCapturingSlot.captured.dispatchTouchEvent(it) }
+            verify(exactly = 1) { activitySessionProvider.recordActivity() }
+            assertComposeClickEvents(motionEvent, mockLayoutNode)
+        } finally {
+            downEvent.recycle()
+            motionEvent.recycle()
+        }
+    }
 
+    private fun assertComposeClickEvents(
+        motionEvent: MotionEvent,
+        mockLayoutNode: LayoutNode,
+    ) {
         val events = openTelemetryRule.logRecords
         assertThat(events).hasSize(2)
 
-        var event = events[0]
-        assertThat(event)
+        assertThat(events[0])
             .hasEventName(APP_SCREEN_CLICK_EVENT_NAME)
             .hasAttributesSatisfyingExactly(
                 equalTo(APP_SCREEN_COORDINATE_X_KEY, motionEvent.x.toLong()),
                 equalTo(APP_SCREEN_COORDINATE_Y_KEY, motionEvent.y.toLong()),
             )
 
-        event = events[1]
-        assertThat(event)
+        assertThat(events[1])
             .hasEventName(APP_WIDGET_CLICK_EVENT_NAME)
             .hasAttributesSatisfying(
                 equalTo(APP_WIDGET_ID_KEY, mockLayoutNode.semanticsId.toString()),

--- a/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
+++ b/instrumentation/native-crash/src/main/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashInstrumentation.kt
@@ -325,7 +325,7 @@ internal data class NativeCrashContext(
 private fun Context.currentCrashContext(openTelemetryRum: OpenTelemetryRum): NativeCrashContext {
     val packageInfo = runCatching { packageManager.getPackageInfo(packageName, 0) }.getOrNull()
     return NativeCrashContext(
-        sessionId = openTelemetryRum.sessionProvider.getSessionId().takeIf { it.isNotBlank() },
+        sessionId = openTelemetryRum.sessionProvider.getSessionIdForAttribution().takeIf { it.isNotBlank() },
         serviceVersion = packageInfo?.versionName,
         osName = "Android",
         osVersion = Build.VERSION.RELEASE,

--- a/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
+++ b/instrumentation/native-crash/src/test/java/io/opentelemetry/android/instrumentation/nativecrash/NativeCrashReporterTest.kt
@@ -273,6 +273,8 @@ class NativeCrashReporterTest {
                 ),
             )
         assertThat(sessionProvider.observer).isNotNull()
+        assertThat(sessionProvider.attributionAccesses).isEqualTo(1)
+        assertThat(sessionProvider.activityAccesses).isZero()
         assertThat(installedMarkerPath).isEqualTo(store.crashRecordPath)
     }
 
@@ -555,8 +557,18 @@ class NativeCrashReporterTest {
     ) : SessionProvider,
         SessionPublisher {
         var observer: SessionObserver? = null
+        var activityAccesses = 0
+        var attributionAccesses = 0
 
-        override fun getSessionId(): String = sessionId
+        override fun getSessionId(): String {
+            activityAccesses++
+            return sessionId
+        }
+
+        override fun getSessionIdForAttribution(): String {
+            attributionAccesses++
+            return sessionId
+        }
 
         override fun addObserver(observer: SessionObserver) {
             this.observer = observer

--- a/instrumentation/view-click/build.gradle.kts
+++ b/instrumentation/view-click/build.gradle.kts
@@ -15,6 +15,7 @@ android {
 
 dependencies {
     api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
+    implementation(project(":common"))
     implementation(project(":services"))
     implementation(project(":agent-api"))
     implementation(project(":instrumentation:android-instrumentation"))

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
@@ -5,11 +5,13 @@
 
 package io.opentelemetry.android.instrumentation.view.click
 
+import android.util.Log
 import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
+import io.opentelemetry.android.common.RumConstants
 import io.opentelemetry.android.instrumentation.view.click.internal.Gesture
 import io.opentelemetry.android.semconv.events.AppScreenClickEvent.Companion.APP_SCREEN_CLICK_EVENT_NAME
 import io.opentelemetry.android.semconv.events.AppScreenFlingEvent
@@ -150,9 +152,17 @@ internal class ViewClickEventGenerator(
     fun generateClick(motionEvent: MotionEvent?) {
         if (motionEvent != null) {
             if (motionEvent.actionMasked == MotionEvent.ACTION_DOWN && windowRef?.get() != null) {
-                recordActivity()
+                recordActivitySafely()
             }
             gestureDetector.onTouchEvent(motionEvent)
+        }
+    }
+
+    private fun recordActivitySafely() {
+        try {
+            recordActivity()
+        } catch (error: Throwable) {
+            Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to record session activity", error)
         }
     }
 

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
@@ -161,7 +161,7 @@ internal class ViewClickEventGenerator(
     private fun recordActivitySafely() {
         try {
             recordActivity()
-        } catch (error: Throwable) {
+        } catch (error: Exception) {
             Log.w(RumConstants.OTEL_RUM_LOG_TAG, "Failed to record session activity", error)
         }
     }

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickEventGenerator.kt
@@ -32,6 +32,7 @@ import java.util.LinkedList
 
 internal class ViewClickEventGenerator(
     private val eventLogger: Logger,
+    private val recordActivity: () -> Unit = {},
 ) {
     private var windowRef: WeakReference<Window>? = null
 
@@ -148,6 +149,9 @@ internal class ViewClickEventGenerator(
 
     fun generateClick(motionEvent: MotionEvent?) {
         if (motionEvent != null) {
+            if (motionEvent.actionMasked == MotionEvent.ACTION_DOWN && windowRef?.get() != null) {
+                recordActivity()
+            }
             gestureDetector.onTouchEvent(motionEvent)
         }
     }

--- a/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentation.kt
+++ b/instrumentation/view-click/src/main/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentation.kt
@@ -26,6 +26,7 @@ class ViewClickInstrumentation : AndroidInstrumentation {
                         .logsBridge
                         .loggerBuilder("io.opentelemetry.android.instrumentation.view.click")
                         .build(),
+                    openTelemetryRum.sessionProvider::recordActivity,
                 ),
             ),
         )

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
@@ -79,6 +79,30 @@ class ViewClickInstrumentationTest {
     private val buttonKey = HW_POINTER_BUTTON_KEY
 
     @Test
+    fun `activity failure does not block touch dispatch`() {
+        val recordActivity = mockk<() -> Unit>()
+        every { recordActivity() } throws IllegalStateException("activity failed")
+        every { window.callback } returns callback
+        every { callback.dispatchTouchEvent(any()) } returns true
+
+        val generator =
+            ViewClickEventGenerator(
+                eventLogger = mockk(relaxed = true),
+                recordActivity = recordActivity,
+            )
+        val wrapper = slot<WindowCallbackWrapper>()
+        every { window.callback = capture(wrapper) } returns Unit
+        generator.startTracking(window)
+
+        val event = MotionEvent.obtain(0L, SystemClock.uptimeMillis(), MotionEvent.ACTION_DOWN, 0f, 0f, 0)
+        wrapper.captured.dispatchTouchEvent(event)
+
+        verify(exactly = 1) { recordActivity() }
+        verify(exactly = 1) { callback.dispatchTouchEvent(event) }
+        event.recycle()
+    }
+
+    @Test
     fun capture_view_click() {
         val activitySessionProvider = mockk<SessionProvider>(relaxUnitFun = true)
         every { activitySessionProvider.recordActivity() } answers {

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
@@ -80,10 +80,14 @@ class ViewClickInstrumentationTest {
 
     @Test
     fun capture_view_click() {
+        val activitySessionProvider = mockk<SessionProvider>(relaxUnitFun = true)
+        every { activitySessionProvider.recordActivity() } answers {
+            assertThat(openTelemetryRule.logRecords).isEmpty()
+        }
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns activitySessionProvider
                 every { clock } returns Clock.getDefault()
             }
 
@@ -115,13 +119,9 @@ class ViewClickInstrumentationTest {
             window.callback = capture(wrapperCapturingSlot)
         }
 
-        wrapperCapturingSlot.captured.dispatchTouchEvent(
-            singleTapSequence[0],
-        )
-        wrapperCapturingSlot.captured.dispatchTouchEvent(
-            singleTapSequence[1],
-        )
+        singleTapSequence.forEach { wrapperCapturingSlot.captured.dispatchTouchEvent(it) }
         fastForwardDoubleTapTimeout()
+        verify(exactly = 1) { activitySessionProvider.recordActivity() }
 
         val events = openTelemetryRule.logRecords
         assertThat(events).hasSize(2)
@@ -154,7 +154,7 @@ class ViewClickInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -226,7 +226,7 @@ class ViewClickInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -289,7 +289,7 @@ class ViewClickInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -330,7 +330,7 @@ class ViewClickInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -399,7 +399,7 @@ class ViewClickInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -470,7 +470,7 @@ class ViewClickInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -539,7 +539,7 @@ class ViewClickInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -609,7 +609,7 @@ class ViewClickInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -671,7 +671,7 @@ class ViewClickInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewClickInstrumentationTest.kt
@@ -95,11 +95,14 @@ class ViewClickInstrumentationTest {
         generator.startTracking(window)
 
         val event = MotionEvent.obtain(0L, SystemClock.uptimeMillis(), MotionEvent.ACTION_DOWN, 0f, 0f, 0)
-        wrapper.captured.dispatchTouchEvent(event)
+        try {
+            wrapper.captured.dispatchTouchEvent(event)
 
-        verify(exactly = 1) { recordActivity() }
-        verify(exactly = 1) { callback.dispatchTouchEvent(event) }
-        event.recycle()
+            verify(exactly = 1) { recordActivity() }
+            verify(exactly = 1) { callback.dispatchTouchEvent(event) }
+        } finally {
+            event.recycle()
+        }
     }
 
     @Test

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewLongPressInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewLongPressInstrumentationTest.kt
@@ -75,7 +75,7 @@ class ViewLongPressInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -144,7 +144,7 @@ class ViewLongPressInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -210,7 +210,7 @@ class ViewLongPressInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 

--- a/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewScrollInstrumentationTest.kt
+++ b/instrumentation/view-click/src/test/kotlin/io/opentelemetry/android/instrumentation/view/click/ViewScrollInstrumentationTest.kt
@@ -81,7 +81,7 @@ class ViewScrollInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -154,7 +154,7 @@ class ViewScrollInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -206,7 +206,7 @@ class ViewScrollInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 
@@ -282,7 +282,7 @@ class ViewScrollInstrumentationTest {
         val openTelemetryRum =
             mockk<OpenTelemetryRum> {
                 every { openTelemetry } returns openTelemetryRule.openTelemetry
-                every { sessionProvider } returns mockk<SessionProvider>()
+                every { sessionProvider } returns mockk<SessionProvider>(relaxUnitFun = true)
                 every { clock } returns Clock.getDefault()
             }
 

--- a/session/api/session.api
+++ b/session/api/session.api
@@ -12,6 +12,8 @@ public abstract interface class io/opentelemetry/android/session/SessionProvider
 	public static final field Companion Lio/opentelemetry/android/session/SessionProvider$Companion;
 	public static fun getNoop ()Lio/opentelemetry/android/session/SessionProvider;
 	public abstract fun getSessionId ()Ljava/lang/String;
+	public fun getSessionIdForAttribution ()Ljava/lang/String;
+	public fun recordActivity ()V
 }
 
 public final class io/opentelemetry/android/session/SessionProvider$Companion {

--- a/session/src/main/kotlin/io/opentelemetry/android/session/SessionProvider.kt
+++ b/session/src/main/kotlin/io/opentelemetry/android/session/SessionProvider.kt
@@ -11,8 +11,29 @@ package io.opentelemetry.android.session
 fun interface SessionProvider {
     /**
      * Retrieves the current session ID.
+     *
+     * The agent's built-in provider also records meaningful activity when this method is called.
      */
     fun getSessionId(): String
+
+    /**
+     * Retrieves the current session ID for passive telemetry attribution.
+     *
+     * Implementations that track activity in [getSessionId] should override this method so passive
+     * telemetry cannot keep a session alive. The default delegates to [getSessionId] for
+     * compatibility with existing custom providers.
+     */
+    fun getSessionIdForAttribution(): String = getSessionId()
+
+    /**
+     * Records meaningful activity for the current session.
+     *
+     * Implementations that maintain an inactivity window should override this method. The default
+     * preserves existing custom-provider behavior by retrieving the current session ID.
+     */
+    fun recordActivity() {
+        getSessionId()
+    }
 
     companion object {
         /**


### PR DESCRIPTION
Part of #910.

- adds compatible hooks for explicit activity and passive attribution
- updates passive telemetry consumers to use attribution-only access
- records activity from the existing View and Compose click instrumentations
- verifies existing Java session providers keep their current behavior


Merge tier: Tier 4

### Follow-ups

- [Inactivity expiry](https://github.com/aranhave/opentelemetry-android/pull/1), including the #794 regression coverage.
- [Default Android input tracking](https://github.com/aranhave/opentelemetry-android/pull/2) for touch, key, and scroll activity.

These drafts are stacked and will be retargeted upstream as their dependencies merge.