### PR TITLE
[proposal] ApiExtension PoC

### DIFF
--- a/agent-api/src/main/java/io/opentelemetry/android/OpenTelemetryRum.kt
+++ b/agent-api/src/main/java/io/opentelemetry/android/OpenTelemetryRum.kt
@@ -5,6 +5,7 @@
 
 package io.opentelemetry.android
 
+import io.opentelemetry.android.extensions.ApiExtension
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
@@ -44,6 +45,17 @@ interface OpenTelemetryRum {
         body: String = "",
         attributes: Attributes = Attributes.empty(),
     )
+
+    /**
+     * Returns the [ApiExtension] registered under [type], or null when this instance doesn't
+     * provide it. Extensions are manual APIs contributed by optional modules, see [ApiExtension].
+     *
+     * Kotlin callers can use the reified [io.opentelemetry.android.extensions.extension] helper
+     * instead.
+     *
+     * The default returns null so that existing implementations of this interface keep working.
+     */
+    fun <T : ApiExtension> getExtension(type: Class<T>): T? = null
 
     /**
      * Initiates orderly shutdown of this OpenTelemetryRum instance. After this method completes,

--- a/agent-api/src/main/java/io/opentelemetry/android/extensions/ApiExtension.kt
+++ b/agent-api/src/main/java/io/opentelemetry/android/extensions/ApiExtension.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.extensions
+
+/**
+ * A manual API that optional modules make available through
+ * [io.opentelemetry.android.OpenTelemetryRum.getExtension].
+ *
+ * [io.opentelemetry.android.OpenTelemetryRum] only exposes what every setup needs. Some modules
+ * need to let users provide information that cannot be reliably inferred on their behalf, such as
+ * whether the user is currently active, or what the current screen is. Those modules define an
+ * [ApiExtension] instead of adding members to [io.opentelemetry.android.OpenTelemetryRum].
+ *
+ * Conventions:
+ * - The public contract is an interface that extends [ApiExtension] and provides [type].
+ *   Implementations stay internal to the module that owns them.
+ * - An extension is a facade over the internals of the module that owns it. It has no lifecycle.
+ * - The extension is the single source of truth for what it controls. Automatic instrumentations
+ *   that infer the same information write through the extension too, so the last write wins.
+ * - Modules may expose a Kotlin extension function on [io.opentelemetry.android.OpenTelemetryRum]
+ *   for convenience, e.g. `fun OpenTelemetryRum.sessions(): SessionActivityApi?`.
+ *
+ * Extensions become available to an [io.opentelemetry.android.OpenTelemetryRum] instance in two
+ * ways:
+ * - Discovered on the classpath via `ServiceLoader` (`@AutoService(ApiExtension::class)`), for
+ *   extensions that don't need anything created during initialization.
+ * - Registered explicitly through the RUM builder, for extensions that wrap internals created
+ *   during initialization.
+ *
+ * Extensions are resolved before instrumentations are installed, so an
+ * [io.opentelemetry.android.instrumentation.AndroidInstrumentation] can obtain them from the
+ * [io.opentelemetry.android.OpenTelemetryRum] it receives in `install()`.
+ */
+interface ApiExtension {
+    /**
+     * The public type this extension is registered under. Lookups through
+     * [io.opentelemetry.android.OpenTelemetryRum.getExtension] must use this exact type.
+     */
+    val type: Class<out ApiExtension>
+}

--- a/agent-api/src/main/java/io/opentelemetry/android/extensions/OpenTelemetryRumExtensions.kt
+++ b/agent-api/src/main/java/io/opentelemetry/android/extensions/OpenTelemetryRumExtensions.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.extensions
+
+import io.opentelemetry.android.OpenTelemetryRum
+
+/**
+ * Kotlin shorthand for [OpenTelemetryRum.getExtension].
+ *
+ * ```
+ * openTelemetryRum.extension<SessionActivityApi>()?.userActive()
+ * ```
+ */
+inline fun <reified T : ApiExtension> OpenTelemetryRum.extension(): T? = getExtension(T::class.java)

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
@@ -14,12 +14,15 @@ import io.opentelemetry.android.RumBuilder
 import io.opentelemetry.android.agent.connectivity.Compression
 import io.opentelemetry.android.agent.connectivity.HttpEndpointConnectivity
 import io.opentelemetry.android.agent.dsl.OpenTelemetryConfiguration
