### PR TITLE
Add DSL for configuring disk buffering

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ private fun initOTel(context: Context): OpenTelemetryRum? =
                     backgroundInactivityTimeout = 5.minutes
                     maxLifetime = 1.days
                 }
+                diskBuffering {
+                    enabled(true)
+                    maxCacheSize = 5 * 1024 * 1024
+                    exportPeriod = 30.seconds
+                }
                 globalAttributes {
                     Attributes.of(stringKey("demo-version"), "test")
                 }

--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -30,18 +30,10 @@ public final class io/opentelemetry/android/agent/connectivity/SSLContextConnect
 public final class io/opentelemetry/android/agent/dsl/DiskBufferingConfigurationSpec : io/opentelemetry/android/agent/dsl/instrumentation/CanBeEnabledAndDisabled {
 	public fun enabled (Z)V
 	public final fun getExportPeriod-UwyO8pc ()J
-	public final fun getMaxCacheFileSize ()I
 	public final fun getMaxCacheSize ()I
-	public final fun getMaxFileAgeForRead-UwyO8pc ()J
-	public final fun getMaxFileAgeForWrite-UwyO8pc ()J
-	public final fun getMinFileAgeForRead-UwyO8pc ()J
 	public final fun getSignalsBufferDir ()Ljava/io/File;
 	public final fun setExportPeriod-LRDsOJo (J)V
-	public final fun setMaxCacheFileSize (I)V
 	public final fun setMaxCacheSize (I)V
-	public final fun setMaxFileAgeForRead-LRDsOJo (J)V
-	public final fun setMaxFileAgeForWrite-LRDsOJo (J)V
-	public final fun setMinFileAgeForRead-LRDsOJo (J)V
 	public final fun setSignalsBufferDir (Ljava/io/File;)V
 }
 

