### PR TITLE
Add a session provider API to the DSL

### DIFF
--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -83,9 +83,11 @@ public final class io/opentelemetry/android/agent/dsl/SemanticConventionsConfigu
 public final class io/opentelemetry/android/agent/dsl/SessionConfiguration {
 	public final fun getBackgroundInactivityTimeout-UwyO8pc ()J
 	public final fun getMaxLifetime-UwyO8pc ()J
+	public final fun getProvider ()Lio/opentelemetry/android/session/SessionProvider;
 	public final fun observers ([Lio/opentelemetry/android/session/SessionObserver;)V
 	public final fun setBackgroundInactivityTimeout-LRDsOJo (J)V
 	public final fun setMaxLifetime-LRDsOJo (J)V
+	public final fun setProvider (Lio/opentelemetry/android/session/SessionProvider;)V
 }
 
 public final class io/opentelemetry/android/agent/dsl/instrumentation/ActivityLifecycleConfiguration : io/opentelemetry/android/agent/dsl/instrumentation/CanBeEnabledAndDisabled, io/opentelemetry/android/agent/dsl/instrumentation/ScreenLifecycleConfigurable {

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
@@ -21,6 +21,7 @@ import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.internal.services.Services
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle
 import io.opentelemetry.android.session.SessionProvider
+import io.opentelemetry.android.session.SessionPublisher
 import io.opentelemetry.exporter.otlp.http.logs.OtlpHttpLogRecordExporter
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter
 import io.opentelemetry.exporter.otlp.http.trace.OtlpHttpSpanExporter
@@ -148,6 +149,17 @@ object OpenTelemetryRumInitializer {
         appLifecycle: AppLifecycle,
         cfg: OpenTelemetryConfiguration,
     ): SessionProvider {
+        val provider = cfg.sessionConfig.provider ?: createSessionManager(appLifecycle, cfg)
+        if (provider is SessionPublisher) {
+            cfg.sessionConfig.getObservers().forEach { provider.addObserver(it) }
+        }
+        return provider
+    }
+
+    private fun createSessionManager(
+        appLifecycle: AppLifecycle,
+        cfg: OpenTelemetryConfiguration,
+    ): SessionManager {
         val sessionConfig =
             SessionConfig(
                 cfg.sessionConfig.backgroundInactivityTimeout,
@@ -156,8 +168,6 @@ object OpenTelemetryRumInitializer {
         val clock = cfg.clock
         val timeoutHandler = SessionIdTimeoutHandler(sessionConfig, clock)
         appLifecycle.registerListener(timeoutHandler)
-        val sessionManager = SessionManager.create(timeoutHandler, sessionConfig, clock)
-        cfg.sessionConfig.getObservers().forEach { sessionManager.addObserver(it) }
-        return sessionManager
+        return SessionManager.create(timeoutHandler, sessionConfig, clock)
     }
 }

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/SessionConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/SessionConfiguration.kt
@@ -6,6 +6,8 @@
 package io.opentelemetry.android.agent.dsl
 
 import io.opentelemetry.android.session.SessionObserver
+import io.opentelemetry.android.session.SessionProvider
+import io.opentelemetry.android.session.SessionPublisher
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
@@ -25,6 +27,14 @@ class SessionConfiguration internal constructor() {
      * The maximum duration which a session can remain open before it automatically expires.
      */
     var maxLifetime: Duration = 4.hours
+
+    /**
+     * A custom [SessionProvider] that controls the session ID. When this is set
+     * [backgroundInactivityTimeout] and [maxLifetime] have no effect
+     * and the supplied provider owns the session lifecycle entirely. Any [observers] are registered
+     * on the supplied provider only if it also implements [SessionPublisher].
+     */
+    var provider: SessionProvider? = null
 
     private var observersList: MutableList<SessionObserver> = mutableListOf()
 

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
@@ -16,6 +16,9 @@ import io.opentelemetry.android.agent.session.SessionIdTimeoutHandler
 import io.opentelemetry.android.internal.services.Services
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle
 import io.opentelemetry.android.session.SessionObserver
+import io.opentelemetry.android.session.SessionProvider
+import io.opentelemetry.android.session.SessionPublisher
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -82,6 +85,86 @@ class OpenTelemetryRumInitializerTest {
         verify {
             o1.onSessionStarted(any(), any())
             o2.onSessionStarted(any(), any())
+        }
+    }
+
+    @Test
+    fun `Verify a custom session provider is used`() {
+        val rum =
+            OpenTelemetryRumInitializer.initialize(
+                context = RuntimeEnvironment.getApplication(),
+                configuration = {
+                    httpExport {
+                        baseUrl = "http://127.0.0.1:4318"
+                    }
+                    session {
+                        provider = SessionProvider { "custom-session-id" }
+                    }
+                },
+            )
+        rum.shutdown()
+
+        assertThat(rum.sessionProvider.getSessionId()).isEqualTo("custom-session-id")
+        verify(exactly = 0) {
+            appLifecycle.registerListener(any<SessionIdTimeoutHandler>())
+        }
+    }
+
+    @Test
+    fun `Verify session observers are applied to a custom session publisher`() {
+        val observer: SessionObserver = mockk()
+        val provider = FakeSessionPublisher()
+
+        OpenTelemetryRumInitializer
+            .initialize(
+                context = RuntimeEnvironment.getApplication(),
+                configuration = {
+                    httpExport {
+                        baseUrl = "http://127.0.0.1:4318"
+                    }
+                    session {
+                        this.provider = provider
+                        observers(observer)
+                    }
+                },
+            ).shutdown()
+        assertThat(provider.observers).contains(observer)
+    }
+
+    @Test
+    fun `Verify session observers are ignored by a custom session provider that cannot publish`() {
+        val observer: SessionObserver = mockk()
+
+        val rum =
+            OpenTelemetryRumInitializer.initialize(
+                context = RuntimeEnvironment.getApplication(),
+                configuration = {
+                    httpExport {
+                        baseUrl = "http://127.0.0.1:4318"
+                    }
+                    session {
+                        provider = SessionProvider { "custom-session-id" }
+                        observers(observer)
+                    }
+                },
+            )
+        rum.shutdown()
+
+        assertThat(rum.sessionProvider.getSessionId()).isEqualTo("custom-session-id")
+        verify(exactly = 0) {
+            observer.onSessionStarted(any(), any())
+        }
+    }
+
+    private class FakeSessionPublisher :
+        SessionProvider,
+        SessionPublisher {
+        val observers = mutableListOf<SessionObserver>()
+
+        override fun getSessionId(): String = "custom-session-id"
+
+        override fun addObserver(observer: SessionObserver) {
+            observers.add(observer)
         }
     }
 

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/SessionConfigurationTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/SessionConfigurationTest.kt
@@ -9,6 +9,7 @@ import io.mockk.mockk
 import io.opentelemetry.android.agent.FakeClock
 import io.opentelemetry.android.agent.FakeInstrumentationLoader
 import io.opentelemetry.android.session.SessionObserver
+import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -32,6 +33,7 @@ internal class SessionConfigurationTest {
     fun testDefaults() {
         assertEquals(15.minutes, otelConfig.sessionConfig.backgroundInactivityTimeout)
         assertEquals(4.hours, otelConfig.sessionConfig.maxLifetime)
+        assertThat(otelConfig.sessionConfig.provider).isNull()
     }
 
     @Test
@@ -47,6 +49,18 @@ internal class SessionConfigurationTest {
             }
         assertEquals(customTimeout, otelConfig.sessionConfig.backgroundInactivityTimeout)
         assertEquals(customLifetime, otelConfig.sessionConfig.maxLifetime)
+    }
+
+    @Test
+    fun `can set a custom session provider`() {
+        val provider = SessionProvider { "custom-session-id" }
+        val otelConfig =
+            otelConfig.apply {
+                session {
+                    this.provider = provider
+                }
+            }
+        assertThat(otelConfig.sessionConfig.provider).isSameAs(provider)
     }
 
     @Test


### PR DESCRIPTION
Fixes #2044 by adding an API to the DSL that allows a `SessionProvider` to be specified. This grants parity with the session APIs that are available in the core module.