### PR TITLE
Add module and instructions for using opentelemetry-kotlin API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,10 @@ android-agent          (opinionated setup: core + default instrumentations + Kot
     |     +-- agent-api     (public API: OpenTelemetryRum interface)
     |
     +-- instrumentation/*   (individual instrumentations, each in its own module)
+
+agent-api-ktx          (optional: opentelemetry-kotlin API accessor)
+    |
+    +-- agent-api
 ```
 
 Key points:
@@ -50,6 +54,8 @@ Key points:
   they cannot work as simple runtime dependencies.
 - **`session`** already provides `SessionProvider`, `SessionPublisher`, and `SessionObserver`.
   Session IDs are already injected into spans via processors in `core`.
+- **`agent-api-ktx`** is an optional add-on that exposes the
+  opentelemetry-kotlin API from an `OpenTelemetryRum`.
 
 ## PR Requirements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### 📈 Enhancements
+
+- New optional `agent-api-ktx` module adding an `OpenTelemetryRum.openTelemetryKotlin` extension
+  property. This allows you to use opentelemetry-kotlin's APIs within opentelemetry-android,
+  backed by the agent's existing Java SDK instance. This module and opentelemetry-kotlin are not
+  stable yet and may change their APIs in future.
+  ([#XXXX](https://github.com/open-telemetry/opentelemetry-android/pull/XXXX))
+
 ## Version 1.7.0 (2026-09-04)
 
 ### 📣 Migration notes

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ private fun initOTel(context: Context): OpenTelemetryRum? =
     }.getOrNull()
 ```
 
-This call will return an `OpenTelemetryRum` instance. You can these use the Agent APIs, and additionally
+This call will return an `OpenTelemetryRum` instance. You can then use the Agent APIs, and additionally
 retrieve the opentelemetry-kotlin and opentelemetry-java APIs for more fine-grained control:
 
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ dependencies {
 }
 ```
 
+### Kotlin API extensions
+
+If you want to use
+[opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin)'s API alongside or instead of
+the OpenTelemetry Java API, add the optional `agent-api-ktx` module:
+
+```kotlin
+dependencies {
+    implementation("io.opentelemetry.android:agent-api-ktx")
+}
+```
+
 ## Snapshot Builds
 
 A snapshot is published for every commit to the `main` branch. Snapshots are intended for testing
@@ -126,7 +138,13 @@ private fun initOTel(context: Context): OpenTelemetryRum? =
     }.getOrNull()
 ```
 
-This call will return an `OpenTelemetryRum` instance with which you can use the Agent and OTel APIs.
+This call will return an `OpenTelemetryRum` instance. You can these use the Agent APIs, and additionally
+retrieve the opentelemetry-kotlin and opentelemetry-java APIs for more fine-grained control:
+
+```kotlin
+val otelJavaApi = otelRum.openTelemetry
+val otelKotlinApi = otelRum.openTelemetryKotlin
+```
 
 # Features
 

--- a/agent-api-ktx/README.md
+++ b/agent-api-ktx/README.md
@@ -1,0 +1,49 @@
+# Agent API Kotlin extensions
+
+Optional module that exposes the
+[opentelemetry-kotlin](https://github.com/open-telemetry/opentelemetry-kotlin) API from an existing
+`OpenTelemetryRum` instance.
+
+> **Not stable.** This module may change its API or
+> be removed in any release, with no deprecation cycle. opentelemetry-kotlin is itself pre-1.0.
+
+## Installation
+
+```kotlin
+dependencies {
+    api(platform("io.opentelemetry.android:opentelemetry-android-bom:<version>-alpha"))
+    implementation("io.opentelemetry.android:agent-api-ktx") // Version is resolved through the BOM
+}
+```
+
+## Usage
+
+```kotlin
+import io.opentelemetry.android.OpenTelemetryRum
+import io.opentelemetry.android.openTelemetryKotlin
+import io.opentelemetry.kotlin.ExperimentalApi
+
+@OptIn(ExperimentalApi::class)
+fun example(rum: OpenTelemetryRum) {
+    val otel = rum.openTelemetryKotlin
+
+    val logger = otel.loggerProvider.getLogger("my_logger")
+    logger.log("Hello, World!")
+
+    val tracer = otel.tracerProvider.getTracer("my_tracer")
+    tracer.startSpan("my_span").end()
+}
+```
+
+`@OptIn` is required for most calls as opentelemetry-kotlin APIs are mostly marked `@ExperimentalApi`.
+See the [upstream getting started guide](https://opentelemetry.io/docs/languages/kotlin/getting-started/)
+for an alternative approach that opts in globally through Kotlin's compiler options.
+
+## What you get
+
+`openTelemetryKotlin` returns the *compat* implementation of opentelemetry-kotlin: a Kotlin API that
+delegates to the OpenTelemetry Java SDK the agent already configures. Spans,
+logs and metrics recorded through it flow through the same processors and exporters as telemetry
+recorded through `OpenTelemetryRum.openTelemetry`, and the two APIs can be used side by side.
+
+The same instance is returned on every access.

--- a/agent-api-ktx/api/agent-api-ktx.api
+++ b/agent-api-ktx/api/agent-api-ktx.api
@@ -1,0 +1,4 @@
+public final class io/opentelemetry/android/OpenTelemetryRumKtxKt {
+	public static final fun getOpenTelemetryKotlin (Lio/opentelemetry/android/OpenTelemetryRum;)Lio/opentelemetry/kotlin/OpenTelemetry;
+}
+

--- a/agent-api-ktx/build.gradle.kts
+++ b/agent-api-ktx/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    id("otel.android-library-conventions")
+    id("otel.publish-conventions")
+}
+
+description = "OpenTelemetry Android Agent API Kotlin extensions"
+
+android {
+    namespace = "io.opentelemetry.android.agent.api.ktx"
+
+    defaultConfig {
+        consumerProguardFiles("consumer-rules.pro")
+    }
+}
+
+dependencies {
+    api(platform(libs.opentelemetry.platform.alpha)) // Required for sonatype publishing
+    api(project(":agent-api"))
+    api(libs.opentelemetry.kotlin.api)
+    implementation(libs.opentelemetry.kotlin.compat)
+}

--- a/agent-api-ktx/src/main/kotlin/io/opentelemetry/android/OpenTelemetryRumKtx.kt
+++ b/agent-api-ktx/src/main/kotlin/io/opentelemetry/android/OpenTelemetryRumKtx.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+@file:OptIn(ExperimentalApi::class)
+
+package io.opentelemetry.android
+
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.kotlin.OpenTelemetry
+import io.opentelemetry.kotlin.toOtelKotlinApi
+import java.util.WeakHashMap
+
+private val compatLock = Any()
+
+private val compatInstances = WeakHashMap<OpenTelemetryRum, OpenTelemetry>()
+
+/**
+ * The opentelemetry-kotlin [OpenTelemetry] API for this instance.
+ *
+ * This returns the *compat* implementation of opentelemetry-kotlin: a Kotlin API whose calls are
+ * delegated under the hood to the OpenTelemetry Java SDK that this agent is built on. It is not a
+ * separate SDK, so telemetry recorded through it is processed and exported by exactly the same
+ * pipeline as telemetry recorded through [OpenTelemetryRum.openTelemetry], and both APIs may be
+ * used side by side.
+ *
+ * The same instance is returned for repeated accesses on the same [OpenTelemetryRum].
+ *
+ * This property, and the whole `agent-api-ktx` module, are **not stable**: the module is published
+ * with an `-alpha` version suffix. opentelemetry-kotlin is itself pre-1.0 and every type reachable
+ * from [OpenTelemetry] is marked [ExperimentalApi], so both this property and the API it exposes
+ * may change or be removed in any release, with no deprecation cycle. Opt in with
+ * `@OptIn(ExperimentalApi::class)` to acknowledge that.
+ */
+@ExperimentalApi
+val OpenTelemetryRum.openTelemetryKotlin: OpenTelemetry
+    get() =
+        synchronized(compatLock) {
+            compatInstances.getOrPut(this) { openTelemetry.toOtelKotlinApi() }
+        }

--- a/agent-api-ktx/src/test/kotlin/io/opentelemetry/android/OpenTelemetryRumKtxTest.kt
+++ b/agent-api-ktx/src/test/kotlin/io/opentelemetry/android/OpenTelemetryRumKtxTest.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+@file:OptIn(ExperimentalApi::class)
+
+package io.opentelemetry.android
+
+import io.mockk.every
+import io.mockk.mockk
+import io.opentelemetry.kotlin.ExperimentalApi
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class OpenTelemetryRumKtxTest {
+    private lateinit var spanExporter: InMemorySpanExporter
+    private lateinit var rum: OpenTelemetryRum
+
+    @BeforeEach
+    fun setUp() {
+        spanExporter = InMemorySpanExporter.create()
+        val sdk =
+            OpenTelemetrySdk
+                .builder()
+                .setTracerProvider(
+                    SdkTracerProvider
+                        .builder()
+                        .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+                        .build(),
+                ).build()
+        rum = mockk<OpenTelemetryRum>()
+        every { rum.openTelemetry } returns sdk
+    }
+
+    @Test
+    fun `records telemetry through the underlying java sdk`() {
+        rum.openTelemetryKotlin
+            .tracerProvider
+            .getTracer("test-scope")
+            .startSpan("test-span")
+            .end()
+
+        val span = spanExporter.finishedSpanItems.single()
+        assertThat(span.name).isEqualTo("test-span")
+        assertThat(span.instrumentationScopeInfo.name).isEqualTo("test-scope")
+    }
+
+    @Test
+    fun `returns the same instance for repeated access`() {
+        assertThat(rum.openTelemetryKotlin).isSameAs(rum.openTelemetryKotlin)
+    }
+}

--- a/docs/KOTLIN_FIRST.md
+++ b/docs/KOTLIN_FIRST.md
@@ -17,6 +17,9 @@ The OpenTelemetry Android Agent is currently built on the OTel Java SDK and ecos
 signals. This will be the case until official Kotlin versions are released and stabilized under the OpenTelemetry org, which is currently 
 under development.
 
+As a stepping stone, the optional [`agent-api-ktx`](../agent-api-ktx) module exposes the opentelemetry-kotlin API from an `OpenTelemetryRum` 
+instance, delegating to the same OTel Java SDK underneath.
+
 ## Java Compatibility
 
 Java and Kotlin are interoperable from a language standpoint, so in theory, the Agent API is callable from Java. But from a public API 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ opentelemetry-instrumentation-alpha = "2.31.1-alpha"
 #opentelemetry-instrumentation = "2.9.0" // alpha bom includes non-alpha bom
 opentelemetry-contrib = "1.60.0-alpha"
 opentelemetry-semconv-kotlin = "0.7.0"
+opentelemetry-kotlin = "0.7.0"
 junit = "6.1.3"
 byteBuddy = "1.18.13"
 okhttp = "5.5.0"
@@ -42,6 +43,8 @@ opentelemetry-instrumentation-api = { module = "io.opentelemetry.instrumentation
 opentelemetry-instrumentation-apiSemconv = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator", version.ref = "opentelemetry-instrumentation-alpha" }
 opentelemetry-instrumentation-okhttp = { module = "io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0", version.ref = "opentelemetry-instrumentation-alpha" }
 opentelemetry-semconv-kotlin = { module = "io.opentelemetry.kotlin:semconv-android", version.ref = "opentelemetry-semconv-kotlin"}
+opentelemetry-kotlin-api = { module = "io.opentelemetry.kotlin:api", version.ref = "opentelemetry-kotlin" }
+opentelemetry-kotlin-compat = { module = "io.opentelemetry.kotlin:compat", version.ref = "opentelemetry-kotlin" }
 opentelemetry-api = { module = "io.opentelemetry:opentelemetry-api" }
 opentelemetry-api-incubator = { module = "io.opentelemetry:opentelemetry-api-incubator" }
 opentelemetry-sdk-extension-incubator = { module = "io.opentelemetry:opentelemetry-sdk-extension-incubator" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,6 +13,7 @@ develocity {
 }
 
 include(":agent-api")
+include(":agent-api-ktx")
 include(":core")
 include(":android-agent")
 include(":test-common")


### PR DESCRIPTION
## Goal

Adds a new module named `agent-api-ktx` which provides the ability to use opentelemetry-kotlin's API in opentelemetry-android.

### How to use it
This module is opt-in and should be added as a dependency to the build.gradle:

```kotlin
dependencies {
    implementation("io.opentelemetry.android:agent-api-ktx")
}
```

The module exposes an extension property on `OpenTelemetryRum` named `openTelemetryKotlin` which exposes opentelemetry-kotlin's API. An example of what this might look like is shown below:

```kotlin
@OptIn(ExperimentalApi::class)
fun example(rum: OpenTelemetryRum) {
    val otel = rum.openTelemetryKotlin

    val logger = otel.loggerProvider.getLogger("my_logger")
    logger.log("Hello, World!")

    val tracer = otel.tracerProvider.getTracer("my_tracer")
    tracer.startSpan("my_span").end()
}
```

### How it works

opentelemetry-kotlin can run in regular mode or ['compat' mode](https://opentelemetry.io/docs/languages/kotlin/getting-started/#use-compatibility-mode). Compat mode decorates an instance of the opentelemetry-java SDK with the Kotlin API which means there should be no change in underlying behavior or where telemetry is sent, and makes it easy to adopt the API piecemeal.

opentelemetry-kotlin achieves this by declaring its API in a separate module, which is then implemented in two separate modules for compat/regular mode.

In future this could allow for the implementation to be switched behind the scenes without imposing any breaking API changes on the library consumer. 

### Why ktx?

Modules with the `-ktx` suffix are widely used in the [Android ecosystem](https://developer.android.com/kotlin/ktx) to retrofit Kotlin APIs onto APIs that were originally designed for Java. They tend to provide syntactic sugar.

An opt-in extension property felt like the right balance as it avoids us committing to adding to the `OpenTelemetryRum` interface ourselves right now, and leaves the option in future while longer-term we decide what happens to Java types on that interface.

### Does anything need to change first?

The `Clock` parameter is inaccurate in the returned Kotlin API because opentelemetry-android uses a custom implementation. https://github.com/open-telemetry/opentelemetry-kotlin/pull/1034 will allow us to address the problem.