+import io.opentelemetry.android.agent.session.SessionActivityApi
+import io.opentelemetry.android.agent.session.SessionActivityApiImpl
 import io.opentelemetry.android.agent.session.SessionConfig
 import io.opentelemetry.android.agent.session.SessionIdTimeoutHandler
 import io.opentelemetry.android.agent.session.SessionManager
 import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.internal.services.Services
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle
+import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateListener
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter
@@ -64,7 +67,10 @@ object OpenTelemetryRumInitializer {
                         instrumentationLoader = instrumentationLoader,
                     ).also(configuration)
 
-                setSessionProvider(createSessionProvider(Services.get(ctx).appLifecycle, cfg))
+                val sessionComponents = createSessionComponents(Services.get(ctx).appLifecycle, cfg)
+                setSessionProvider(sessionComponents.sessionProvider)
+                // Registered explicitly because it wraps internals created right here.
+                addApiExtension(sessionComponents.activityApi)
                 setResource(
                     AndroidResource
                         .createDefault(ctx)
@@ -144,10 +150,10 @@ object OpenTelemetryRumInitializer {
             else -> "none"
         }
 
-    private fun createSessionProvider(
+    private fun createSessionComponents(
         appLifecycle: AppLifecycle,
         cfg: OpenTelemetryConfiguration,
-    ): SessionProvider {
+    ): SessionComponents {
         val sessionConfig =
             SessionConfig(
                 cfg.sessionConfig.backgroundInactivityTimeout,
@@ -155,9 +161,25 @@ object OpenTelemetryRumInitializer {
             )
         val clock = cfg.clock
         val timeoutHandler = SessionIdTimeoutHandler(sessionConfig, clock)
-        appLifecycle.registerListener(timeoutHandler)
+        val sessionActivityApi = SessionActivityApiImpl(timeoutHandler)
+
+        // Default inference of user activity from the app lifecycle. It writes through the same
+        // API that apps use, so whichever signal came last wins.
+        appLifecycle.registerListener(
+            object : ApplicationStateListener {
+                override fun onApplicationForegrounded() = sessionActivityApi.userActive()
+
+                override fun onApplicationBackgrounded() = sessionActivityApi.userInactive()
+            },
+        )
+
         val sessionManager = SessionManager.create(timeoutHandler, sessionConfig, clock)
         cfg.sessionConfig.getObservers().forEach { sessionManager.addObserver(it) }
-        return sessionManager
+        return SessionComponents(sessionManager, sessionActivityApi)
     }
+
+    private class SessionComponents(
+        val sessionProvider: SessionProvider,
+        val activityApi: SessionActivityApi,
+    )
 }

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionActivityApi.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionActivityApi.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.session
+
+import io.opentelemetry.android.Incubating
+import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.extensions.ApiExtension
+
+/**
+ * Manual API to tell the session manager whether the user is actively using the app.
+ *
+ * A session expires after a period of user inactivity. By default, the agent infers activity from
+ * the app lifecycle (the user is active while the app is in the foreground and inactive once it
+ * goes to the background). That default doesn't fit every app, for example a media player that is
+ * still being used from a notification while backgrounded. This API lets the app report the state
+ * itself.
+ *
+ * This API is the single source of truth for user activity. The default lifecycle based inference
+ * writes through it as well, so the last write wins regardless of where it came from.
+ *
+ * Obtain it with [sessions] or `openTelemetryRum.getExtension(SessionActivityApi::class.java)`.
+ */
+@Incubating
+interface SessionActivityApi : ApiExtension {
+    override val type: Class<out ApiExtension>
+        get() = SessionActivityApi::class.java
+
+    /**
+     * Signals that the user is actively using the app. If the inactivity timeout has already
+     * elapsed, the next telemetry item starts a new session.
+     */
+    fun userActive()
+
+    /**
+     * Signals that the user stopped using the app. The session expires if [userActive] isn't
+     * called again before the configured inactivity timeout.
+     */
+    fun userInactive()
+}
+
+/**
+ * Convenience accessor for Kotlin callers. Returns null when the sessions extension isn't
+ * available in this [OpenTelemetryRum] instance.
+ */
+@Incubating
+fun OpenTelemetryRum.sessions(): SessionActivityApi? = getExtension(SessionActivityApi::class.java)

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionActivityApiImpl.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionActivityApiImpl.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.session
+
+import io.opentelemetry.android.Incubating
+
+/**
+ * Facade over [SessionIdTimeoutHandler], which is internal to the agent and created during
+ * initialization. Because of that, this extension is registered explicitly through the RUM builder
+ * rather than discovered from the classpath.
+ */
+@OptIn(Incubating::class)
+internal class SessionActivityApiImpl(
+    private val timeoutHandler: SessionIdTimeoutHandler,
+) : SessionActivityApi {
+    override fun userActive() {
+        timeoutHandler.onUserActive()
+    }
+
+    override fun userInactive() {
+        timeoutHandler.onUserInactive()
+    }
+}

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionIdTimeoutHandler.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionIdTimeoutHandler.kt
@@ -6,7 +6,6 @@
 package io.opentelemetry.android.agent.session
 
 import io.opentelemetry.android.Incubating
-import io.opentelemetry.android.internal.services.applifecycle.ApplicationStateListener
 import io.opentelemetry.sdk.common.Clock
 import kotlin.time.Duration
 
@@ -14,25 +13,29 @@ import kotlin.time.Duration
  * This class encapsulates the following criteria about the sessionId timeout:
  *
  *
- *  * If the app is in the foreground sessionId should never time out.
- *  * If the app is in the background and no activity (spans) happens for >15 minutes, sessionId
+ *  * While the user is active the sessionId should never time out.
+ *  * If the user is inactive and no activity (spans) happens for >15 minutes, sessionId
  * should time out.
- *  * If the app is in the background and some activity (spans) happens in <15 minute intervals,
+ *  * If the user is inactive and some activity (spans) happens in <15 minute intervals,
  * sessionId should not time out.
  *
  *
- * Consequently, when the app spent >15 minutes without any activity (spans) in the background,
- * after moving to the foreground the first span should trigger the sessionId timeout.
+ * Consequently, when >15 minutes went by without any activity (spans) while the user was inactive,
+ * the first span after the user becomes active again should trigger the sessionId timeout.
+ *
+ * Whether the user is active or not is reported through [onUserActive] and [onUserInactive].
+ * Those are driven by [SessionActivityApi], which apps can call directly and which the agent's
+ * default lifecycle based inference also writes through.
  */
 internal class SessionIdTimeoutHandler(
     private val clock: Clock,
     private val sessionBackgroundInactivityTimeout: Duration,
-) : ApplicationStateListener {
+) {
     @Volatile
     private var timeoutStartNanos: Long = 0
 
     @Volatile
-    private var state = State.FOREGROUND
+    private var state = State.ACTIVE
 
     // for testing
     @OptIn(Incubating::class)
@@ -41,17 +44,22 @@ internal class SessionIdTimeoutHandler(
         sessionConfig.backgroundInactivityTimeout,
     )
 
-    override fun onApplicationForegrounded() {
-        state = State.TRANSITIONING_TO_FOREGROUND
+    fun onUserActive() {
+        // Only leave the inactive state. The timeout is evaluated lazily on the next session id
+        // request, so the first telemetry item after the user becomes active can still start a
+        // new session when the inactivity timeout has elapsed.
+        if (state == State.INACTIVE) {
+            state = State.TRANSITIONING_TO_ACTIVE
+        }
     }
 
-    override fun onApplicationBackgrounded() {
-        state = State.BACKGROUND
+    fun onUserInactive() {
+        state = State.INACTIVE
     }
 
     fun hasTimedOut(): Boolean {
-        // don't apply sessionId timeout to apps in the foreground
-        if (state == State.FOREGROUND) {
+        // don't apply sessionId timeout while the user is active
+        if (state == State.ACTIVE) {
             return false
         }
         val elapsedTime = clock.nanoTime() - timeoutStartNanos
@@ -61,17 +69,17 @@ internal class SessionIdTimeoutHandler(
     fun bump() {
         timeoutStartNanos = clock.nanoTime()
 
-        // move from the temporary transition state to foreground after the first span
-        if (state == State.TRANSITIONING_TO_FOREGROUND) {
-            state = State.FOREGROUND
+        // move from the temporary transition state to active after the first span
+        if (state == State.TRANSITIONING_TO_ACTIVE) {
+            state = State.ACTIVE
         }
     }
 
     private enum class State {
-        FOREGROUND,
-        BACKGROUND,
+        ACTIVE,
+        INACTIVE,
 
-        /** A temporary state representing the first event after the app has been brought back.  */
-        TRANSITIONING_TO_FOREGROUND,
+        /** A temporary state representing the first event after the user became active again. */
+        TRANSITIONING_TO_ACTIVE,
     }
 }

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumBuilder.kt
@@ -16,6 +16,7 @@ import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.export.BufferDelegatingLogExporter
 import io.opentelemetry.android.export.BufferDelegatingMetricExporter
 import io.opentelemetry.android.export.BufferDelegatingSpanExporter
+import io.opentelemetry.android.extensions.ApiExtension
 import io.opentelemetry.android.features.diskbuffering.SignalFromDiskExporter
 import io.opentelemetry.android.features.diskbuffering.SignalFromDiskExporter.Companion.set
 import io.opentelemetry.android.features.diskbuffering.scheduler.DiskBufferingEnablement
@@ -109,6 +110,7 @@ class OpenTelemetryRumBuilder internal constructor(
         mutableListOf()
     private val instrumentations: MutableList<AndroidInstrumentation> =
         mutableListOf()
+    private val apiExtensions: MutableList<ApiExtension> = mutableListOf()
 
     val instrumentationLoader: AndroidInstrumentationLoader = AndroidInstrumentationLoaderImpl()
 
@@ -203,6 +205,15 @@ class OpenTelemetryRumBuilder internal constructor(
      */
     fun addInstrumentation(instrumentation: AndroidInstrumentation): OpenTelemetryRumBuilder {
         instrumentations.add(instrumentation)
+        return this
+    }
+
+    /**
+     * Registers an [ApiExtension] to be exposed through [OpenTelemetryRum.getExtension].
+     * See [SdkPreconfiguredRumBuilder.addApiExtension].
+     */
+    fun addApiExtension(extension: ApiExtension): OpenTelemetryRumBuilder {
+        apiExtensions.add(extension)
         return this
     }
 
@@ -409,6 +420,7 @@ class OpenTelemetryRumBuilder internal constructor(
             )
         }
         instrumentations.forEach(Consumer(delegate::addInstrumentation))
+        apiExtensions.forEach(Consumer(delegate::addApiExtension))
         return delegate.build()
     }
 

--- a/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumImpl.kt
+++ b/core/src/main/java/io/opentelemetry/android/OpenTelemetryRumImpl.kt
@@ -5,6 +5,8 @@
 
 package io.opentelemetry.android
 
+import io.opentelemetry.android.extensions.ApiExtension
+import io.opentelemetry.android.extensions.ApiExtensionRegistry
 import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
@@ -15,6 +17,7 @@ internal class OpenTelemetryRumImpl(
     override val openTelemetry: OpenTelemetry,
     override val sessionProvider: SessionProvider,
     override val clock: Clock,
+    private val apiExtensions: ApiExtensionRegistry,
 ) : OpenTelemetryRum {
     var onShutdown: Runnable = Runnable {}
     private val logger: Logger =
@@ -34,6 +37,8 @@ internal class OpenTelemetryRumImpl(
             .setAllAttributes(attributes)
             .emit()
     }
+
+    override fun <T : ApiExtension> getExtension(type: Class<T>): T? = apiExtensions.get(type)
 
     override fun shutdown() {
         onShutdown.run()

--- a/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
+++ b/core/src/main/java/io/opentelemetry/android/SdkPreconfiguredRumBuilder.kt
@@ -10,6 +10,9 @@ import android.content.Context
 import android.util.Log
 import io.opentelemetry.android.common.RumConstants
 import io.opentelemetry.android.config.OtelRumConfig
+import io.opentelemetry.android.extensions.ApiExtension
+import io.opentelemetry.android.extensions.ApiExtensionLoader
+import io.opentelemetry.android.extensions.ApiExtensionRegistry
 import io.opentelemetry.android.instrumentation.AndroidInstrumentation
 import io.opentelemetry.android.instrumentation.AndroidInstrumentationLoader
 import io.opentelemetry.android.instrumentation.InstrumentationConfigurators
@@ -27,6 +30,7 @@ class SdkPreconfiguredRumBuilder internal constructor(
 ) {
     private var onShutdown: Runnable = Runnable {} // nop
     private val instrumentations = mutableListOf<AndroidInstrumentation>()
+    private val apiExtensions = mutableListOf<ApiExtension>()
 
     /**
      * Adds an instrumentation to be applied as a part of the [build] method call.
@@ -35,6 +39,19 @@ class SdkPreconfiguredRumBuilder internal constructor(
      */
     fun addInstrumentation(instrumentation: AndroidInstrumentation): SdkPreconfiguredRumBuilder {
         instrumentations.add(instrumentation)
+        return this
+    }
+
+    /**
+     * Registers an [ApiExtension] to be exposed through [OpenTelemetryRum.getExtension]. Use this
+     * for extensions that wrap internals created during initialization, which therefore can't be
+     * discovered from the classpath. An extension registered here replaces a discovered extension
+     * of the same [ApiExtension.type].
+     *
+     * @return `this`
+     */
+    fun addApiExtension(extension: ApiExtension): SdkPreconfiguredRumBuilder {
+        apiExtensions.add(extension)
         return this
     }
 
@@ -67,6 +84,14 @@ class SdkPreconfiguredRumBuilder internal constructor(
         }
 
         val enabledInstrumentations = getEnabledInstrumentations()
+        // Extensions are resolved before instrumentations are installed so that instrumentations
+        // can obtain them from the OpenTelemetryRum instance they receive in install().
+        // TODO: add a dedicated config toggle to disable classpath discovery of extensions.
+        val apiExtensionRegistry =
+            ApiExtensionRegistry.create(
+                discovered = ApiExtensionLoader.load(),
+                registered = apiExtensions,
+            )
         val openTelemetryRum =
             OpenTelemetryRumImpl(
                 openTelemetry =
@@ -78,6 +103,7 @@ class SdkPreconfiguredRumBuilder internal constructor(
                     ),
                 sessionProvider = sessionProvider,
                 clock = clock,
+                apiExtensions = apiExtensionRegistry,
             )
         openTelemetryRum.onShutdown =
             Runnable {

--- a/core/src/main/java/io/opentelemetry/android/extensions/ApiExtensionLoader.kt
+++ b/core/src/main/java/io/opentelemetry/android/extensions/ApiExtensionLoader.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.extensions
+
+import java.util.ServiceLoader
+
+/**
+ * Discovers [ApiExtension] implementations declared via SPI (`@AutoService(ApiExtension::class)`).
+ */
+internal object ApiExtensionLoader {
+    /**
+     * See the R8 note on
+     * [io.opentelemetry.android.instrumentation.AndroidInstrumentationLoaderImpl.loadInstrumentations]
+     * before changing the shape of this function. The two-argument `load` overload, the literal
+     * class reference and the local for-each are required for R8 to replace the reflective lookup
+     * with direct instantiation.
+     */
+    fun load(): List<ApiExtension> {
+        val extensions = mutableListOf<ApiExtension>()
+        for (extension in ServiceLoader.load(ApiExtension::class.java, ApiExtension::class.java.classLoader)) {
+            extensions.add(extension)
+        }
+        return extensions
+    }
+}

--- a/core/src/main/java/io/opentelemetry/android/extensions/ApiExtensionRegistry.kt
+++ b/core/src/main/java/io/opentelemetry/android/extensions/ApiExtensionRegistry.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.extensions
+
+import android.util.Log
+import io.opentelemetry.android.common.RumConstants.OTEL_RUM_LOG_TAG
+
+/**
+ * The [ApiExtension] instances available to a single
+ * [io.opentelemetry.android.OpenTelemetryRum] instance, keyed by [ApiExtension.type].
+ */
+internal class ApiExtensionRegistry private constructor(
+    private val extensions: Map<Class<out ApiExtension>, ApiExtension>,
+) {
+    @Suppress("UNCHECKED_CAST")
+    fun <T : ApiExtension> get(type: Class<T>): T? = extensions[type] as? T
+
+    companion object {
+        /**
+         * Builds the registry from classpath-discovered extensions and explicitly registered ones.
+         * Explicitly registered extensions are applied last, so they replace a discovered extension
+         * of the same type.
+         */
+        fun create(
+            discovered: List<ApiExtension>,
+            registered: List<ApiExtension>,
+        ): ApiExtensionRegistry {
+            val result = mutableMapOf<Class<out ApiExtension>, ApiExtension>()
+            for (extension in discovered + registered) {
+                val previous = result.put(extension.type, extension)
+                if (previous != null) {
+                    Log.w(
+                        OTEL_RUM_LOG_TAG,
+                        "ApiExtension '${extension.type.name}' provided by '${previous.javaClass.name}' " +
+                            "was replaced by '${extension.javaClass.name}'.",
+                    )
+                }
+            }
+            return ApiExtensionRegistry(result)
+        }
+    }
+}


### PR DESCRIPTION
> PoC. Not to be merged.

A mechanism that allows extending `OpenTelemetryRum`'s APIs without having to change `OpenTelemetryRum` or make it aware of feature-specific use cases.

## Why

`OpenTelemetryRum` is the core of what this project configures and hands to users. `AndroidInstrumentation` covers the "generate telemetry automatically on my behalf" use case. There's a second use case it doesn't cover: things that cannot be inferred reliably for every app, where we should give users a manual API instead of guessing for them. Two examples:

- #910: apps need to tell the session manager whether the user is active or not. Foreground/background is a reasonable default, but it's wrong for apps that are still in use from a notification (media players, for instance).
- The "current screen" attribute. Today `ScreenAttributesSpanProcessor` takes the last resumed activity or fragment as the current screen, via `VisibleScreenTracker`. That's a guess, and it doesn't hold for every app (see also #1909 for Compose).

These APIs are not core to `OpenTelemetryRum`, so they don't belong in the interface. They are also owned by different modules, some of them optional. This PR adds a small mechanism so each module can expose its own manual API through the `OpenTelemetryRum` instance, the same way `AndroidInstrumentation` lets each module contribute automatic telemetry.

This is a scaffolding PR. It's meant to show the key parts and how they connect. It doesn't compile yet and tests haven't been updated.

## Key parts

### `agent-api`

- `ApiExtension`: the marker every extension implements. It has a single member, `type`, which is the public interface the extension is registered under and looked up by. The public contract of an extension is an interface extending `ApiExtension`. Implementations stay internal to the module that owns them.
- `OpenTelemetryRum.getExtension(type)`: returns the extension registered under `type`, or null when this instance doesn't have it. It has a default body returning null, so existing implementations of `OpenTelemetryRum` keep compiling (`agent-api` is stable).
- `OpenTelemetryRum.extension<T>()`: reified Kotlin shorthand for the above.

### `core`

- `ApiExtensionLoader`: discovers extensions on the classpath through `ServiceLoader`, same shape as `AndroidInstrumentationLoaderImpl` so R8 can still rewrite the lookup.
- `ApiExtensionRegistry`: the map of extensions available to one `OpenTelemetryRum` instance. Built from discovered extensions first, then explicitly registered ones. An explicit registration replaces a discovered extension of the same type, with a warning in the log.
- `OpenTelemetryRumBuilder.addApiExtension()` and `SdkPreconfiguredRumBuilder.addApiExtension()`: explicit registration. This is for extensions that wrap internals created during initialization, which can't be discovered from the classpath.
- `SdkPreconfiguredRumBuilder.build()` resolves the registry before instrumentations are installed, so any `AndroidInstrumentation` can grab an extension from the `OpenTelemetryRum` it receives in `install()`.

`core` doesn't know about any concrete extension, just like it doesn't know about concrete instrumentations.

### `android-agent` (proof of concept for #910)

- `SessionActivityApi`: public interface with `userActive()` and `userInactive()`, plus a `fun OpenTelemetryRum.sessions()` convenience accessor for Kotlin callers.
- `SessionActivityApiImpl`: internal facade over `SessionIdTimeoutHandler`. Registered explicitly in `OpenTelemetryRumInitializer` because the handler is created there.
- `SessionIdTimeoutHandler` no longer implements `ApplicationStateListener`. It exposes `onUserActive()` / `onUserInactive()` and its states are renamed to active/inactive. `onUserActive()` only leaves the inactive state, so the first telemetry item after the user becomes active can still start a new session if the timeout elapsed.
- The initializer keeps the default lifecycle based inference, but it now goes through the extension: a lifecycle listener calls `userActive()` on foreground and `userInactive()` on background.

## How it's expected to be used

From app code:

```kotlin
val rum = OpenTelemetryRumInitializer.initialize(this)

// Kotlin convenience accessor. Null when the extension isn't available in this instance.
rum.sessions()?.userInactive()

// Generic lookup, works for any extension.
rum.extension<SessionActivityApi>()?.userActive()
```

From an instrumentation:

```kotlin
override fun install(context: Context, openTelemetryRum: OpenTelemetryRum) {
    val sessions = openTelemetryRum.extension<SessionActivityApi>()
    // ...call sessions?.userActive() when this instrumentation infers activity.
}
```

Defining an extension in a module:

```kotlin
// Public contract.
interface ScreenApi : ApiExtension {
    override val type: Class<out ApiExtension> get() = ScreenApi::class.java
    fun setCurrentScreen(name: String)
}

// Internal implementation. Either registered explicitly through the builder, or
// annotated with @AutoService(ApiExtension::class) if it doesn't need anything from initialization.
internal class ScreenApiImpl : ScreenApi { ... }

// Optional Kotlin convenience accessor.
fun OpenTelemetryRum.screens(): ScreenApi? = getExtension(ScreenApi::class.java)
```

## Rules the mechanism relies on

- An extension is a pure facade over its module's internals. No lifecycle, nothing to shut down.
- An extension is the single source of truth for what it controls. Automatic instrumentations that infer the same information write through the extension too. Last write wins. The sessions PoC follows this: the lifecycle listener and the app both write through `SessionActivityApi`.
- When both a discovered and an explicitly registered extension exist for the same type, the explicit one wins.
- Lookups return null when the extension isn't available, for example when using `RumBuilder` directly without the module that provides it.

## Not in this PR

- A config toggle to disable classpath discovery of extensions (separate from the instrumentation one).
- The screen API. Where it lives is still to be decided, possibly a new shared module.
- Test updates. `SessionIdTimeoutHandler` tests still reference the old lifecycle callbacks, and any test constructing `OpenTelemetryRumImpl` directly needs the new registry argument.
- `apiDump` for `agent-api`, `core` and `android-agent`.

## Open for discussion

- Naming: `ApiExtension` and `getExtension()` vs something that doesn't collide with Kotlin extension functions.
- Whether `SessionActivityApi` belongs in `android-agent` or in `session`.
- Anything else I might've missed.
