### PR TITLE
feat(session): allow custom storage in the DSL

### DIFF
--- a/android-agent/api/android-agent.api
+++ b/android-agent/api/android-agent.api
@@ -86,6 +86,7 @@ public final class io/opentelemetry/android/agent/dsl/SessionConfiguration {
 	public final fun observers ([Lio/opentelemetry/android/session/SessionObserver;)V
 	public final fun setBackgroundInactivityTimeout-LRDsOJo (J)V
 	public final fun setMaxLifetime-LRDsOJo (J)V
+	public final fun storage (Lio/opentelemetry/android/agent/session/SessionStorage;)V
 }
 
 public final class io/opentelemetry/android/agent/dsl/instrumentation/ActivityLifecycleConfiguration : io/opentelemetry/android/agent/dsl/instrumentation/CanBeEnabledAndDisabled, io/opentelemetry/android/agent/dsl/instrumentation/ScreenLifecycleConfigurable {
@@ -135,5 +136,10 @@ public final class io/opentelemetry/android/agent/dsl/instrumentation/SlowRender
 	public final fun detectionPollInterval-LRDsOJo (J)V
 	public final fun enableVerboseDebugLogging ()V
 	public fun enabled (Z)V
+}
+
+public abstract interface class io/opentelemetry/android/agent/session/SessionStorage {
+	public abstract fun get ()Lio/opentelemetry/android/session/Session;
+	public abstract fun save (Lio/opentelemetry/android/session/Session;)V
 }
 

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializer.kt
@@ -156,7 +156,7 @@ object OpenTelemetryRumInitializer {
         val clock = cfg.clock
         val timeoutHandler = SessionIdTimeoutHandler(sessionConfig, clock)
         appLifecycle.registerListener(timeoutHandler)
-        val sessionManager = SessionManager.create(timeoutHandler, sessionConfig, clock)
+        val sessionManager = SessionManager.create(timeoutHandler, sessionConfig, clock, cfg.sessionConfig.sessionStorage)
         cfg.sessionConfig.getObservers().forEach { sessionManager.addObserver(it) }
         return sessionManager
     }

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/SessionConfiguration.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/dsl/SessionConfiguration.kt
@@ -5,6 +5,9 @@
 
 package io.opentelemetry.android.agent.dsl
 
+import io.opentelemetry.android.Incubating
+import io.opentelemetry.android.agent.session.InMemorySessionStorage
+import io.opentelemetry.android.agent.session.SessionStorage
 import io.opentelemetry.android.session.SessionObserver
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
@@ -14,6 +17,7 @@ import kotlin.time.Duration.Companion.minutes
  * Type-safe config DSL that controls how sessions should behave.
  */
 @OpenTelemetryDslMarker
+@OptIn(Incubating::class)
 class SessionConfiguration internal constructor() {
     /**
      * The maximum duration which a session can remain open in the background before it
@@ -25,6 +29,19 @@ class SessionConfiguration internal constructor() {
      * The maximum duration which a session can remain open before it automatically expires.
      */
     var maxLifetime: Duration = 4.hours
+
+    internal var sessionStorage: SessionStorage = InMemorySessionStorage()
+        private set
+
+    /**
+     * Replaces the default in-memory storage without changing session generation, expiry, or
+     * observers. This does not restore sessions across launches; see [SessionStorage] for the
+     * startup and failure contract. If called more than once, the last storage supplied is used.
+     */
+    @Incubating
+    fun storage(storage: SessionStorage) {
+        sessionStorage = storage
+    }
 
     private var observersList: MutableList<SessionObserver> = mutableListOf()
 

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/InMemorySessionStorage.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/InMemorySessionStorage.kt
@@ -5,8 +5,10 @@
 
 package io.opentelemetry.android.agent.session
 
+import io.opentelemetry.android.Incubating
 import io.opentelemetry.android.session.Session
 
+@OptIn(Incubating::class)
 internal class InMemorySessionStorage(
     @Volatile var session: Session = invalidSession,
 ) : SessionStorage {

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionManager.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionManager.kt
@@ -12,7 +12,6 @@ import io.opentelemetry.android.session.SessionProvider
 import io.opentelemetry.android.session.SessionPublisher
 import io.opentelemetry.sdk.common.Clock
 import java.util.concurrent.CopyOnWriteArrayList
-import java.util.concurrent.atomic.AtomicReference
 import kotlin.random.Random
 import kotlin.time.Duration
 
@@ -25,45 +24,35 @@ internal class SessionManager(
     private val maxSessionLifetime: Duration,
 ) : SessionProvider,
     SessionPublisher {
-    private val session: AtomicReference<Session> = AtomicReference(invalidSession)
+    private val lock = Any()
+    private var session: Session = invalidSession
     private val observers = CopyOnWriteArrayList<SessionObserver>()
 
     init {
-        sessionStorage.save(session.get())
+        sessionStorage.save(session)
     }
 
     override fun addObserver(observer: SessionObserver) {
         observers.add(observer)
     }
 
-    override fun getSessionId(): String {
-        val currentSession = session.get()
-
-        // Check if we need to create a new session.
-        return if (sessionHasExpired(currentSession) || timeoutHandler.hasTimedOut()) {
-            val newId = idGenerator.generateSessionId()
-            val newSession = SessionImpl(newId, clock.now())
-
-            // Atomically update the session only if it hasn't been changed by another thread.
-            if (session.compareAndSet(currentSession, newSession)) {
-                sessionStorage.save(newSession)
+    override fun getSessionId(): String =
+        synchronized(lock) {
+            val currentSession = session
+            if (sessionHasExpired(currentSession) || timeoutHandler.hasTimedOut()) {
+                val newId = idGenerator.generateSessionId()
+                val newSession = SessionImpl(newId, clock.now())
+                session = newSession
+                // Storage and observers may record telemetry that reads the session again.
                 timeoutHandler.bump()
-                // Observers need to be called after bumping the timer because it may create a new
-                // span.
+                sessionStorage.save(newSession)
                 notifyObserversOfSessionUpdate(currentSession, newSession)
                 newSession.id
             } else {
-                // Another thread accessed this function prior to creating a new session. Use the
-                // current session.
                 timeoutHandler.bump()
-                session.get().id
+                currentSession.id
             }
-        } else {
-            // No new session needed, just bump the timeout and return current session ID
-            timeoutHandler.bump()
-            currentSession.id
         }
-    }
 
     private fun notifyObserversOfSessionUpdate(
         currentSession: Session,

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionManager.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionManager.kt
@@ -16,6 +16,7 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.random.Random
 import kotlin.time.Duration
 
+@OptIn(Incubating::class)
 internal class SessionManager(
     private val clock: Clock,
     private val sessionStorage: SessionStorage = InMemorySessionStorage(),
@@ -86,11 +87,13 @@ internal class SessionManager(
             timeoutHandler: SessionIdTimeoutHandler,
             sessionConfig: SessionConfig,
             clock: Clock,
+            sessionStorage: SessionStorage = InMemorySessionStorage(),
         ): SessionManager =
             SessionManager(
                 timeoutHandler = timeoutHandler,
                 maxSessionLifetime = sessionConfig.maxLifetime,
                 clock = clock,
+                sessionStorage = sessionStorage,
             )
     }
 }

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionStorage.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionStorage.kt
@@ -17,8 +17,9 @@ import io.opentelemetry.android.session.Session
  *
  * Calls run synchronously on the calling thread, including during SDK initialization and
  * telemetry recording. Implementations must be thread-safe, return promptly, and handle their
- * own failures without throwing. Concurrent saves are not guaranteed to arrive in session
- * creation order. The manager does not provide a storage fallback or manage storage cleanup.
+ * own failures without throwing. Each manager serializes session access, saves, and observer
+ * notifications. A save must not wait for another thread to access that manager's session.
+ * The manager does not provide a storage fallback or manage storage cleanup.
  */
 @Incubating
 interface SessionStorage {

--- a/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionStorage.kt
+++ b/android-agent/src/main/kotlin/io/opentelemetry/android/agent/session/SessionStorage.kt
@@ -5,10 +5,26 @@
 
 package io.opentelemetry.android.agent.session
 
+import io.opentelemetry.android.Incubating
 import io.opentelemetry.android.session.Session
 
-internal interface SessionStorage {
+/**
+ * Storage for sessions written by the agent's built-in session manager.
+ *
+ * The manager currently saves an empty session (ID `""`, start timestamp `-1`) during
+ * initialization, then saves each newly generated session. It does not call [get] to restore
+ * a session, so supplying persistent storage alone does not enable session restoration.
+ *
+ * Calls run synchronously on the calling thread, including during SDK initialization and
+ * telemetry recording. Implementations must be thread-safe, return promptly, and handle their
+ * own failures without throwing. Concurrent saves are not guaranteed to arrive in session
+ * creation order. The manager does not provide a storage fallback or manage storage cleanup.
+ */
+@Incubating
+interface SessionStorage {
+    /** Returns the session held by this storage. The built-in manager does not currently read it. */
     fun get(): Session
 
+    /** Saves [newSession], including the empty session supplied during initialization. */
     fun save(newSession: Session)
 }

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/OpenTelemetryRumInitializerTest.kt
@@ -13,14 +13,22 @@ import io.mockk.mockk
 import io.mockk.verify
 import io.opentelemetry.android.Incubating
 import io.opentelemetry.android.agent.session.SessionIdTimeoutHandler
+import io.opentelemetry.android.agent.session.SessionStorage
+import io.opentelemetry.android.agent.session.invalidSession
 import io.opentelemetry.android.internal.services.Services
 import io.opentelemetry.android.internal.services.applifecycle.AppLifecycle
+import io.opentelemetry.android.session.Session
 import io.opentelemetry.android.session.SessionObserver
+import io.opentelemetry.sdk.testing.time.TestClock
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RuntimeEnvironment
+import java.util.Collections
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.hours
 
 @OptIn(Incubating::class)
 @RunWith(AndroidJUnit4::class)
@@ -82,6 +90,41 @@ class OpenTelemetryRumInitializerTest {
         verify {
             o1.onSessionStarted(any(), any())
             o2.onSessionStarted(any(), any())
+        }
+    }
+
+    @Test
+    fun `custom storage is used by the configured manager`() {
+        val storage = mockk<SessionStorage>()
+        val saved = Collections.synchronizedList(mutableListOf<Session>())
+        every { storage.save(capture(saved)) } returns Unit
+        val testClock = TestClock.create()
+        val observer = mockk<SessionObserver>(relaxed = true)
+        val rum =
+            OpenTelemetryRumInitializer.initialize(RuntimeEnvironment.getApplication()) {
+                clock = testClock
+                disableLogging()
+                disableTracing()
+                disableMetrics()
+                session {
+                    storage(storage)
+                    maxLifetime = 1.hours
+                    observers(observer)
+                }
+            }
+        try {
+            val first = rum.sessionProvider.getSessionId()
+            assertThat(saved.first()).isSameAs(invalidSession)
+            assertThat(saved.last().id).isEqualTo(first)
+            testClock.advance(1, TimeUnit.HOURS)
+            val second = rum.sessionProvider.getSessionId()
+            assertThat(second).isNotEqualTo(first)
+            assertThat(saved.map { it.id }).containsExactly("", first, second)
+            verify { observer.onSessionStarted(match { it.id == second }, match { it.id == first }) }
+            verify { appLifecycle.registerListener(any<SessionIdTimeoutHandler>()) }
+            verify(exactly = 0) { storage.get() }
+        } finally {
+            rum.shutdown()
         }
     }
 

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/SessionStorageConfigurationTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/dsl/SessionStorageConfigurationTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.dsl
+
+import io.mockk.mockk
+import io.opentelemetry.android.Incubating
+import io.opentelemetry.android.agent.FakeClock
+import io.opentelemetry.android.agent.FakeInstrumentationLoader
+import io.opentelemetry.android.agent.session.InMemorySessionStorage
+import io.opentelemetry.android.agent.session.SessionStorage
+import io.opentelemetry.android.session.SessionObserver
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+@OptIn(Incubating::class)
+internal class SessionStorageConfigurationTest {
+    private val config = OpenTelemetryConfiguration(clock = FakeClock(), instrumentationLoader = FakeInstrumentationLoader())
+
+    @Test
+    fun `each configuration has its own default in-memory storage`() {
+        assertThat(config.sessionConfig.sessionStorage).isInstanceOf(InMemorySessionStorage::class.java)
+        assertThat(config.sessionConfig.sessionStorage).isNotSameAs(SessionConfiguration().sessionStorage)
+        assertThat(config.sessionConfig.backgroundInactivityTimeout).isEqualTo(15.minutes)
+        assertThat(config.sessionConfig.maxLifetime).isEqualTo(4.hours)
+    }
+
+    @Test
+    fun `last storage wins without replacing other session configuration`() {
+        val first = mockk<SessionStorage>()
+        val last = mockk<SessionStorage>()
+        val observer = mockk<SessionObserver>()
+        config.session {
+            storage(first)
+            backgroundInactivityTimeout = 3.minutes
+            maxLifetime = 2.hours
+            observers(observer)
+        }
+        config.session { storage(last) }
+
+        assertThat(config.sessionConfig.sessionStorage).isSameAs(last)
+        assertThat(config.sessionConfig.backgroundInactivityTimeout).isEqualTo(3.minutes)
+        assertThat(config.sessionConfig.maxLifetime).isEqualTo(2.hours)
+        assertThat(config.sessionConfig.getObservers()).containsExactly(observer)
+    }
+}

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionStorageTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionStorageTest.kt
@@ -18,8 +18,11 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.io.IOException
 import java.util.concurrent.Callable
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 
@@ -163,6 +166,131 @@ internal class SessionStorageTest {
             executor.shutdownNow()
             assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue()
         }
+    }
+
+    @Test
+    fun `slow storage cannot cause overlapping inactivity transitions`() {
+        verifySerializedTransition(pauseDuringSave = true)
+    }
+
+    @Test
+    fun `a later expiry waits until observer notification completes`() {
+        verifySerializedTransition(pauseDuringSave = false)
+    }
+
+    private fun verifySerializedTransition(pauseDuringSave: Boolean) {
+        val paused = CountDownLatch(1)
+        val resume = CountDownLatch(1)
+        val contenderStarted = CountDownLatch(1)
+        val events = CopyOnWriteArrayList<String>()
+        var shouldPause = false
+
+        fun pauseOnce() {
+            if (shouldPause) {
+                shouldPause = false
+                paused.countDown()
+                check(resume.await(5, TimeUnit.SECONDS))
+            }
+        }
+        val storage =
+            object : SessionStorage {
+                override fun get(): Session = error("The manager must not read storage")
+
+                override fun save(newSession: Session) {
+                    if (pauseDuringSave) pauseOnce()
+                    events.add("save:${newSession.id}")
+                }
+            }
+        val manager = createManager(storage)
+        manager.addObserver(
+            object : SessionObserver {
+                override fun onSessionEnded(session: Session) {
+                    if (!pauseDuringSave) pauseOnce()
+                    events.add("end:${session.id}")
+                }
+
+                override fun onSessionStarted(
+                    newSession: Session,
+                    previousSession: Session,
+                ) {
+                    events.add("start:${newSession.id}")
+                }
+            },
+        )
+        val initial = manager.getSessionId()
+        events.clear()
+        timeoutHandler.onApplicationBackgrounded()
+        clock.advance(1, TimeUnit.MINUTES)
+        shouldPause = true
+        val executor = Executors.newFixedThreadPool(2)
+        try {
+            val first = executor.submit(Callable { manager.getSessionId() })
+            assertThat(paused.await(5, TimeUnit.SECONDS)).isTrue()
+            // A later expiry must not overtake the previous transition's notifications.
+            if (!pauseDuringSave) clock.advance(1, TimeUnit.HOURS)
+            val second =
+                executor.submit(
+                    Callable {
+                        contenderStarted.countDown()
+                        manager.getSessionId()
+                    },
+                )
+            assertThat(contenderStarted.await(5, TimeUnit.SECONDS)).isTrue()
+            assertThatThrownBy { second.get(200, TimeUnit.MILLISECONDS) }
+                .isInstanceOf(TimeoutException::class.java)
+            resume.countDown()
+            val firstId = first.get(5, TimeUnit.SECONDS)
+            val secondId = second.get(5, TimeUnit.SECONDS)
+            assertThat(firstId).isNotEqualTo(initial)
+            val expected = mutableListOf("save:$firstId", "end:$initial", "start:$firstId")
+            if (pauseDuringSave) {
+                assertThat(secondId).isEqualTo(firstId)
+            } else {
+                assertThat(secondId).isNotEqualTo(firstId)
+                expected.addAll(listOf("save:$secondId", "end:$firstId", "start:$secondId"))
+            }
+            assertThat(events).containsExactlyElementsOf(expected)
+        } finally {
+            resume.countDown()
+            executor.shutdownNow()
+            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue()
+        }
+    }
+
+    @Test
+    fun `storage and observers can read the new session during an inactivity transition`() {
+        val observedIds = mutableListOf<String>()
+        lateinit var manager: SessionManager
+        val storage =
+            object : SessionStorage {
+                override fun get(): Session = error("The manager must not read storage")
+
+                override fun save(newSession: Session) {
+                    if (newSession.id.isNotEmpty()) observedIds.add(manager.getSessionId())
+                }
+            }
+        manager = createManager(storage)
+        manager.addObserver(
+            object : SessionObserver {
+                override fun onSessionEnded(session: Session) {
+                    observedIds.add(manager.getSessionId())
+                }
+
+                override fun onSessionStarted(
+                    newSession: Session,
+                    previousSession: Session,
+                ) {
+                    observedIds.add(manager.getSessionId())
+                }
+            },
+        )
+        val first = manager.getSessionId()
+        timeoutHandler.onApplicationBackgrounded()
+        clock.advance(1, TimeUnit.MINUTES)
+        val second = manager.getSessionId()
+
+        assertThat(second).isNotEqualTo(first)
+        assertThat(observedIds).containsExactly(first, first, first, second, second, second)
     }
 
     private fun createManager(storage: SessionStorage): SessionManager = SessionManager.create(timeoutHandler, config, clock, storage)

--- a/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionStorageTest.kt
+++ b/android-agent/src/test/kotlin/io/opentelemetry/android/agent/session/SessionStorageTest.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.opentelemetry.android.agent.session
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import io.mockk.verifyOrder
+import io.opentelemetry.android.Incubating
+import io.opentelemetry.android.session.Session
+import io.opentelemetry.android.session.SessionObserver
+import io.opentelemetry.sdk.testing.time.TestClock
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import java.io.IOException
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+@OptIn(Incubating::class)
+internal class SessionStorageTest {
+    private val clock = TestClock.create()
+    private val config = SessionConfig(backgroundInactivityTimeout = 1.minutes, maxLifetime = 1.hours)
+    private val timeoutHandler = SessionIdTimeoutHandler(config, clock)
+
+    @Test
+    fun `startup saves an empty session without reading stored state`() {
+        val storage = mockk<SessionStorage>()
+        val saved = mutableListOf<Session>()
+        val previousId = "a".repeat(32)
+        every { storage.get() } returns SessionImpl(previousId, clock.now())
+        every { storage.save(capture(saved)) } returns Unit
+
+        val manager = createManager(storage)
+        assertThat(saved).containsExactly(invalidSession)
+
+        val id = manager.getSessionId()
+        assertThat(id).isNotEmpty().isNotEqualTo(previousId)
+        assertThat(saved).hasSize(2)
+        assertThat(saved.last().id).isEqualTo(id)
+        assertThat(saved.last().startTimestamp).isEqualTo(clock.now())
+        verify(exactly = 0) { storage.get() }
+    }
+
+    @Test
+    fun `storage preserves inactivity and lifetime expiry and observer ordering`() {
+        val storage = mockk<SessionStorage>(relaxed = true)
+        val saved = mutableListOf<Session>()
+        every { storage.save(capture(saved)) } returns Unit
+        val observer = mockk<SessionObserver>(relaxed = true)
+        val manager = createManager(storage)
+        manager.addObserver(observer)
+
+        val first = manager.getSessionId()
+        timeoutHandler.onApplicationBackgrounded()
+        clock.advance(59, TimeUnit.SECONDS)
+        assertThat(manager.getSessionId()).isEqualTo(first)
+        assertThat(saved).hasSize(2)
+
+        // Reading the current session remains activity and extends the inactivity timeout.
+        clock.advance(59, TimeUnit.SECONDS)
+        assertThat(manager.getSessionId()).isEqualTo(first)
+        clock.advance(1, TimeUnit.MINUTES)
+        val second = manager.getSessionId()
+        assertThat(second).isNotEqualTo(first)
+
+        timeoutHandler.onApplicationForegrounded()
+        assertThat(manager.getSessionId()).isEqualTo(second)
+        clock.advance(1, TimeUnit.HOURS)
+        val third = manager.getSessionId()
+        assertThat(third).isNotEqualTo(second)
+        assertThat(saved.map { it.id }).containsExactly("", first, second, third)
+        verifyOrder {
+            storage.save(saved[1])
+            observer.onSessionEnded(invalidSession)
+            observer.onSessionStarted(saved[1], invalidSession)
+            storage.save(saved[2])
+            observer.onSessionEnded(saved[1])
+            observer.onSessionStarted(saved[2], saved[1])
+            storage.save(saved[3])
+            observer.onSessionEnded(saved[2])
+            observer.onSessionStarted(saved[3], saved[2])
+        }
+        verify(exactly = 3) { observer.onSessionStarted(any(), any()) }
+        verify(exactly = 3) { observer.onSessionEnded(any()) }
+        verify(exactly = 0) { storage.get() }
+    }
+
+    @Test
+    fun `handled storage failures do not interrupt sessions or observers`() {
+        val backingStorage = mockk<SessionStorage>()
+        every { backingStorage.save(any()) } throws IOException("unavailable")
+        val cache = InMemorySessionStorage()
+        val storage =
+            object : SessionStorage {
+                override fun get(): Session = cache.get()
+
+                override fun save(newSession: Session) {
+                    cache.save(newSession)
+                    try {
+                        backingStorage.save(newSession)
+                    } catch (_: IOException) {
+                        // This implementation chooses to retain the in-memory copy on failure.
+                    }
+                }
+            }
+        val observer = mockk<SessionObserver>(relaxed = true)
+        val manager = createManager(storage)
+        manager.addObserver(observer)
+        val first = manager.getSessionId()
+        clock.advance(1, TimeUnit.HOURS)
+        val second = manager.getSessionId()
+
+        assertThat(second).isNotEqualTo(first)
+        assertThat(storage.get().id).isEqualTo(second)
+        verify(exactly = 3) { backingStorage.save(any()) }
+        verify(exactly = 2) { observer.onSessionStarted(any(), any()) }
+        verify { observer.onSessionEnded(match { it.id == first }) }
+    }
+
+    @Test
+    fun `unhandled storage failures propagate during initialization`() {
+        val storage = mockk<SessionStorage>()
+        val failure = IOException("unhandled")
+        every { storage.save(any()) } throws failure
+
+        assertThatThrownBy { createManager(storage) }.isSameAs(failure)
+        verify(exactly = 1) { storage.save(invalidSession) }
+        verify(exactly = 0) { storage.get() }
+    }
+
+    @Test
+    fun `a new manager does not resume the session in reused storage`() {
+        val storage = InMemorySessionStorage()
+        val first = createManager(storage).getSessionId()
+        val nextManager = createManager(storage)
+
+        assertThat(storage.get()).isSameAs(invalidSession)
+        assertThat(nextManager.getSessionId()).isNotEqualTo(first)
+    }
+
+    @Test
+    fun `concurrent first access saves only one new session`() {
+        val storage = mockk<SessionStorage>(relaxed = true)
+        val manager = createManager(storage)
+        val executor = Executors.newFixedThreadPool(4)
+        try {
+            val ids =
+                executor
+                    .invokeAll(List(20) { Callable { manager.getSessionId() } }, 5, TimeUnit.SECONDS)
+                    .map { it.get() }
+            assertThat(ids.toSet()).hasSize(1)
+            verify(exactly = 1) { storage.save(invalidSession) }
+            verify(exactly = 1) { storage.save(match { it.id == ids.first() }) }
+            verify(exactly = 0) { storage.get() }
+        } finally {
+            executor.shutdownNow()
+            assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue()
+        }
+    }
+
+    private fun createManager(storage: SessionStorage): SessionManager = SessionManager.create(timeoutHandler, config, clock, storage)
+}


### PR DESCRIPTION
Part of #2048, following the [SIG discussion](https://github.com/open-telemetry/opentelemetry-android/issues/2048#issuecomment-5622292142).

Adds `session { storage(myStorage) }` using the existing session manager. The in-memory default, expiry, activity tracking and observers stay unchanged. The existing storage interface and new setter are marked incubating.

This is the configuration hook, not session restoration. The manager still writes an empty session at startup and never reads storage. Storage implementations handle their own failures; disk storage and restart policy stay separate.

 Tier 4: public API addition.