--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -29,6 +29,20 @@ public final class io/opentelemetry/android/agent/connectivity/SSLContextConnect
 
 public final class io/opentelemetry/android/agent/dsl/DiskBufferingConfigurationSpec : io/opentelemetry/android/agent/dsl/instrumentation/CanBeEnabledAndDisabled {
 	public fun enabled (Z)V
+	public final fun getExportPeriod-UwyO8pc ()J
+	public final fun getMaxCacheFileSize ()I
+	public final fun getMaxCacheSize ()I
+	public final fun getMaxFileAgeForRead-UwyO8pc ()J
+	public final fun getMaxFileAgeForWrite-UwyO8pc ()J
+	public final fun getMinFileAgeForRead-UwyO8pc ()J
+	public final fun getSignalsBufferDir ()Ljava/io/File;
+	public final fun setExportPeriod-LRDsOJo (J)V
+	public final fun setMaxCacheFileSize (I)V
+	public final fun setMaxCacheSize (I)V
+	public final fun setMaxFileAgeForRead-LRDsOJo (J)V
+	public final fun setMaxFileAgeForWrite-LRDsOJo (J)V
+	public final fun setMinFileAgeForRead-LRDsOJo (J)V
+	public final fun setSignalsBufferDir (Ljava/io/File;)V
 }
 
 public final class io/opentelemetry/android/agent/dsl/EndpointConfiguration {

--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -31,10 +31,10 @@ public final class io/opentelemetry/android/agent/dsl/DiskBufferingConfiguration
 	public fun enabled (Z)V
 	public final fun getExportPeriod-UwyO8pc ()J
 	public final fun getMaxCacheSize ()I
-	public final fun getSignalsBufferDir ()Ljava/io/File;
+	public final fun getTelemetryStorageDir ()Ljava/io/File;
 	public final fun setExportPeriod-LRDsOJo (J)V
 	public final fun setMaxCacheSize (I)V
-	public final fun setSignalsBufferDir (Ljava/io/File;)V
+	public final fun setTelemetryStorageDir (Ljava/io/File;)V
 }
 
 public final class io/opentelemetry/android/agent/dsl/EndpointConfiguration {

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
@@ -63,6 +63,7 @@ object OpenTelemetryRumInitializer {
                         rumConfig = rumConfig,
                         instrumentationLoader = instrumentationLoader,
                     ).also(configuration)
+                cfg.diskBufferingConfig.applyToRumConfig()
 
                 setSessionProvider(createSessionProvider(Services.get(ctx).appLifecycle, cfg))
                 setResource(

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/DiskBufferingConfigurationSpec.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/DiskBufferingConfigurationSpec.kt
@@ -9,10 +9,8 @@ import io.opentelemetry.android.agent.dsl.instrumentation.CanBeEnabledAndDisable
 import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.features.diskbuffering.DEFAULT_MAX_CACHE_SIZE
 import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig
-import io.opentelemetry.android.features.diskbuffering.MAX_CACHE_FILE_SIZE
 import java.io.File
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.seconds
 
 /**
@@ -28,27 +26,6 @@ class DiskBufferingConfigurationSpec internal constructor(
      * The maximum amount of disk space, in bytes, that buffered telemetry may occupy.
      */
     var maxCacheSize: Int = DEFAULT_MAX_CACHE_SIZE
-
-    /**
-     * The maximum size, in bytes, of a single buffer file.
-     */
-    var maxCacheFileSize: Int = MAX_CACHE_FILE_SIZE
-
-    /**
-     * The age at which a buffer file stops being appended to and a new one is started. Must be
-     * shorter than [minFileAgeForRead].
-     */
-    var maxFileAgeForWrite: Duration = 30.seconds
-
-    /**
-     * The minimum age a buffer file must reach before it’s eligible for export.
-     */
-    var minFileAgeForRead: Duration = 33.seconds
-
-    /**
-     * The age at which a buffer file is considered stale and is discarded without being exported.
-     */
-    var maxFileAgeForRead: Duration = 18.hours
 
     /**
      * How often buffered telemetry is read back from disk and exported. Must be greater than zero.
@@ -77,10 +54,6 @@ class DiskBufferingConfigurationSpec internal constructor(
             DiskBufferingConfig.create(
                 enabled = enabled,
                 maxCacheSize = maxCacheSize,
-                maxFileAgeForWriteMillis = maxFileAgeForWrite.inWholeMilliseconds,
-                minFileAgeForReadMillis = minFileAgeForRead.inWholeMilliseconds,
-                maxFileAgeForReadMillis = maxFileAgeForRead.inWholeMilliseconds,
-                maxCacheFileSize = maxCacheFileSize,
                 signalsBufferDir = signalsBufferDir,
                 exportPeriodMillis = exportPeriod.inWholeMilliseconds,
             ),

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/DiskBufferingConfigurationSpec.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/DiskBufferingConfigurationSpec.kt
@@ -41,8 +41,7 @@ class DiskBufferingConfigurationSpec internal constructor(
     var maxFileAgeForWrite: Duration = 30.seconds
 
     /**
-     * The minimum age a buffer file must reach before its eligible for
-     * export.
+     * The minimum age a buffer file must reach before it’s eligible for export.
      */
     var minFileAgeForRead: Duration = 33.seconds
 

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/DiskBufferingConfigurationSpec.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/DiskBufferingConfigurationSpec.kt
@@ -7,7 +7,13 @@ package io.opentelemetry.android.agent.dsl
 
 import io.opentelemetry.android.agent.dsl.instrumentation.CanBeEnabledAndDisabled
 import io.opentelemetry.android.config.OtelRumConfig
+import io.opentelemetry.android.features.diskbuffering.DEFAULT_MAX_CACHE_SIZE
 import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig
+import io.opentelemetry.android.features.diskbuffering.MAX_CACHE_FILE_SIZE
+import java.io.File
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Type-safe config DSL that controls how disk buffering of exported telemetry should behave.
@@ -17,16 +23,68 @@ class DiskBufferingConfigurationSpec internal constructor(
     private val rumConfig: OtelRumConfig,
 ) : CanBeEnabledAndDisabled {
     internal var enabled: Boolean = true
-        set(value) {
-            field = value
-            rumConfig.setDiskBufferingConfig(DiskBufferingConfig.create(enabled = value))
-        }
+
+    /**
+     * The maximum amount of disk space, in bytes, that buffered telemetry may occupy.
+     */
+    var maxCacheSize: Int = DEFAULT_MAX_CACHE_SIZE
+
+    /**
+     * The maximum size, in bytes, of a single buffer file.
+     */
+    var maxCacheFileSize: Int = MAX_CACHE_FILE_SIZE
+
+    /**
+     * The age at which a buffer file stops being appended to and a new one is started. Must be
+     * shorter than [minFileAgeForRead].
+     */
+    var maxFileAgeForWrite: Duration = 30.seconds
+
+    /**
+     * The minimum age a buffer file must reach before its eligible for
+     * export.
+     */
+    var minFileAgeForRead: Duration = 33.seconds
+
+    /**
+     * The age at which a buffer file is considered stale and is discarded without being exported.
+     */
+    var maxFileAgeForRead: Duration = 18.hours
+
+    /**
+     * How often buffered telemetry is read back from disk and exported. Must be greater than zero.
+     */
+    var exportPeriod: Duration = 10.seconds
+
+    /**
+     * The directory in which buffered telemetry is stored until it is exported. By default
+     * the application's cache directory is used.
+     */
+    var signalsBufferDir: File? = null
 
     init {
-        rumConfig.setDiskBufferingConfig(DiskBufferingConfig.create(enabled))
+        applyToRumConfig()
     }
 
     override fun enabled(enabled: Boolean) {
         this.enabled = enabled
+    }
+
+    /**
+     * Builds a complete [DiskBufferingConfig] from the current state
+     */
+    internal fun applyToRumConfig() {
+        rumConfig.setDiskBufferingConfig(
+            DiskBufferingConfig.create(
+                enabled = enabled,
+                maxCacheSize = maxCacheSize,
+                maxFileAgeForWriteMillis = maxFileAgeForWrite.inWholeMilliseconds,
+                minFileAgeForReadMillis = minFileAgeForRead.inWholeMilliseconds,
+                maxFileAgeForReadMillis = maxFileAgeForRead.inWholeMilliseconds,
+                maxCacheFileSize = maxCacheFileSize,
+                signalsBufferDir = signalsBufferDir,
+                exportPeriodMillis = exportPeriod.inWholeMilliseconds,
+            ),
+        )
     }
 }

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/DiskBufferingConfigurationSpec.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/DiskBufferingConfigurationSpec.kt
@@ -24,6 +24,9 @@ class DiskBufferingConfigurationSpec internal constructor(
 
     /**
      * The maximum amount of disk space, in bytes, that buffered telemetry may occupy.
+     *
+     * This budget is split evenly three ways, so spans, logs, and metrics each get a third of
+     * the value set here, regardless of which signals the application actually emits.
      */
     var maxCacheSize: Int = DEFAULT_MAX_CACHE_SIZE
 
@@ -33,10 +36,11 @@ class DiskBufferingConfigurationSpec internal constructor(
     var exportPeriod: Duration = 10.seconds
 
     /**
-     * The directory in which buffered telemetry is stored until it is exported. By default
-     * the application's cache directory is used.
+     * The root directory in which buffered telemetry is stored until it is exported. Each signal
+     * type is stored in its own subdirectory of this location, as a directory may only hold one
+     * of spans, logs, or metrics. By default the application's cache directory is used.
      */
-    var signalsBufferDir: File? = null
+    var telemetryStorageDir: File? = null
 
     init {
         applyToRumConfig()
@@ -54,7 +58,7 @@ class DiskBufferingConfigurationSpec internal constructor(
             DiskBufferingConfig.create(
                 enabled = enabled,
                 maxCacheSize = maxCacheSize,
-                signalsBufferDir = signalsBufferDir,
+                signalsBufferDir = telemetryStorageDir,
                 exportPeriodMillis = exportPeriod.inWholeMilliseconds,
             ),
         )

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/OpenTelemetryConfiguration.kt
@@ -105,6 +105,7 @@ class OpenTelemetryConfiguration internal constructor(
      */
     fun diskBuffering(action: DiskBufferingConfigurationSpec.() -> Unit) {
         diskBufferingConfig.action()
+        diskBufferingConfig.applyToRumConfig()
     }
 
     /**

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/DiskBufferingConfigTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/DiskBufferingConfigTest.kt
@@ -13,9 +13,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.File
-import kotlin.time.Duration.Companion.days
-import kotlin.time.Duration.Companion.hours
-import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 class DiskBufferingConfigTest {
@@ -46,10 +43,6 @@ class DiskBufferingConfigTest {
     fun `dsl exposes the core defaults`() {
         val spec = otelConfig.diskBufferingConfig
         assertThat(spec.maxCacheSize).isEqualTo(10 * 1024 * 1024)
-        assertThat(spec.maxCacheFileSize).isEqualTo(1024 * 1024)
-        assertThat(spec.maxFileAgeForWrite).isEqualTo(30.seconds)
-        assertThat(spec.minFileAgeForRead).isEqualTo(33.seconds)
-        assertThat(spec.maxFileAgeForRead).isEqualTo(18.hours)
         assertThat(spec.exportPeriod).isEqualTo(10.seconds)
         assertThat(spec.signalsBufferDir).isNull()
     }
@@ -69,10 +62,6 @@ class DiskBufferingConfigTest {
         otelConfig.diskBuffering {
             enabled(true)
             maxCacheSize = 5 * 1024 * 1024
-            maxCacheFileSize = 512 * 1024
-            maxFileAgeForWrite = 1.minutes
-            minFileAgeForRead = 2.minutes
-            maxFileAgeForRead = 1.days
             exportPeriod = 30.seconds
             signalsBufferDir = bufferDir
         }
@@ -82,26 +71,10 @@ class DiskBufferingConfigTest {
                 DiskBufferingConfig.create(
                     enabled = true,
                     maxCacheSize = 5 * 1024 * 1024,
-                    maxFileAgeForWriteMillis = 60_000,
-                    minFileAgeForReadMillis = 120_000,
-                    maxFileAgeForReadMillis = 86_400_000,
-                    maxCacheFileSize = 512 * 1024,
                     signalsBufferDir = bufferDir,
                     exportPeriodMillis = 30_000,
                 ),
             )
-    }
-
-    @Test
-    fun `does not validate intermediate state within a block`() {
-        otelConfig.diskBuffering {
-            maxFileAgeForWrite = 60.seconds
-            minFileAgeForRead = 90.seconds
-        }
-
-        val config = otelConfig.rumConfig.getDiskBufferingConfig()
-        assertThat(config.maxFileAgeForWriteMillis).isEqualTo(60_000)
-        assertThat(config.minFileAgeForReadMillis).isEqualTo(90_000)
     }
 
     @Test

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/DiskBufferingConfigTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/DiskBufferingConfigTest.kt
@@ -9,15 +9,19 @@ import io.opentelemetry.android.agent.FakeClock
 import io.opentelemetry.android.agent.FakeInstrumentationLoader
 import io.opentelemetry.android.config.OtelRumConfig
 import io.opentelemetry.android.features.diskbuffering.DiskBufferingConfig
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
-import org.junit.Before
-import org.junit.Test
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 class DiskBufferingConfigTest {
     private lateinit var otelConfig: OpenTelemetryConfiguration
 
-    @Before
+    @BeforeEach
     fun setUp() {
         otelConfig =
             OpenTelemetryConfiguration(
@@ -28,8 +32,26 @@ class DiskBufferingConfigTest {
 
     @Test
     fun testDefaults() {
-        assertTrue(otelConfig.diskBufferingConfig.enabled)
-        assertTrue(otelConfig.rumConfig.getDiskBufferingConfig().enabled)
+        assertThat(otelConfig.diskBufferingConfig.enabled).isTrue()
+        assertThat(otelConfig.rumConfig.getDiskBufferingConfig().enabled).isTrue()
+    }
+
+    @Test
+    fun `dsl defaults match the core defaults`() {
+        assertThat(otelConfig.rumConfig.getDiskBufferingConfig())
+            .isEqualTo(DiskBufferingConfig.create(enabled = true))
+    }
+
+    @Test
+    fun `dsl exposes the core defaults`() {
+        val spec = otelConfig.diskBufferingConfig
+        assertThat(spec.maxCacheSize).isEqualTo(10 * 1024 * 1024)
+        assertThat(spec.maxCacheFileSize).isEqualTo(1024 * 1024)
+        assertThat(spec.maxFileAgeForWrite).isEqualTo(30.seconds)
+        assertThat(spec.minFileAgeForRead).isEqualTo(33.seconds)
+        assertThat(spec.maxFileAgeForRead).isEqualTo(18.hours)
+        assertThat(spec.exportPeriod).isEqualTo(10.seconds)
+        assertThat(spec.signalsBufferDir).isNull()
     }
 
     @Test
@@ -37,8 +59,63 @@ class DiskBufferingConfigTest {
         otelConfig.diskBuffering {
             enabled(false)
         }
-        assertFalse(otelConfig.diskBufferingConfig.enabled)
-        assertFalse(otelConfig.rumConfig.getDiskBufferingConfig().enabled)
+        assertThat(otelConfig.diskBufferingConfig.enabled).isFalse()
+        assertThat(otelConfig.rumConfig.getDiskBufferingConfig().enabled).isFalse()
+    }
+
+    @Test
+    fun `applies every option to the rum config`() {
+        val bufferDir = File("/tmp/otel-signals")
+        otelConfig.diskBuffering {
+            enabled(true)
+            maxCacheSize = 5 * 1024 * 1024
+            maxCacheFileSize = 512 * 1024
+            maxFileAgeForWrite = 1.minutes
+            minFileAgeForRead = 2.minutes
+            maxFileAgeForRead = 1.days
+            exportPeriod = 30.seconds
+            signalsBufferDir = bufferDir
+        }
+
+        assertThat(otelConfig.rumConfig.getDiskBufferingConfig())
+            .isEqualTo(
+                DiskBufferingConfig.create(
+                    enabled = true,
+                    maxCacheSize = 5 * 1024 * 1024,
+                    maxFileAgeForWriteMillis = 60_000,
+                    minFileAgeForReadMillis = 120_000,
+                    maxFileAgeForReadMillis = 86_400_000,
+                    maxCacheFileSize = 512 * 1024,
+                    signalsBufferDir = bufferDir,
+                    exportPeriodMillis = 30_000,
+                ),
+            )
+    }
+
+    @Test
+    fun `does not validate intermediate state within a block`() {
+        otelConfig.diskBuffering {
+            maxFileAgeForWrite = 60.seconds
+            minFileAgeForRead = 90.seconds
+        }
+
+        val config = otelConfig.rumConfig.getDiskBufferingConfig()
+        assertThat(config.maxFileAgeForWriteMillis).isEqualTo(60_000)
+        assertThat(config.minFileAgeForReadMillis).isEqualTo(90_000)
+    }
+
+    @Test
+    fun `re-entering the block keeps previously configured values`() {
+        otelConfig.diskBuffering {
+            maxCacheSize = 2048
+        }
+        otelConfig.diskBuffering {
+            exportPeriod = 5.seconds
+        }
+
+        val config = otelConfig.rumConfig.getDiskBufferingConfig()
+        assertThat(config.maxCacheSize).isEqualTo(2048)
+        assertThat(config.exportPeriodMillis).isEqualTo(5_000)
     }
 
     @Test
@@ -55,7 +132,7 @@ class DiskBufferingConfigTest {
                 instrumentationLoader = FakeInstrumentationLoader(),
                 clock = FakeClock(),
             )
-        assertTrue(otelConfig.diskBufferingConfig.enabled)
-        assertTrue(otelConfig.rumConfig.getDiskBufferingConfig().enabled)
+        assertThat(otelConfig.diskBufferingConfig.enabled).isTrue()
+        assertThat(otelConfig.rumConfig.getDiskBufferingConfig().enabled).isTrue()
     }
 }

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/DiskBufferingConfigTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/DiskBufferingConfigTest.kt
@@ -44,7 +44,7 @@ class DiskBufferingConfigTest {
         val spec = otelConfig.diskBufferingConfig
         assertThat(spec.maxCacheSize).isEqualTo(10 * 1024 * 1024)
         assertThat(spec.exportPeriod).isEqualTo(10.seconds)
-        assertThat(spec.signalsBufferDir).isNull()
+        assertThat(spec.telemetryStorageDir).isNull()
     }
 
     @Test
@@ -63,7 +63,7 @@ class DiskBufferingConfigTest {
             enabled(true)
             maxCacheSize = 5 * 1024 * 1024
             exportPeriod = 30.seconds
-            signalsBufferDir = bufferDir
+            telemetryStorageDir = bufferDir
         }
 
         assertThat(otelConfig.rumConfig.getDiskBufferingConfig())

--- a/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfig.kt
+++ b/core/src/main/java/io/opentelemetry/android/features/diskbuffering/DiskBufferingConfig.kt
@@ -26,6 +26,7 @@ data class DiskBufferingConfig
         val minFileAgeForReadMillis: Long = TimeUnit.SECONDS.toMillis(DEFAULT_MIN_FILE_AGE_FOR_READ_MS),
         val maxFileAgeForReadMillis: Long = TimeUnit.HOURS.toMillis(DEFAULT_MAX_FILE_AGE_FOR_READ_MS),
         val maxCacheFileSize: Int = MAX_CACHE_FILE_SIZE,
+        @Deprecated("This option has no effect and will be removed in a future release.")
         val debugEnabled: Boolean = false,
         /**
          * The directory where the SDK stores the buffered signals before they are exported. If


### PR DESCRIPTION
Closes #2041 by adding a DSL that allows library consumers to configure disk buffering. This adds important functionality that is currently available in the core module (specifying the export period, storage location, and max cache size).